### PR TITLE
BF: Application can crash when a video failed to be converted before …

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1468,7 +1468,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
             }
         }];
         
-    } failure:^(NSError *error) {
+    } failure:^() {
         
         // Update the local echo with the error state
         localEcho.mxkState = MXKEventStateSendingFailed;
@@ -1476,7 +1476,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
         
         if (failure)
         {
-            failure(error);
+            failure(nil);
         }
     }];
 }

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -554,51 +554,56 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     
     // Export video file
     [exportSession exportAsynchronouslyWithCompletionHandler:^{
-        
-        // Check status
-        if ([exportSession status] == AVAssetExportSessionStatusCompleted)
-        {
-            
-            AVURLAsset* asset = [AVURLAsset URLAssetWithURL:outputVideoLocalURL
-                                                    options:[NSDictionary dictionaryWithObjectsAndKeys:
-                                                             [NSNumber numberWithBool:YES],
-                                                             AVURLAssetPreferPreciseDurationAndTimingKey,
-                                                             nil]
-                                 ];
-            
-            double durationInMs = (1000 * CMTimeGetSeconds(asset.duration));
-            
-            // Extract the video size
-            CGSize videoSize;
-            NSArray *videoTracks = [asset tracksWithMediaType:AVMediaTypeVideo];
-            if (videoTracks.count > 0)
+
+        // Come back to the UI thread to avoid race conditions
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            // Check status
+            if ([exportSession status] == AVAssetExportSessionStatusCompleted)
             {
-                
-                AVAssetTrack *videoTrack = [videoTracks objectAtIndex:0];
-                videoSize = videoTrack.naturalSize;
-                
-                // The operation is complete
-                success(outputVideoLocalURL, mimetype, videoSize, durationInMs);
+
+                AVURLAsset* asset = [AVURLAsset URLAssetWithURL:outputVideoLocalURL
+                                                        options:[NSDictionary dictionaryWithObjectsAndKeys:
+                                                                 [NSNumber numberWithBool:YES],
+                                                                 AVURLAssetPreferPreciseDurationAndTimingKey,
+                                                                 nil]
+                                     ];
+
+                double durationInMs = (1000 * CMTimeGetSeconds(asset.duration));
+
+                // Extract the video size
+                CGSize videoSize;
+                NSArray *videoTracks = [asset tracksWithMediaType:AVMediaTypeVideo];
+                if (videoTracks.count > 0)
+                {
+
+                    AVAssetTrack *videoTrack = [videoTracks objectAtIndex:0];
+                    videoSize = videoTrack.naturalSize;
+
+                    // The operation is complete
+                    success(outputVideoLocalURL, mimetype, videoSize, durationInMs);
+                }
+                else
+                {
+
+                    NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. Cannot extract video size.");
+
+                    // Remove output file (if any)
+                    [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
+                    failure();
+                }
             }
             else
             {
-                
-                NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. Cannot extract video size.");
-                
+
+                NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. exportSession.status: %d", (int)exportSession.status);
+
                 // Remove output file (if any)
                 [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
                 failure();
             }
-        }
-        else
-        {
-            
-            NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. exportSession.status: %d", (int)exportSession.status);
-            
-            // Remove output file (if any)
-            [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
-            failure();
-        }
+        });
+
     }];
 }
 

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -555,11 +555,13 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     // Export video file
     [exportSession exportAsynchronouslyWithCompletionHandler:^{
 
+        AVAssetExportSessionStatus status = exportSession.status;
+
         // Come back to the UI thread to avoid race conditions
         dispatch_async(dispatch_get_main_queue(), ^{
 
             // Check status
-            if ([exportSession status] == AVAssetExportSessionStatusCompleted)
+            if (status == AVAssetExportSessionStatusCompleted)
             {
 
                 AVURLAsset* asset = [AVURLAsset URLAssetWithURL:outputVideoLocalURL
@@ -596,7 +598,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
             else
             {
 
-                NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. exportSession.status: %d", (int)exportSession.status);
+                NSLog(@"[MXKTools] convertVideoToMP4: Video export failed. exportSession.status: %tu", status);
 
                 // Remove output file (if any)
                 [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];


### PR DESCRIPTION
…sending (https://github.com/vector-im/vector-ios/issues/318)

Fixed possible race condition as iOS calls the [AVAssetExportSession exportAsynchronouslyWithCompletionHandler] block on a private thread.