### PR TITLE
MXKRoomBubbleTableViewCell: Add overlay container

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -27,7 +27,7 @@
 @implementation MXKRoomBubbleCellData
 @synthesize senderId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment;
 @synthesize textMessage, attributedTextMessage;
-@synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel;
+@synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel, useCustomReceipts;
 
 #pragma mark - MXKRoomBubbleCellDataStoring
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -121,19 +121,24 @@
 @property (nonatomic) BOOL isTyping;
 
 /**
- Show the date time label in rendered bubble cell (NO by default)
+ Show the date time label in rendered bubble cell. NO by default.
  */
 @property (nonatomic) BOOL showBubbleDateTime;
 
 /**
- The date time label is not managed by MatrixKit. (NO by default).
+ Disable the default display of date time labels by MatrixKit. NO by default.
  */
 @property (nonatomic) BOOL useCustomDateTimeLabel;
 
 /**
- Show the receipts in rendered bubble cell (YES by default)
+ Show the receipts in rendered bubble cell. YES by default.
  */
 @property (nonatomic) BOOL showBubbleReceipts;
+
+/**
+ Disable the default display of read receipts by MatrixKit. NO by default.
+ */
+@property (nonatomic) BOOL useCustomReceipts;
 
 #pragma mark - Public methods
 /**

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -126,7 +126,7 @@
 @property (nonatomic) BOOL showBubbleDateTime;
 
 /**
- Disable the default display of date time labels by MatrixKit. NO by default.
+ A Boolean value that determines whether the date time labels are customized (By default date time display is handled by MatrixKit). NO by default.
  */
 @property (nonatomic) BOOL useCustomDateTimeLabel;
 
@@ -136,7 +136,7 @@
 @property (nonatomic) BOOL showBubbleReceipts;
 
 /**
- Disable the default display of read receipts by MatrixKit. NO by default.
+ A Boolean value that determines whether the read receipts are customized (By default read receipts display is handled by MatrixKit). NO by default.
  */
 @property (nonatomic) BOOL useCustomReceipts;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -150,7 +150,7 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
 @property (nonatomic) BOOL showBubblesDateTime;
 
 /**
- Disable the default display of date time labels by MatrixKit. NO by default.
+ A Boolean value that determines whether the date time labels are customized (By default date time display is handled by MatrixKit). NO by default.
  */
 @property (nonatomic) BOOL useCustomDateTimeLabel;
 
@@ -160,7 +160,7 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
 @property (nonatomic) BOOL showBubbleReceipts;
 
 /**
- Disable the default display of read receipts by MatrixKit. NO by default.
+ A Boolean value that determines whether the read receipts are customized (By default read receipts display is handled by MatrixKit). NO by default.
  */
 @property (nonatomic) BOOL useCustomReceipts;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -145,19 +145,24 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
 @property (nonatomic) MXKEventFormatter *eventFormatter;
 
 /**
- Show the date time label in rendered room bubble cells (NO by default)
+ Show the date time label in rendered room bubble cells. NO by default.
  */
 @property (nonatomic) BOOL showBubblesDateTime;
 
 /**
-  The date time label is not managed by MatrixKit. (NO by default).
+ Disable the default display of date time labels by MatrixKit. NO by default.
  */
 @property (nonatomic) BOOL useCustomDateTimeLabel;
 
 /**
- Show the receipts in rendered bubble cell (YES by default)
+ Show the receipts in rendered bubble cell. YES by default.
  */
 @property (nonatomic) BOOL showBubbleReceipts;
+
+/**
+ Disable the default display of read receipts by MatrixKit. NO by default.
+ */
+@property (nonatomic) BOOL useCustomReceipts;
 
 /**
  Show the typing notifications of other room members in the chat history (YES by default).

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -133,6 +133,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
         _showTypingNotifications = YES;
         
         self.useCustomDateTimeLabel = NO;
+        self.useCustomReceipts = NO;
         
         _maxBackgroundCachedBubblesCount = MXKROOMDATASOURCE_CACHED_BUBBLES_COUNT_THRESHOLD;
         

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -30,7 +30,7 @@
 /**
  Action identifier used when the user tapped on message text view.
  
- The `userInfo` is nil.
+ The `userInfo` dictionary contains an `MXEvent` object under the `kMXKRoomBubbleCellEventKey` key, representing the tapped event.
  */
 extern NSString *const kMXKRoomBubbleCellTapOnMessageTextView;
 
@@ -54,6 +54,13 @@ extern NSString *const kMXKRoomBubbleCellTapOnDateTimeContainer;
  The `userInfo` is nil. The attachment can be retrieved via MXKRoomBubbleTableViewCell.attachmentView.
  */
 extern NSString *const kMXKRoomBubbleCellTapOnAttachmentView;
+
+/**
+ Action identifier used when the user tapped on overlay container.
+ 
+ The `userInfo` is nil
+ */
+extern NSString *const kMXKRoomBubbleCellTapOnOverlayContainer;
 
 /**
  Action identifier used when the user pressed unsent button displayed in front of an unsent event.
@@ -121,6 +128,7 @@ extern NSString *const kMXKRoomBubbleCellEventKey;
 @property (strong, nonatomic) IBOutlet UIImageView *playIconView;
 @property (strong, nonatomic) IBOutlet UIImageView *fileTypeIconView;
 @property (weak, nonatomic) IBOutlet UIView *bubbleInfoContainer;
+@property (weak, nonatomic) IBOutlet UIView *bubbleOverlayContainer;
 
 @property (weak, nonatomic) IBOutlet UIView *progressView;
 @property (weak, nonatomic) IBOutlet UILabel *statsLabel;


### PR DESCRIPTION
+ MXKRoomDataSource: Add a new flag 'useCustomReceipts' to disable the default display of read receipts by MatrixKit.