### PR TITLE
Fixed https://github.com/vector-im/vector-ios/issues/192: Chat screen lag during the history scrolling

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2047,11 +2047,14 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
         [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:nil];
     }
 
+    CGPoint contentOffset = self.bubblesTableView.contentOffset;
+
+    BOOL hasScrolledToTheBottom = [self reloadBubblesTable:YES];
+
     // If the user is scrolling while we reload the data for a new incoming message for example,
     // there will be a jump in the table view display.
     // Resetting the contentOffset after the reload fixes the issue.
-    CGPoint contentOffset = self.bubblesTableView.contentOffset;
-    if ([self reloadBubblesTable:YES] == NO)
+    if (hasScrolledToTheBottom == NO)
     {
         self.bubblesTableView.contentOffset = contentOffset;
     }

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2046,8 +2046,15 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
         NSArray *attachmentsWithThumbnail = self.roomDataSource.attachmentsWithThumbnail;
         [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:nil];
     }
-    
-    [self reloadBubblesTable:YES];
+
+    // If the user is scrolling while we reload the data for a new incoming message for example,
+    // there will be a jump in the table view display.
+    // Resetting the contentOffset after the reload fixes the issue.
+    CGPoint contentOffset = self.bubblesTableView.contentOffset;
+    if ([self reloadBubblesTable:YES] == NO)
+    {
+        self.bubblesTableView.contentOffset = contentOffset;
+    }
 }
 
 - (void)dataSource:(MXKDataSource *)dataSource didStateChange:(MXKDataSourceState)state


### PR DESCRIPTION
This also fixes the jump on an incoming messages when the user scrolls (even with no back pagination)