### PR TITLE
Room page loading improvement

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2409,11 +2409,13 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (scrollView == _bubblesTableView && scrollView.contentSize.height)
+    // Consider this callback to reset scrolling to bottom flag
+    isScrollingToBottom = NO;
+
+    // shouldScrollToBottomOnTableRefresh is used to inhibit false detection of
+    // scrolling action from the user when the viewVC appears or rotates
+    if (scrollView == _bubblesTableView && scrollView.contentSize.height && !shouldScrollToBottomOnTableRefresh)
     {
-        // Consider this callback to reset scrolling to bottom flag
-        isScrollingToBottom = NO;
-        
         // when the content size if smaller that the frame
         // scrollViewDidEndDecelerating is not called
         // so test it when the content offset goes back to the screen top.

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -1301,6 +1301,7 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     isBackPaginationInProgress = YES;
     [self startActivityIndicator];
     [roomDataSource paginateBackMessagesToFillRect:frame
+                       withMinRequestMessagesCount:_backPaginationLimit
                                            success:^{
                                                
                                                // Stop spinner
@@ -1347,7 +1348,7 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     isBackPaginationInProgress = YES;
     
     // Trigger back pagination
-    [roomDataSource paginateBackMessages:limit success:^(NSUInteger addedCellNumber) {
+    [roomDataSource paginateBackMessages:limit onlyFromStore:NO success:^(NSUInteger addedCellNumber) {
         
         // We will adjust the vertical offset in order to unchange the current display (back pagination should be inconspicuous)
         CGFloat verticalOffset = 0;
@@ -1413,7 +1414,7 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     isBackPaginationInProgress = YES;
     
     // Trigger back pagination to find previous attachments
-    [roomDataSource paginateBackMessages:_backPaginationLimit success:^(NSUInteger addedCellNumber) {
+    [roomDataSource paginateBackMessages:_backPaginationLimit onlyFromStore:NO success:^(NSUInteger addedCellNumber) {
         
         // Check whether attachments viewer is still visible
         if (attachmentsViewer)

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -175,7 +175,7 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
 @property (nonatomic) BOOL showTypingNotifications;
 
 /**
- The pagination applied on the rendered room bubble cells (MXKRoomDataSourceBubblesPaginationNone by default)
+ The pagination applied on the rendered room bubble cells (MXKRoomDataSourceBubblesPaginationNone by default).
  */
 @property (nonatomic) MXKRoomDataSourceBubblesPagination bubblesPagination;
 
@@ -254,21 +254,24 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
  This method fails (with nil error) if the data source is not ready (see `MXKDataSourceStateReady`).
  
  @param numItems the number of items to get.
+ @param onlyFromStore if YES, return available events from the store, do not make a pagination request to the homeserver.
  @param success a block called when the operation succeeds. This block returns the number of added cells.
  (Note this count may be 0 if paginated messages have been concatenated to the current first cell).
  @param failure a block called when the operation fails.
  */
-- (void)paginateBackMessages:(NSUInteger)numItems success:(void (^)(NSUInteger addedCellNumber))success failure:(void (^)(NSError *error))failure;
+- (void)paginateBackMessages:(NSUInteger)numItems onlyFromStore:(BOOL)onlyFromStore success:(void (^)(NSUInteger addedCellNumber))success failure:(void (^)(NSError *error))failure;
 
 /**
  Load enough messages to fill the rect.
  This method fails (with nil error) if the data source is not ready (see `MXKDataSourceStateReady`).
  
- @param the rect to fill.
+ @param rect the rect to fill.
+ @param minRequestMessagesCount if messages are not available in the store, a request to the homeserver
+        is required. minRequestMessagesCount indicates the minimum messages count to retrieve from the hs.
  @param success a block called when the operation succeeds.
  @param failure a block called when the operation fails.
  */
-- (void)paginateBackMessagesToFillRect:(CGRect)rect success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)paginateBackMessagesToFillRect:(CGRect)rect withMinRequestMessagesCount:(NSUInteger)minRequestMessagesCount success:(void (^)())success failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Sending

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -780,7 +780,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
 }
 
 #pragma mark - Pagination
-- (void)paginateBackMessages:(NSUInteger)numItems success:(void (^)(NSUInteger addedCellNumber))success failure:(void (^)(NSError *error))failure
+- (void)paginateBackMessages:(NSUInteger)numItems onlyFromStore:(BOOL)onlyFromStore success:(void (^)(NSUInteger addedCellNumber))success failure:(void (^)(NSError *error))failure
 {
     // Check the current data source state, and the actual user membership for this room.
     if (state != MXKDataSourceStateReady || self.room.state.membership == MXMembershipUnknown || self.room.state.membership == MXMembershipInvite)
@@ -818,7 +818,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     }];
     
     // Launch the pagination
-    backPaginationRequest = [_room paginateBackMessages:numItems complete:^{
+    backPaginationRequest = [_room paginateBackMessages:numItems onlyFromStore:onlyFromStore complete:^{
         
         backPaginationRequest = nil;
         // Once done, process retrieved events
@@ -856,26 +856,47 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     }];
 };
 
-- (void)paginateBackMessagesToFillRect:(CGRect)rect success:(void (^)())success failure:(void (^)(NSError *error))failure
+- (void)paginateBackMessagesToFillRect:(CGRect)rect withMinRequestMessagesCount:(NSUInteger)minRequestMessagesCount success:(void (^)())success failure:(void (^)(NSError *error))failure
 {
+    NSLog(@"[MXKRoomDataSource] paginateBackMessagesToFillRect: %@", NSStringFromCGRect(rect));
+
     // Get the total height of cells already loaded in memory
     CGFloat minMessageHeight = CGFLOAT_MAX;
     CGFloat bubblesTotalHeight = 0;
-    for (NSInteger i = bubbles.count - 1; i >= 0; i--)
-    {
-        CGFloat bubbleHeight = [self cellHeightAtIndex:i withMaximumWidth:rect.size.width];
-        
-        bubblesTotalHeight += bubbleHeight;
 
-        if (bubblesTotalHeight > rect.size.height)
+    // Check whether data has been aldready loaded
+    if (bubbles.count)
+    {
+        for (NSInteger i = bubbles.count - 1; i >= 0; i--)
         {
-            // No need to compute more cells heights, there are enough to fill the rect
-            break;
+            CGFloat bubbleHeight = [self cellHeightAtIndex:i withMaximumWidth:rect.size.width];
+
+            bubblesTotalHeight += bubbleHeight;
+
+            if (bubblesTotalHeight > rect.size.height)
+            {
+                // No need to compute more cells heights, there are enough to fill the rect
+                NSLog(@"[MXKRoomDataSource] -> %tu already loaded bubbles are enough to fill the screen", bubbles.count - i);
+                break;
+            }
+
+            // Compute the minimal height an event takes
+            id<MXKRoomBubbleCellDataStoring> bubbleData = bubbles[i];
+            minMessageHeight = MIN(minMessageHeight,  bubbleHeight / bubbleData.events.count);
         }
-        
-        // Compute the minimal height an event takes
-        id<MXKRoomBubbleCellDataStoring> bubbleData = bubbles[i];
-        minMessageHeight = MIN(minMessageHeight,  bubbleHeight / bubbleData.events.count);
+    }
+    else
+    {
+        NSLog(@"[MXKRoomDataSource] paginateBackMessagesToFillRect: Prefill with data from the store");
+        // Give a chance to load data from the store before doing homeserver requests
+        // Reuse minRequestMessagesCount because we need to provide a number.
+        [self paginateBackMessages:minRequestMessagesCount onlyFromStore:YES success:^(NSUInteger addedCellNumber) {
+
+            // Then retry
+            [self paginateBackMessagesToFillRect:rect withMinRequestMessagesCount:minRequestMessagesCount success:success failure:failure];
+
+        } failure:failure];
+        return;
     }
     
     // Is there enough cells to cover all the requested height?
@@ -890,11 +911,15 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
             // Load messages to cover the remaining height
             // Use an extra of 50% to manage unsupported/unexpected/redated events
             NSUInteger messagesToLoad = ceil((rect.size.height - bubblesTotalHeight) / minMessageHeight * 1.5);
+
+            // It does not worth to make a pagination request for only 1 message.
+            // So, use minRequestMessagesCount
+            messagesToLoad = MAX(messagesToLoad, minRequestMessagesCount);
             
             NSLog(@"[MXKRoomDataSource] paginateBackMessagesToFillRect: need to paginate %tu events to cover %fpx", messagesToLoad, rect.size.height - bubblesTotalHeight);
-            [self paginateBackMessages:messagesToLoad success:^(NSUInteger addedCellNumber) {
+            [self paginateBackMessages:messagesToLoad onlyFromStore:NO success:^(NSUInteger addedCellNumber) {
                 
-                [self paginateBackMessagesToFillRect:rect success:success failure:failure];
+                [self paginateBackMessagesToFillRect:rect withMinRequestMessagesCount:minRequestMessagesCount success:success failure:failure];
                 
             } failure:failure];
         }

--- a/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -92,7 +92,7 @@
         // Trigger asynchronously this back pagination to not block the UI thread.
         dispatch_async(dispatch_get_main_queue(), ^{
         
-            [roomDataSource paginateBackMessages:5 success:nil failure:nil];
+            [roomDataSource paginateBackMessages:5 onlyFromStore:NO success:nil failure:nil];
             
         });
         


### PR DESCRIPTION
The goal of this PR is to remove non required pagination requests when opening a room. It saves network data usage and boost the room content display.

The non required pagination requests occurred:
- the first time the datasource was used. In this case, the room data source made a pagination request instead of using messages from the store - which are often enough to fill the screen.

- when the user came back to a room. When coming back the code made an unexpected pagination request.

This PR depends on https://github.com/matrix-org/matrix-ios-sdk/pull/71.