### PR TITLE
MXKRoomDataSource: Support server sync v2.

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -380,7 +380,7 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     if (self.roomDataSource && (self.roomDataSource.state == MXKDataSourceStatePreparing || self.roomDataSource.serverSyncEventCount))
     {
         // dataSource is not ready, keep running the loading wheel
-        [self.activityIndicator startAnimating];
+        [self startActivityIndicator];
     }
 }
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -149,7 +149,7 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
  The events are processed asynchronously. This property counts the number of queued events
  during server sync for which the process is pending.
  */
-@property (nonatomic, readonly) NSUInteger serverSyncEventCount;
+@property (nonatomic, readonly) NSInteger serverSyncEventCount;
 
 /**
  The current text message partially typed in text input (use nil to reset it).


### PR DESCRIPTION
Reload data source when the local history has been flushed on limited timeline room sync.