### PR TITLE
Don't delete the pusher when we close the session

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -290,6 +290,12 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         {
             // Close session (keep the storage).
             [self closeSession:NO];
+	    if (_enablePushNotifications)
+	    {
+		// Turn off pusher
+		[self enablePusher:NO success:nil failure:nil];
+	    }
+    
         }
         else if (!mxSession)
         {
@@ -454,12 +460,6 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
  */
 - (void)closeSession:(BOOL)clearStore
 {
-    if (_enablePushNotifications)
-    {
-        // Turn off pusher
-        [self enablePusher:NO success:nil failure:nil];
-    }
-    
     [self removeNotificationListener];
     
     if (reachabilityObserver)
@@ -505,6 +505,12 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)logout
 {
     [self closeSession:YES];
+    if (_enablePushNotifications)
+    {
+        // Turn off pusher
+        [self enablePusher:NO success:nil failure:nil];
+    }
+    
 }
 
 - (void)pauseInBackgroundTask


### PR DESCRIPTION
only when we logout or disable the account, otherwise we delete and (usually) recreate our pusher every time the app starts, which is a Bad Idea.

Should fix the problem where push turns itself off sometimes and then you get no push until you open the app again.