### PR TITLE
MXKRoomViewController: Do nothing when clicking on an unsent media.

### DIFF
--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -820,6 +820,10 @@
                             }
                             
                             NSLog(@"[MXKAttachmentsVC] video download failed: %@", error);
+
+                            // Display the navigation bar so that the user can leave this screen
+                            self.navigationController.navigationBarHidden = NO;
+
                             // Notify MatrixKit user
                             [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
                             

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2918,16 +2918,24 @@ NSString *const kCmdResetUserPowerLevel = @"/deop";
     
     if (roomBubbleTableViewCell.bubbleData.isAttachmentWithThumbnail)
     {
-        NSArray *attachmentsWithThumbnail = self.roomDataSource.attachmentsWithThumbnail;
-        
-        // Present an attachment viewer
-        attachmentsViewer = [MXKAttachmentsViewController attachmentsViewController];
-        attachmentsViewer.delegate = self;
-        attachmentsViewer.complete = ([roomDataSource.timeline canPaginate:MXTimelineDirectionBackwards] == NO);
-        attachmentsViewer.hidesBottomBarWhenPushed = YES;
-        [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:selectedAttachment.event.eventId];
+        if (selectedAttachment.event.mxkState == MXKEventStateDefault || selectedAttachment.event.mxkState == MXKEventStateBing)
+        {
+            NSArray *attachmentsWithThumbnail = self.roomDataSource.attachmentsWithThumbnail;
 
-        [self.navigationController pushViewController:attachmentsViewer animated:YES];
+            // Present an attachment viewer
+            attachmentsViewer = [MXKAttachmentsViewController attachmentsViewController];
+            attachmentsViewer.delegate = self;
+            attachmentsViewer.complete = ([roomDataSource.timeline canPaginate:MXTimelineDirectionBackwards] == NO);
+            attachmentsViewer.hidesBottomBarWhenPushed = YES;
+            [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:selectedAttachment.event.eventId];
+
+            [self.navigationController pushViewController:attachmentsViewer animated:YES];
+        }
+        else
+        {
+            // Let's the application do something
+            NSLog(@"[MXKRoomVC] showAttachmentInCell on an unsent media");
+        }
     }
     else if (selectedAttachment.type == MXKAttachmentTypeAudio)
     {


### PR DESCRIPTION
This issue is related to https://github.com/vector-im/vector-ios/issues/313. It prevents the kit from trying to display an unsent media.