### PR TITLE
MXKAccount: the push gateway URL must be configurable

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -61,6 +61,12 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 @property (nonatomic) NSString *identityServerURL;
 
 /**
+ The Push Gateway URL used to send event notifications to (nil by default).
+ This URL should be over HTTPS and never over HTTP.
+ */
+@property (nonatomic) NSString *pushGatewayURL;
+
+/**
  The matrix REST client used to make matrix API requests.
  */
 @property (nonatomic, readonly) MXRestClient *mxRestClient;


### PR DESCRIPTION
Related PR in vector-ios: https://github.com/vector-im/vector-ios/pull/173

Related PR in matrix-ios-console: https://github.com/matrix-org/matrix-ios-console/pull/8