### PR TITLE
Customize the table used to retrieve the localized version of a string.

### DIFF
--- a/MatrixKit/Categories/NSBundle+MatrixKit.h
+++ b/MatrixKit/Categories/NSBundle+MatrixKit.h
@@ -37,9 +37,16 @@
  */
 + (NSURL *)mxk_audioURLFromMXKAssetsBundleWithName:(NSString *)name;
 
+/**
+ Customize the table used to retrieve the localized version of a string during [mxk_localizedStringForKey:] call.
+ If the key is not defined in this table, the localized string is retrieved from the default table "MatrixKit.strings".
+ 
+ @param tableName the name of the table containing the key-value pairs. Also, the suffix for the strings file (a file with the .strings extension) to store the localized string.
+ */
++ (void)mxk_customizeLocalizedStringTableName:(NSString*)tableName;
 
 /**
- Retrieve localized string from MatrixKit Assets bundle.
+ Retrieve localized string from the customized table. If none, MatrixKit Assets bundle is used.
  
  @param key The string key.
  @return The localized string.

--- a/MatrixKit/Categories/NSBundle+MatrixKit.m
+++ b/MatrixKit/Categories/NSBundle+MatrixKit.m
@@ -19,6 +19,8 @@
 
 @implementation NSBundle (MatrixKit)
 
+static NSString *customLocalizedStringTableName = nil;
+
 + (NSBundle*)mxk_assetsBundle
 {
     NSString *bundleResourcePath = [NSBundle mainBundle].resourcePath;
@@ -58,9 +60,27 @@ static MXKLRUCache *imagesResourceCache = nil;
     return [NSURL fileURLWithPath:[[NSBundle mxk_assetsBundle] pathForResource:name ofType:@"mp3" inDirectory:@"Sounds"]];
 }
 
++ (void)mxk_customizeLocalizedStringTableName:(NSString*)tableName
+{
+    customLocalizedStringTableName = tableName;
+}
+
 + (NSString *)mxk_localizedStringForKey:(NSString *)key
 {
-    return NSLocalizedStringFromTableInBundle(key, @"MatrixKit", [NSBundle mxk_assetsBundle], nil);
+    NSString *localizedString;
+    
+    // Check first customized table
+    if (customLocalizedStringTableName)
+    {
+        localizedString = NSLocalizedStringFromTable(key, customLocalizedStringTableName, nil);
+    }
+    
+    if (!localizedString)
+    {
+        localizedString = NSLocalizedStringFromTableInBundle(key, @"MatrixKit", [NSBundle mxk_assetsBundle], nil);
+    }
+    
+    return localizedString;
 }
 
 @end


### PR DESCRIPTION
If the key is not defined in this table, the localized string is retrieved from the default table "MatrixKit.strings".