### PR TITLE
Mxk data source refactoring

### DIFF
--- a/MatrixKit/Controllers/MXKRoomMemberListViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberListViewController.m
@@ -16,7 +16,7 @@
 
 #import "MXKRoomMemberListViewController.h"
 
-#import "MXKRoomMemberTableViewCell.h" // imported here to provide 'updateActivityInfo' definition.
+#import "MXKRoomMemberTableViewCell.h"
 
 #import "MXKAlert.h"
 
@@ -149,11 +149,12 @@
     // Add an accessory view to the search bar in order to retrieve keyboard view.
     self.membersSearchBar.inputAccessoryView = [[UIView alloc] initWithFrame:CGRectZero];
     
-    // Check whether a room has been defined
-    if (dataSource)
-    {
-        [self configureView];
-    }
+    // Finalize table view configuration
+    self.membersTableView.delegate = self;
+    self.membersTableView.dataSource = dataSource; // Note datasource may be nil here.
+    
+    // Set up default table view cell class
+    [self.membersTableView registerNib:MXKRoomMemberTableViewCell.nib forCellReuseIdentifier:MXKRoomMemberTableViewCell.defaultReuseIdentifier];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -283,24 +284,6 @@
 
 #pragma mark - Internal methods
 
-- (void)configureView
-{
-    self.membersTableView.delegate = self;
-    
-    // Set up table data source
-    self.membersTableView.dataSource = dataSource;
-    
-    // Set up classes to use for cells
-    if ([[dataSource cellViewClassForCellIdentifier:kMXKRoomMemberCellIdentifier] nib])
-    {
-        [self.membersTableView registerNib:[[dataSource cellViewClassForCellIdentifier:kMXKRoomMemberCellIdentifier] nib] forCellReuseIdentifier:kMXKRoomMemberCellIdentifier];
-    }
-    else
-    {
-        [self.membersTableView registerClass:[dataSource cellViewClassForCellIdentifier:kMXKRoomMemberCellIdentifier] forCellReuseIdentifier:kMXKRoomMemberCellIdentifier];
-    }
-}
-
 - (void)scrollToTop
 {
     // stop any scrolling effect
@@ -390,11 +373,25 @@
     
     if (self.membersTableView)
     {
-        [self configureView];
+        // Set up table data source
+        self.membersTableView.dataSource = dataSource;
     }
 }
 
 #pragma mark - MXKDataSourceDelegate
+
+- (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+{
+    // Return the default member table view cell
+    return MXKRoomMemberTableViewCell.class;
+}
+
+- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+{
+    // Consider the default member table view cell
+    return MXKRoomMemberTableViewCell.defaultReuseIdentifier;
+}
+
 - (void)dataSource:(MXKDataSource *)dataSource didCellChange:(id)changes
 {
     if (presenceUpdateTimer)

--- a/MatrixKit/Models/MXKDataSource.h
+++ b/MatrixKit/Models/MXKDataSource.h
@@ -50,6 +50,10 @@ typedef enum : NSUInteger {
 
 /**
  `MXKDataSource` is the base class for data sources managed by MatrixKit.
+ 
+ Inherited 'MXKDataSource' instances are used to handle table or collection data.
+ They may conform to UITableViewDataSource or UICollectionViewDataSource protocol to be used as data source delegate
+ for a UITableView or a UICollectionView instance.
  */
 @interface MXKDataSource : NSObject <MXKCellRenderingDelegate>
 {
@@ -77,8 +81,7 @@ typedef enum : NSUInteger {
 /**
  Base constructor of data source.
  
- Customization like class registrations must be done before loading data (see '[MXKDataSource registerCellDataClass: forCellIdentifier:]'
- and '[MXKDataSource registerCellViewClass: forCellIdentifier:]') .
+ Customization like class registrations must be done before loading data (see '[MXKDataSource registerCellDataClass: forCellIdentifier:]') .
  That is why 3 steps should be considered during 'MXKDataSource' initialization:
  1- call [MXKDataSource initWithMatrixSession:] to initialize a new allocated object.
  2- customize classes and others...
@@ -123,27 +126,8 @@ typedef enum : NSUInteger {
  */
 - (Class)cellDataClassForCellIdentifier:(NSString *)identifier;
 
-
-#pragma mark - MXKCellRendering classes
-/**
- Register the MXKCellRendering-compliant class and that will be used to display cells
- with the designated identifier.
-
- @param cellViewClass a class implementing the `MXKCellRendering` protocol.
- @param identifier the identifier of targeted cell.
- */
-- (void)registerCellViewClass:(Class<MXKCellRendering>)cellViewClass forCellIdentifier:(NSString *)identifier;
-
-/**
- Return the MXKCellRendering-compliant class that manages the display of cells with the designated identifier.
-
- @param identifier the cell identifier.
- @return the associated MXKCellData-inherited class.
- */
-- (Class<MXKCellRendering>)cellViewClassForCellIdentifier:(NSString *)identifier;
-
-
 #pragma mark - Pending HTTP requests 
+
 /**
  Cancel all registered requests.
  */
@@ -151,8 +135,29 @@ typedef enum : NSUInteger {
 
 @end
 
-
 @protocol MXKDataSourceDelegate <NSObject>
+
+/**
+ Ask the delegate which MXKCellRendering-compliant class must be used to render this cell data.
+ 
+ This method is called when MXKDataSource instance is used as the data source delegate of a table or a collection.
+ CAUTION: The table or the collection MUST have registered the returned class with the same identifier than the one returned by [cellReuseIdentifierForCellData:].
+ 
+ @param cellData the cell data to display.
+ @return a MXKCellRendering-compliant class which inherits UITableViewCell or UICollectionViewCell class (nil if the cellData is not supported).
+ */
+- (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData;
+
+/**
+ Ask the delegate which identifier must be used to dequeue reusable cell for this cell data.
+ 
+ This method is called when MXKDataSource instance is used as the data source delegate of a table or a collection.
+ CAUTION: The table or the collection MUST have registered the right class with the returned identifier (see [cellViewClassForCellData:]).
+ 
+ @param cellData the cell data to display.
+ @return the reuse identifier for the cell (nil if the cellData is not supported).
+ */
+- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData;
 
 /**
  Tells the delegate that some cell data/views have been changed.

--- a/MatrixKit/Models/MXKDataSource.m
+++ b/MatrixKit/Models/MXKDataSource.m
@@ -25,11 +25,6 @@
      The mapping between cell identifiers and MXKCellData classes.
      */
     NSMutableDictionary *cellDataMap;
-    
-    /**
-     The mapping between cell identifiers and MXKCellRendering classes.
-     */
-    NSMutableDictionary *cellViewMap;
 }
 @end
 
@@ -45,7 +40,6 @@
     {
         state = MXKDataSourceStateUnknown;
         cellDataMap = [NSMutableDictionary dictionary];
-        cellViewMap = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -86,7 +80,6 @@
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     cellDataMap = nil;
-    cellViewMap = nil;
 }
 
 #pragma mark - MXSessionStateDidChangeNotification
@@ -118,19 +111,6 @@
 {
     return cellDataMap[identifier];
 }
-
-
-#pragma mark - MXKCellRendering classes
-- (void)registerCellViewClass:(Class<MXKCellRendering>)cellViewClass forCellIdentifier:(NSString *)identifier
-{
-    cellViewMap[identifier] = cellViewClass;
-}
-
-- (Class<MXKCellRendering>)cellViewClassForCellIdentifier:(NSString *)identifier
-{
-    return cellViewMap[identifier];
-}
-
 
 #pragma mark - MXKCellRenderingDelegate
 - (void)cell:(id<MXKCellRendering>)cell didRecognizeAction:(NSString*)actionIdentifier userInfo:(NSDictionary *)userInfo

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -21,16 +21,6 @@
 
 #import "MXKRoomBubbleCellData.h"
 
-#import "MXKRoomIncomingTextMsgBubbleCell.h"
-#import "MXKRoomIncomingTextMsgHiddenSenderBubbleCell.h"
-#import "MXKRoomIncomingAttachmentBubbleCell.h"
-#import "MXKRoomIncomingAttachmentHiddenSenderBubbleCell.h"
-
-#import "MXKRoomOutgoingTextMsgBubbleCell.h"
-#import "MXKRoomOutgoingTextMsgHiddenSenderBubbleCell.h"
-#import "MXKRoomOutgoingAttachmentBubbleCell.h"
-#import "MXKRoomOutgoingAttachmentHiddenSenderBubbleCell.h"
-
 #import "MXKTools.h"
 
 #import "MXKAppSettings.h"
@@ -40,16 +30,6 @@
 #pragma mark - Constant definitions
 
 NSString *const kMXKRoomBubbleCellDataIdentifier = @"kMXKRoomBubbleCellDataIdentifier";
-
-NSString *const kMXKRoomIncomingTextMsgCellIdentifier = @"kMXKRoomIncomingTextMsgCellIdentifier";
-NSString *const kMXKRoomIncomingTextMsgHiddenSenderCellIdentifier = @"kMXKRoomIncomingTextMsgHiddenSenderCellIdentifier";
-NSString *const kMXKRoomIncomingAttachmentCellIdentifier = @"kMXKRoomIncomingAttachmentCellIdentifier";
-NSString *const kMXKRoomIncomingAttachmentHiddenSenderCellIdentifier = @"kMXKRoomIncomingAttachmentHiddenSenderCellIdentifier";
-
-NSString *const kMXKRoomOutgoingTextMsgCellIdentifier = @"kMXKRoomOutgoingTextMsgCellIdentifier";
-NSString *const kMXKRoomOutgoingTextMsgHiddenSenderCellIdentifier = @"kMXKRoomOutgoingTextMsgHiddenSenderCellIdentifier";
-NSString *const kMXKRoomOutgoingAttachmentCellIdentifier = @"kMXKRoomOutgoingAttachmentCellIdentifier";
-NSString *const kMXKRoomOutgoingAttachmentHiddenSenderCellIdentifier = @"kMXKRoomOutgoingAttachmentHiddenSenderCellIdentifier";
 
 NSString *const kMXKRoomDataSourceMetaDataChanged = @"kMXKRoomDataSourceMetaDataChanged";
 NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncStatusChanged";
@@ -142,18 +122,6 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
         // Set default data and view classes
         // Cell data
         [self registerCellDataClass:MXKRoomBubbleCellData.class forCellIdentifier:kMXKRoomBubbleCellDataIdentifier];
-        
-        // For incoming messages
-        [self registerCellViewClass:MXKRoomIncomingTextMsgBubbleCell.class forCellIdentifier:kMXKRoomIncomingTextMsgCellIdentifier];
-        [self registerCellViewClass:MXKRoomIncomingTextMsgHiddenSenderBubbleCell.class forCellIdentifier:kMXKRoomIncomingTextMsgHiddenSenderCellIdentifier];
-        [self registerCellViewClass:MXKRoomIncomingAttachmentBubbleCell.class forCellIdentifier:kMXKRoomIncomingAttachmentCellIdentifier];
-        [self registerCellViewClass:MXKRoomIncomingAttachmentHiddenSenderBubbleCell.class forCellIdentifier:kMXKRoomIncomingAttachmentHiddenSenderCellIdentifier];
-        
-        // And outgoing messages
-        [self registerCellViewClass:MXKRoomOutgoingTextMsgBubbleCell.class forCellIdentifier:kMXKRoomOutgoingTextMsgCellIdentifier];
-        [self registerCellViewClass:MXKRoomOutgoingTextMsgHiddenSenderBubbleCell.class forCellIdentifier:kMXKRoomOutgoingTextMsgHiddenSenderCellIdentifier];
-        [self registerCellViewClass:MXKRoomOutgoingAttachmentBubbleCell.class forCellIdentifier:kMXKRoomOutgoingAttachmentCellIdentifier];
-        [self registerCellViewClass:MXKRoomOutgoingAttachmentHiddenSenderBubbleCell.class forCellIdentifier:kMXKRoomOutgoingAttachmentHiddenSenderCellIdentifier];
         
         // Set default MXEvent -> NSString formatter
         self.eventFormatter = [[MXKEventFormatter alloc] initWithMatrixSession:self.mxSession];
@@ -802,68 +770,17 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
 
 - (CGFloat)cellHeightAtIndex:(NSInteger)index withMaximumWidth:(CGFloat)maxWidth
 {
-    // Compute here height of bubble cell
-    CGFloat rowHeight;
-    
     id<MXKRoomBubbleCellDataStoring> bubbleData = [self cellDataAtIndex:index];
     
     // Sanity check
-    if (!bubbleData)
+    if (bubbleData && self.delegate)
     {
-        return 0;
+        // Compute here height of bubble cell
+        Class<MXKCellRendering> cellViewClass = [self.delegate cellViewClassForCellData:bubbleData];
+        return [cellViewClass heightForCellData:bubbleData withMaximumWidth:maxWidth];
     }
     
-    Class cellViewClass;
-    if (bubbleData.isIncoming)
-    {
-        if (bubbleData.isAttachmentWithThumbnail)
-        {
-            if (bubbleData.shouldHideSenderInformation)
-            {
-                cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomIncomingAttachmentHiddenSenderCellIdentifier];
-            }
-            else
-            {
-                cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomIncomingAttachmentCellIdentifier];
-            }
-        }
-        else
-        {
-            if (bubbleData.shouldHideSenderInformation)
-            {
-                cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomIncomingTextMsgHiddenSenderCellIdentifier];
-            }
-            else
-            {
-                cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomIncomingTextMsgCellIdentifier];
-            }
-        }
-    }
-    else if (bubbleData.isAttachmentWithThumbnail)
-    {
-        if (bubbleData.shouldHideSenderInformation)
-        {
-            cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomOutgoingAttachmentHiddenSenderCellIdentifier];
-        }
-        else
-        {
-            cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomOutgoingAttachmentCellIdentifier];
-        }
-    }
-    else
-    {
-        if (bubbleData.shouldHideSenderInformation)
-        {
-            cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomOutgoingTextMsgHiddenSenderCellIdentifier];
-        }
-        else
-        {
-            cellViewClass = [self cellViewClassForCellIdentifier:kMXKRoomOutgoingTextMsgCellIdentifier];
-        }
-    }
-    
-    rowHeight = [cellViewClass heightForCellData:bubbleData withMaximumWidth:maxWidth];
-    return rowHeight;
+    return 0;
 }
 
 #pragma mark - Pagination
@@ -2124,84 +2041,44 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    UITableViewCell<MXKCellRendering> *cell;
+    
     id<MXKRoomBubbleCellDataStoring> bubbleData = [self cellDataAtIndex:indexPath.row];
     
+    if (bubbleData && self.delegate)
+    {
+        // Retrieve the cell identifier according to cell data.
+        NSString *identifier = [self.delegate cellReuseIdentifierForCellData:bubbleData];
+        if (identifier)
+        {
+            cell = [tableView dequeueReusableCellWithIdentifier:identifier forIndexPath:indexPath];
+            
+            // Make sure we listen to user actions on the cell
+            if (!cell.delegate)
+            {
+                cell.delegate = self;
+            }
+            
+            // Update typing flag before rendering
+            bubbleData.isTyping = _showTypingNotifications && currentTypingUsers && ([currentTypingUsers indexOfObject:bubbleData.senderId] != NSNotFound);
+            // Report the current timestamp display option
+            bubbleData.showBubbleDateTime = self.showBubblesDateTime;
+            // display the read receipts
+            bubbleData.showBubbleReceipts = self.showBubbleReceipts;
+            // let the caller application manages the time label
+            bubbleData.useCustomDateTimeLabel = self.useCustomDateTimeLabel;
+            
+            // Make the bubble display the data
+            [cell render:bubbleData];
+        }
+    }
+    
     // Sanity check: this method may be called during a layout refresh while room data have been modified.
-    if (!bubbleData)
+    if (!cell)
     {
         // Return an empty cell
         return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"fakeCell"];
     }
-    
-    // The cell to use depends if this is a message from the user or not
-    // Then use the cell class defined by the table view
-    MXKRoomBubbleTableViewCell *cell;
-    
-    if (bubbleData.isIncoming)
-    {
-        if (bubbleData.isAttachmentWithThumbnail)
-        {
-            if (bubbleData.shouldHideSenderInformation)
-            {
-                cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomIncomingAttachmentHiddenSenderCellIdentifier forIndexPath:indexPath];
-            }
-            else
-            {
-                cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomIncomingAttachmentCellIdentifier forIndexPath:indexPath];
-            }
-        }
-        else
-        {
-            if (bubbleData.shouldHideSenderInformation)
-            {
-                cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomIncomingTextMsgHiddenSenderCellIdentifier forIndexPath:indexPath];
-            }
-            else
-            {
-                cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomIncomingTextMsgCellIdentifier forIndexPath:indexPath];
-            }
-        }
-    }
-    else if (bubbleData.isAttachmentWithThumbnail)
-    {
-        if (bubbleData.shouldHideSenderInformation)
-        {
-            cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomOutgoingAttachmentHiddenSenderCellIdentifier forIndexPath:indexPath];
-        }
-        else
-        {
-            cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomOutgoingAttachmentCellIdentifier forIndexPath:indexPath];
-        }
-    }
-    else
-    {
-        if (bubbleData.shouldHideSenderInformation)
-        {
-            cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomOutgoingTextMsgHiddenSenderCellIdentifier forIndexPath:indexPath];
-        }
-        else
-        {
-            cell = [tableView dequeueReusableCellWithIdentifier:kMXKRoomOutgoingTextMsgCellIdentifier forIndexPath:indexPath];
-        }
-    }
-    
-    // Make sure we listen to user actions on the cell
-    if (!cell.delegate)
-    {
-        cell.delegate = self;
-    }
-    
-    // Update typing flag before rendering
-    bubbleData.isTyping = _showTypingNotifications && currentTypingUsers && ([currentTypingUsers indexOfObject:bubbleData.senderId] != NSNotFound);
-    // Report the current timestamp display option
-    bubbleData.showBubbleDateTime = self.showBubblesDateTime;
-    // display the read receipts
-    bubbleData.showBubbleReceipts = self.showBubbleReceipts;
-    // let the caller application manages the time label
-    bubbleData.useCustomDateTimeLabel = self.useCustomDateTimeLabel;
-    
-    // Make the bubble display the data
-    [cell render:bubbleData];
     
     return cell;
 }

--- a/MatrixKit/Models/RoomList/MXKInterleavedRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKInterleavedRecentsDataSource.m
@@ -40,9 +40,6 @@
     if (self)
     {
         interleavedCellDataArray = [NSMutableArray array];
-        
-        // Reset default view classes
-        [self registerCellViewClass:MXKInterleavedRecentTableViewCell.class forCellIdentifier:kMXKRecentCellIdentifier];
     }
     return self;
 }
@@ -335,23 +332,24 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     id<MXKRecentCellDataStoring> roomData = [self cellDataAtIndexPath:indexPath];
-    if (roomData)
+    if (roomData && self.delegate)
     {
-        MXKRecentTableViewCell *cell  = [tableView dequeueReusableCellWithIdentifier:kMXKRecentCellIdentifier forIndexPath:indexPath];
-        
-        // Make the bubble display the data
-        [cell render:roomData];
-        
-        // Clear the user flag, if only one recents list is available
-        if (displayedRecentsDataSourceArray.count == 1)
+        NSString *cellIdentifier = [self.delegate cellReuseIdentifierForCellData:roomData];
+        if (cellIdentifier)
         {
-            if ([cell isKindOfClass:[MXKInterleavedRecentTableViewCell class]])
+            UITableViewCell<MXKCellRendering> *cell  = [tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
+            
+            // Make the bubble display the data
+            [cell render:roomData];
+            
+            // Clear the user flag, if only one recents list is available
+            if (displayedRecentsDataSourceArray.count == 1 && [cell isKindOfClass:[MXKInterleavedRecentTableViewCell class]])
             {
                 ((MXKInterleavedRecentTableViewCell*)cell).userFlag.backgroundColor = [UIColor clearColor];
             }
+            
+            return cell;
         }
-        
-        return cell;
     }
     return nil;
 }

--- a/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
@@ -16,8 +16,6 @@
 
 #import "MXKRecentsDataSource.h"
 
-#import "MXKRecentTableViewCell.h"
-
 #import "NSBundle+MatrixKit.h"
 
 #import "MXKConstants.h"
@@ -59,7 +57,6 @@
         
         // Set default data and view classes
         [self registerCellDataClass:MXKRecentCellData.class forCellIdentifier:kMXKRecentCellIdentifier];
-        [self registerCellViewClass:MXKRecentTableViewCell.class forCellIdentifier:kMXKRecentCellIdentifier];
     }
     return self;
 }
@@ -89,7 +86,6 @@
         
         // Set the actual data and view classes
         [recentsDataSource registerCellDataClass:[self cellDataClassForCellIdentifier:kMXKRecentCellIdentifier] forCellIdentifier:kMXKRecentCellIdentifier];
-        [recentsDataSource registerCellViewClass:[self cellViewClassForCellIdentifier:kMXKRecentCellIdentifier] forCellIdentifier:kMXKRecentCellIdentifier];
         
         [mxSessionArray addObject:matrixSession];
         
@@ -198,26 +194,6 @@
     }
     
     return currentState;
-}
-
-- (void)registerCellDataClass:(Class)cellDataClass forCellIdentifier:(NSString *)identifier
-{
-    [super registerCellDataClass:cellDataClass forCellIdentifier:identifier];
-    
-    for (MXKSessionRecentsDataSource *recentsDataSource in recentsDataSourceArray)
-    {
-        [recentsDataSource registerCellDataClass:cellDataClass forCellIdentifier:identifier];
-    }
-}
-
-- (void)registerCellViewClass:(Class<MXKCellRendering>)cellViewClass forCellIdentifier:(NSString *)identifier
-{
-    [super registerCellViewClass:cellViewClass forCellIdentifier:identifier];
-    
-    for (MXKSessionRecentsDataSource *recentsDataSource in recentsDataSourceArray)
-    {
-        [recentsDataSource registerCellViewClass:cellViewClass forCellIdentifier:identifier];
-    }
 }
 
 - (void)destroy
@@ -442,18 +418,22 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section < displayedRecentsDataSourceArray.count)
+    if (indexPath.section < displayedRecentsDataSourceArray.count && self.delegate)
     {
         MXKSessionRecentsDataSource *recentsDataSource = [displayedRecentsDataSourceArray objectAtIndex:indexPath.section];
         
         id<MXKRecentCellDataStoring> roomData = [recentsDataSource cellDataAtIndex:indexPath.row];
         
-        MXKRecentTableViewCell *cell  = [tableView dequeueReusableCellWithIdentifier:kMXKRecentCellIdentifier forIndexPath:indexPath];
-        
-        // Make the bubble display the data
-        [cell render:roomData];
-        
-        return cell;
+        NSString *cellIdentifier = [self.delegate cellReuseIdentifierForCellData:roomData];
+        if (cellIdentifier)
+        {
+            UITableViewCell<MXKCellRendering> *cell  = [tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
+            
+            // Make the bubble display the data
+            [cell render:roomData];
+            
+            return cell;
+        }
     }
     return nil;
 }
@@ -473,6 +453,28 @@
 }
 
 #pragma mark - MXKDataSourceDelegate
+
+- (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+{
+    // Retrieve the class from the delegate here
+    if (self.delegate)
+    {
+        return [self.delegate cellViewClassForCellData:cellData];
+    }
+    
+    return nil;
+}
+
+- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+{
+    // Retrieve the identifier from the delegate here
+    if (self.delegate)
+    {
+        return [self.delegate cellReuseIdentifierForCellData:cellData];
+    }
+    
+    return nil;
+}
 
 - (void)dataSource:(MXKDataSource*)dataSource didCellChange:(id)changes
 {

--- a/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
@@ -16,8 +16,6 @@
 
 #import "MXKSessionRecentsDataSource.h"
 
-#import "MXKRecentTableViewCell.h"
-
 #import "MXKRoomDataSourceManager.h"
 
 #pragma mark - Constant definitions
@@ -62,7 +60,6 @@ NSString *const kMXKRecentCellIdentifier = @"kMXKRecentCellIdentifier";
         
         // Set default data and view classes
         [self registerCellDataClass:MXKRecentCellData.class forCellIdentifier:kMXKRecentCellIdentifier];
-        [self registerCellViewClass:MXKRecentTableViewCell.class forCellIdentifier:kMXKRecentCellIdentifier];
         
         // Set default MXEvent -> NSString formatter
         _eventFormatter = [[MXKEventFormatter alloc] initWithMatrixSession:self.mxSession];
@@ -255,10 +252,15 @@ NSString *const kMXKRecentCellIdentifier = @"kMXKRecentCellIdentifier";
 
 - (CGFloat)cellHeightAtIndex:(NSInteger)index
 {
-    id<MXKRecentCellDataStoring> cellData = [self cellDataAtIndex:index];
+    if (self.delegate)
+    {
+        id<MXKRecentCellDataStoring> cellData = [self cellDataAtIndex:index];
+        
+        Class<MXKCellRendering> class = [self.delegate cellViewClassForCellData:cellData];
+        return [class heightForCellData:cellData withMaximumWidth:0];
+    }
     
-    Class<MXKCellRendering> class = [self cellViewClassForCellIdentifier:kMXKRecentCellIdentifier];
-    return [class heightForCellData:cellData withMaximumWidth:0];
+    return 0;
 }
 
 

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.xib
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -13,10 +13,12 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aXI-hs-gNf" id="q4T-pF-CuP">
+                <rect key="frame" x="0.0" y="0.0" width="600" height="49"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CJC-M2-3cz" customClass="MXKImageView">
                         <rect key="frame" x="8" y="5" width="40" height="40"/>
+                        <animations/>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="CJC-M2-3cz" secondAttribute="height" multiplier="1:1" id="bly-Ea-Vvq"/>
@@ -24,12 +26,14 @@
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="userLabel" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iFy-OK-xut" userLabel="userLabel">
                         <rect key="frame" x="56" y="5" width="520" height="34"/>
+                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W5Z-3a-LW2" userLabel="PowerContainer">
                         <rect key="frame" x="578" y="18" width="14" height="14"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="14" id="7fi-W6-3Sa"/>
@@ -38,12 +42,14 @@
                     </view>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YAu-wP-WnM" userLabel="typingBadge">
                         <rect key="frame" x="5" y="0.0" width="20" height="20"/>
+                        <animations/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="dFN-Im-pSS"/>
                             <constraint firstAttribute="width" constant="20" id="scT-z6-Uun"/>
                         </constraints>
                     </imageView>
                 </subviews>
+                <animations/>
                 <constraints>
                     <constraint firstItem="YAu-wP-WnM" firstAttribute="leading" secondItem="q4T-pF-CuP" secondAttribute="leading" constant="5" id="5ft-Pb-UJN"/>
                     <constraint firstAttribute="trailingMargin" secondItem="W5Z-3a-LW2" secondAttribute="trailing" id="74P-LT-vkG"/>
@@ -58,6 +64,7 @@
                     <constraint firstAttribute="trailing" secondItem="iFy-OK-xut" secondAttribute="trailing" constant="24" id="sVQ-oi-McX"/>
                 </constraints>
             </tableViewCellContentView>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <connections>
                 <outlet property="pictureView" destination="CJC-M2-3cz" id="AZY-ZP-KSE"/>

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ ecosystem based on 4 components:
 ViewController
   The ViewController is responsible for managing the display and user actions.
 
-Dataource
+DataSource
   Provides the ViewController with items (CellView objects) to display. More
   accurately, the DataSource gets data (mainly Matrix events) from the Matrix
   SDK. It asks CellData objects to process the data into human readable text and
@@ -136,26 +136,21 @@ The kit has been designed so that developers can make customisations at
 different levels, which are:
 
 ViewController
-  The provided ViewControllers can be subclassed in order to change their
-  default behavior and the interactions with the end user.
+  The provided ViewControllers can be subclassed in order to customise the following points:
+- the CellView class used by the DataSource to render CellData.
+- the layout of the table or the collection view.
+- the interactions with the end user.
 
 CellView
-  The developer can indicate to the DataSource which view class it should use to
-  render CellData. This can be used to completely change the way items are
-  displayed. Note that CellView classes must implement the MXKCellRendering
-  protocol.
+  The developer may override MatrixKit CellViews to completely change the way items are displayed. Note that CellView classes must be conformed to the MXKCellRendering protocol.
 
 CellData
-  The developer can provide another CellData class in order to compute data
-  differently.
+  The developer can implement his own CellData classes in order to prepare differently rendered data. Note that the use of customised CellData classes is handled at DataSource level (see registerCellDataClass method).
 
 DataSource
   This object gets the data from the Matrix SDK and serves it to the view
   controller via CellView and CellData objects. You can override the default
   DataSource to have a different behaviour.
-
-UIAppearance (Not yet available)
-    Views in MatrixKit use the UIKit UIAppearance concept to allow easy skinning.
 
 
 Customisation example
@@ -167,25 +162,23 @@ This use case shows how to make `cellView` customisation.
 
 A room chat is basically a list of items where each item represents a message
 (or a set of messages if they are grouped by sender). In the code, these items
-are inherit from UITableViewCell. If you are not happy with the default
-ones used by MXKRoomViewController and MXKRoomDataSource, you can tell them to
-use a UITableViewCell class of your own as follows::
+are inherit from MXKTableViewCell. If you are not happy with the default
+ones used by MXKRoomViewController and MXKRoomDataSource, you can change them by overriding MXKDataSourceDelegate methods in your view controller:
 
-        // Init the room data source
-        MXKRoomDataSource *roomDataSource = [[MXKRoomDataSource alloc] initWithRoomId:@"!cURbafjkfsMDVwdRDQ:matrix.org" andMatrixSession:mxSession];
+        - (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+		{ 
+		    // Let `MyOwnBubbleTableViewCell` class manage the display of message cells
+	        // This class must inherit from UITableViewCell and must conform the `MXKCellRendering` protocol
+		    return MyOwnBubbleTableViewCell.class;
+		}
 
-        // `cellView` Customisation
-        // Let the `MyOwnIncomingBubbleTableViewCell` class manage the display of message cells
-        // This class must inherit from UITableViewCell and must conform the `MXKCellRendering` protocol
-        [roomDataSource registerCellViewClass:MyOwnIncomingBubbleTableViewCell.class
-                            forCellIdentifier:kMXKRoomIncomingTextMsgBubbleTableViewCellIdentifier];
-
-        // Then finalise the room view controller
-        MXKRoomViewController *roomViewController = [[MXKRoomViewController alloc] init];
-        [roomViewController displayRoom:roomDataSource];
+		- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+		{
+		    // Return the `MyOwnBubbleTableViewCell` cell identifier.
+		    return @"MyOwnBubbleTableViewCellIdentifier";
+		}
         
-This example also illustrates how you can define different `cellView` classes
-for received and sent messages.
+You may return a `cellView` class by taking into account the provided cell data. For example you can define different classes for received and sent messages.
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -163,20 +163,20 @@ This use case shows how to make `cellView` customisation.
 A room chat is basically a list of items where each item represents a message
 (or a set of messages if they are grouped by sender). In the code, these items
 are inherit from MXKTableViewCell. If you are not happy with the default
-ones used by MXKRoomViewController and MXKRoomDataSource, you can change them by overriding MXKDataSourceDelegate methods in your view controller:
+ones used by MXKRoomViewController and MXKRoomDataSource, you can change them by overriding MXKDataSourceDelegate methods in your view controller::
 
-        - (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
-		{ 
-		    // Let `MyOwnBubbleTableViewCell` class manage the display of message cells
-	        // This class must inherit from UITableViewCell and must conform the `MXKCellRendering` protocol
-		    return MyOwnBubbleTableViewCell.class;
-		}
-
-		- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
-		{
-		    // Return the `MyOwnBubbleTableViewCell` cell identifier.
-		    return @"MyOwnBubbleTableViewCellIdentifier";
-		}
+    - (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+    {
+       // Let `MyOwnBubbleTableViewCell` class manage the display of message cells
+       // This class must inherit from UITableViewCell and must conform the `MXKCellRendering` protocol
+       return MyOwnBubbleTableViewCell.class;
+    }
+    
+    - (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+    {
+        // Return the `MyOwnBubbleTableViewCell` cell identifier.
+        return @"MyOwnBubbleTableViewCellIdentifier";
+    }
         
 You may return a `cellView` class by taking into account the provided cell data. For example you can define different classes for received and sent messages.
 

--- a/Samples/MatrixKitSample/MXKSampleJSQMessagesViewController.m
+++ b/Samples/MatrixKitSample/MXKSampleJSQMessagesViewController.m
@@ -141,6 +141,21 @@
 }
 
 #pragma mark - MXKDataSourceDelegate
+
+- (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+{
+    // In this sample, the data source is not used to provide collection view cell
+    // That is why we return nil here.
+    return nil;
+}
+
+- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+{
+    // In this sample, the data source is not used to provide collection view cell
+    // That is why we return nil here.
+    return nil;
+}
+
 - (void)dataSource:(MXKDataSource *)dataSource didCellChange:(id)changes
 {
     // For now, do a simple full reload

--- a/Samples/MatrixKitSample/MXKSampleMainTableViewController.m
+++ b/Samples/MatrixKitSample/MXKSampleMainTableViewController.m
@@ -19,8 +19,6 @@
 #import "MXKSampleJSQMessagesViewController.h"
 #import "MXKSampleRoomMembersViewController.h"
 
-#import "MXKSampleRoomMemberTableViewCell.h"
-
 #import <MatrixSDK/MXFileStore.h>
 
 @interface MXKSampleMainTableViewController ()
@@ -653,9 +651,6 @@
         sampleRoomMemberListViewController.delegate = self;
         
         MXKRoomMemberListDataSource *listDataSource = [[MXKRoomMemberListDataSource alloc] initWithRoomId:selectedRoom.state.roomId andMatrixSession:selectedRoom.mxSession];
-        
-        // Replace default table view cell with customized cell: `MXKSampleRoomMemberTableViewCell`
-        [listDataSource registerCellViewClass:MXKSampleRoomMemberTableViewCell.class forCellIdentifier:kMXKRoomMemberCellIdentifier];
         
         [listDataSource finalizeInitialization];
         

--- a/Samples/MatrixKitSample/MXKSampleRoomMembersViewController.m
+++ b/Samples/MatrixKitSample/MXKSampleRoomMembersViewController.m
@@ -16,6 +16,8 @@
 
 #import "MXKSampleRoomMembersViewController.h"
 
+#import "MXKSampleRoomMemberTableViewCell.h"
+
 @interface MXKSampleRoomMembersViewController ()
 
 @end
@@ -29,12 +31,29 @@
     // Turn off optional navigation bar items
     self.enableMemberInvitation = NO;
     self.enableMemberSearch = NO;
+    
+    // Set up customized table view cell class
+    [self.membersTableView registerNib:MXKSampleRoomMemberTableViewCell.nib forCellReuseIdentifier:MXKSampleRoomMemberTableViewCell.defaultReuseIdentifier];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Override MXKDataSourceDelegate to use customized table view cell
+
+- (Class<MXKCellRendering>)cellViewClassForCellData:(MXKCellData*)cellData
+{
+    // Return the default member table view cell
+    return MXKSampleRoomMemberTableViewCell.class;
+}
+
+- (NSString *)cellReuseIdentifierForCellData:(MXKCellData*)cellData
+{
+    // Consider the default member table view cell
+    return MXKSampleRoomMemberTableViewCell.defaultReuseIdentifier;
 }
 
 @end


### PR DESCRIPTION
The aim of this refactoring is to handle the cell view definition at view controller level instead of data source level.

For that:
- we define 2 new methods in MXKDataSourceDelegate protocol: one to retrieve the cell view class adapted to render a cell data, another to retrieve the associated identifier used to dequeue  and reuse table or collection cells.
- we remove the definition of cell view identifiers in data source headers. These identifiers are now handled at view controller level.