### PR TITLE
Memory warnings are now handled by 'MXKRoomDataSourceManager' instanc…

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -219,6 +219,11 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
  */
 - (void)limitMemoryUsage:(NSInteger)maxBubbleNb;
 
+/**
+ Force data reload.
+ */
+- (void)reload;
+
 #pragma mark - Public methods
 /**
  Get the data for the cell at the given index.

--- a/MatrixKit/Models/Room/MXKRoomDataSourceManager.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSourceManager.m
@@ -25,6 +25,11 @@
      Each key is a room ID. Each value, the MXKRoomDataSource instance.
      */
     NSMutableDictionary *roomDataSources;
+    
+    /**
+     Observe UIApplicationDidReceiveMemoryWarningNotification to dispose of any resources that can be recreated.
+     */
+    id UIApplicationDidReceiveMemoryWarningNotificationObserver;
 }
 
 @end
@@ -76,7 +81,7 @@ static Class _roomDataSourceClass;
         MXKRoomDataSourceManager *roomDataSourceManager = [_roomDataSourceManagers objectForKey:mxSessionId];
         if (roomDataSourceManager)
         {
-            [roomDataSourceManager reset];
+            [roomDataSourceManager destroy];
             [_roomDataSourceManagers removeObjectForKey:mxSessionId];
         }
     }
@@ -99,7 +104,7 @@ static Class _roomDataSourceClass;
                 MXKRoomDataSourceManager *roomDataSourceManager = [_roomDataSourceManagers objectForKey:mxSessionId];
                 if (roomDataSourceManager)
                 {
-                    [roomDataSourceManager reset];
+                    [roomDataSourceManager destroy];
                     [_roomDataSourceManagers removeObjectForKey:mxSessionId];
                 }
             }
@@ -117,6 +122,22 @@ static Class _roomDataSourceClass;
         _releasePolicy = MXKRoomDataSourceManagerReleasePolicyNeverRelease;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didMXSessionDidLeaveRoom:) name:kMXSessionDidLeaveRoomNotification object:nil];
+        
+        // Observe UIApplicationDidReceiveMemoryWarningNotification
+        UIApplicationDidReceiveMemoryWarningNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+            
+            NSLog(@"MXKRoomDataSourceManager %@: Received memory warning.", self);
+            
+            // Reload all data sources (except the current used ones) to reduce memory usage.
+            for (MXKRoomDataSource *roomDataSource in roomDataSources.allValues)
+            {
+                if (!roomDataSource.delegate)
+                {
+                    [roomDataSource reload];
+                }
+            }
+            
+        }];
     }
     return self;
 }
@@ -124,6 +145,17 @@ static Class _roomDataSourceClass;
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidLeaveRoomNotification object:nil];
+}
+
+- (void)destroy
+{
+    [self reset];
+    
+    if (UIApplicationDidReceiveMemoryWarningNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:UIApplicationDidReceiveMemoryWarningNotificationObserver];
+        UIApplicationDidReceiveMemoryWarningNotificationObserver = nil;
+    }
 }
 
 #pragma mark


### PR DESCRIPTION
…e to reload unused data source.

It is not required anymore to reload all matrix sessions on memory warning