### PR TITLE
mxk_localizedStringForKey: Fixed translation defaulting to MatrixKit translation

### DIFF
--- a/MatrixKit/Categories/NSBundle+MatrixKit.m
+++ b/MatrixKit/Categories/NSBundle+MatrixKit.m
@@ -70,12 +70,14 @@ static MXKLRUCache *imagesResourceCache = nil;
     NSString *localizedString;
     
     // Check first customized table
+    // Use "_", a string that does not worth to be translated, as default value to mark
+    // a key that does not have a value in the customized table.
     if (customLocalizedStringTableName)
     {
-        localizedString = NSLocalizedStringFromTable(key, customLocalizedStringTableName, nil);
+        localizedString = NSLocalizedStringWithDefaultValue(key, customLocalizedStringTableName, [NSBundle mainBundle], @"_", nil);
     }
-    
-    if (!localizedString)
+
+    if (localizedString.length == 1 && [localizedString isEqualToString:@"_"])
     {
         localizedString = NSLocalizedStringFromTableInBundle(key, @"MatrixKit", [NSBundle mxk_assetsBundle], nil);
     }


### PR DESCRIPTION
The code for "Check first customized table" in mxk_localizedStringForKey did not work.
If a key has no value in the translation file, iOS does not return nil but the key itself.

There is no way on iOS to check value existence :(
The proposed fix is based on the assumption that a developer will not translate the single character string "_". With this implementation, the code does not spend its life in string comparison to check the translation value existence.

