### PR TITLE
Strip whitespace around usernames

### DIFF
--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -577,7 +577,10 @@ NSString *const MXKAuthErrorDomain = @"MXKAuthErrorDomain";
                 {
                     MXKAuthInputsPasswordBasedView *authInputsView = (MXKAuthInputsPasswordBasedView*)currentAuthInputsView;
                     
-                    [mxRestClient loginWithUser:authInputsView.userLoginTextField.text andPassword:authInputsView.passWordTextField.text
+                    NSString *user = authInputsView.userLoginTextField.text;
+                    user = [user stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+                    [mxRestClient loginWithUser:user andPassword:authInputsView.passWordTextField.text
                                         success:^(MXCredentials *credentials){
                                             [_authenticationActivityIndicator stopAnimating];
                                             


### PR DESCRIPTION
Whitespace is not valid in a username, and sometimes my phone
autocompletes with a space at the end for some reason