### PR TITLE
MXKRoomBubbleTableView: Handle avatar tap

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -1897,7 +1897,30 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     }
     else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellTapOnAvatarView])
     {
-        NSLog(@"    -> Avatar of %@ has been tapped", userInfo[kMXKRoomBubbleCellUserIdKey]);
+        //NSLog(@"    -> Avatar of %@ has been tapped", userInfo[kMXKRoomBubbleCellUserIdKey]);
+        
+        // Add the member display name in text input
+        MXRoomMember *selectedRoomMember = [roomDataSource.room.state memberWithUserId:userInfo[kMXKRoomBubbleCellUserIdKey]];
+        if (selectedRoomMember)
+        {
+            NSString *memberName = selectedRoomMember.displayname.length ? selectedRoomMember.displayname : selectedRoomMember.userId;
+            if (inputToolbarView.textMessage.length)
+            {
+                inputToolbarView.textMessage = [NSString stringWithFormat:@"%@ %@", inputToolbarView.textMessage, memberName];
+            }
+            else if ([selectedRoomMember.userId isEqualToString:self.mainSession.myUser.userId])
+            {
+                // Prepare emote
+                inputToolbarView.textMessage = @"/me ";
+            }
+            else
+            {
+                // Bing the member
+                inputToolbarView.textMessage = [NSString stringWithFormat:@"%@: ", memberName];
+            }
+            
+            [inputToolbarView becomeFirstResponder];
+        }
     }
     else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellTapOnDateTimeContainer])
     {
@@ -2248,6 +2271,10 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
                 currentAlert = nil;
             }
         }
+    }
+    else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellLongPressOnAvatarView])
+    {
+        NSLog(@"    -> Avatar of %@ has been long pressed", userInfo[kMXKRoomBubbleCellUserIdKey]);
     }
     else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellUnsentButtonPressed])
     {

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -91,6 +91,13 @@ extern NSString *const kMXKRoomBubbleCellLongPressOnEvent;
 extern NSString *const kMXKRoomBubbleCellLongPressOnProgressView;
 
 /**
+ Action identifier used when the user long pressed on avatar view.
+ 
+ The `userInfo` dictionary contains an `NSString` object under the `kMXKRoomBubbleCellUserIdKey` key, representing the user id of the concerned avatar.
+ */
+extern NSString *const kMXKRoomBubbleCellLongPressOnAvatarView;
+
+/**
  Notifications `userInfo` keys
  */
 extern NSString *const kMXKRoomBubbleCellUserIdKey;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -32,6 +32,7 @@ NSString *const kMXKRoomBubbleCellUnsentButtonPressed = @"kMXKRoomBubbleCellUnse
 
 NSString *const kMXKRoomBubbleCellLongPressOnEvent = @"kMXKRoomBubbleCellLongPressOnEvent";
 NSString *const kMXKRoomBubbleCellLongPressOnProgressView = @"kMXKRoomBubbleCellLongPressOnProgressView";
+NSString *const kMXKRoomBubbleCellLongPressOnAvatarView = @"kMXKRoomBubbleCellLongPressOnAvatarView";
 
 NSString *const kMXKRoomBubbleCellUserIdKey = @"kMXKRoomBubbleCellUserIdKey";
 NSString *const kMXKRoomBubbleCellEventKey = @"kMXKRoomBubbleCellEventKey";
@@ -78,6 +79,10 @@ NSString *const kMXKRoomBubbleCellEventKey = @"kMXKRoomBubbleCellEventKey";
         [tapGesture setDelegate:self];
         [self.pictureView addGestureRecognizer:tapGesture];
         self.pictureView.userInteractionEnabled = YES;
+        
+        // Add a long gesture recognizer on avatar (in order to display for example the member details)
+        UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
+        [self.pictureView addGestureRecognizer:longPress];
     }
     
     if (self.messageTextView)
@@ -90,7 +95,7 @@ NSString *const kMXKRoomBubbleCellEventKey = @"kMXKRoomBubbleCellEventKey";
         [self.messageTextView addGestureRecognizer:tapGesture];
         self.messageTextView.userInteractionEnabled = YES;
         
-        // Add a long gesture recognizer on text view in order to display event details
+        // Add a long gesture recognizer on text view (in order to display for example the event details)
         UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
         [self.messageTextView addGestureRecognizer:longPress];
     }
@@ -925,6 +930,10 @@ static NSMutableDictionary *childClasses;
             {
                 [delegate cell:self didRecognizeAction:kMXKRoomBubbleCellLongPressOnEvent userInfo:@{kMXKRoomBubbleCellEventKey:selectedEvent}];
             }
+        }
+        else if (view == self.pictureView)
+        {
+            [delegate cell:self didRecognizeAction:kMXKRoomBubbleCellLongPressOnAvatarView userInfo:@{kMXKRoomBubbleCellUserIdKey: bubbleData.senderId}];
         }
     }
 }

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
@@ -117,6 +117,11 @@
     growingTextView.placeholder = inPlaceholder;
 }
 
+- (BOOL)becomeFirstResponder
+{
+    return [growingTextView becomeFirstResponder];
+}
+
 - (void)dismissKeyboard
 {
     [growingTextView resignFirstResponder];

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
@@ -54,6 +54,11 @@
     }
 }
 
+- (BOOL)becomeFirstResponder
+{
+    return [_messageComposerTextView becomeFirstResponder];
+}
+
 - (void)dismissKeyboard
 {
     if (_messageComposerTextView)


### PR DESCRIPTION
Add member display name in text input when user taps on avatar.
Note: We add here a new event to handle long press on the avatar view.