### PR TITLE
MXKContact: Add hasPrefix method

### DIFF
--- a/MatrixKit/Models/Contact/MXKContact.h
+++ b/MatrixKit/Models/Contact/MXKContact.h
@@ -113,9 +113,17 @@ extern NSString *const kMXKContactMatrixContactPrefixId;
 - (UIImage*)thumbnailWithPreferedSize:(CGSize)size;
 
 /**
+ Tell whether a component of the contact's displayName, or one of his matrix id/email has the provided prefix.
+ 
+ @param prefix a non empty string.
+ @return YES when at least one matrix id, email or a component of the display name has this prefix.
+ */
+- (BOOL)hasPrefix:(NSString*)prefix;
+
+/**
  Check if the patterns can match with this contact
  */
-- (BOOL) matchedWithPatterns:(NSArray*)patterns;
+- (BOOL)matchedWithPatterns:(NSArray*)patterns;
 
 /**
  Internationalize the contact phonenumbers

--- a/MatrixKit/Models/Contact/MXKContact.m
+++ b/MatrixKit/Models/Contact/MXKContact.m
@@ -261,13 +261,15 @@ NSString *const kMXKContactMatrixContactPrefixId = @"Matrix_";
 
 - (BOOL)hasPrefix:(NSString*)prefix
 {
+    prefix = [prefix lowercaseString];
+    
     // Check first display name
     if (_displayName.length)
     {
-        NSArray *components = [_displayName componentsSeparatedByString:@""];
+        NSArray *components = [_displayName componentsSeparatedByString:@" "];
         for (NSString *component in components)
         {
-            NSString *theComponent = [component stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            NSString *theComponent = [[component stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
             if ([theComponent hasPrefix:prefix])
             {
                 return YES;
@@ -280,7 +282,7 @@ NSString *const kMXKContactMatrixContactPrefixId = @"Matrix_";
     NSString *idPrefix = [NSString stringWithFormat:@"@%@", prefix];
     for (NSString* mxId in identifiers)
     {
-        if ([mxId hasPrefix:idPrefix])
+        if ([[mxId lowercaseString] hasPrefix:idPrefix])
         {
             return YES;
         }
@@ -289,7 +291,7 @@ NSString *const kMXKContactMatrixContactPrefixId = @"Matrix_";
     // Check email
     for (MXKEmail* email in _emailAddresses)
     {
-        if ([email.emailAddress hasPrefix:prefix])
+        if ([[email.emailAddress lowercaseString] hasPrefix:prefix])
         {
             return YES;
         }

--- a/MatrixKit/Models/Contact/MXKContact.m
+++ b/MatrixKit/Models/Contact/MXKContact.m
@@ -259,6 +259,45 @@ NSString *const kMXKContactMatrixContactPrefixId = @"Matrix_";
     return _sortingDisplayName;
 }
 
+- (BOOL)hasPrefix:(NSString*)prefix
+{
+    // Check first display name
+    if (_displayName.length)
+    {
+        NSArray *components = [_displayName componentsSeparatedByString:@""];
+        for (NSString *component in components)
+        {
+            NSString *theComponent = [component stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            if ([theComponent hasPrefix:prefix])
+            {
+                return YES;
+            }
+        }
+    }
+    
+    // Check matrix identifiers
+    NSArray *identifiers = self.matrixIdentifiers;
+    NSString *idPrefix = [NSString stringWithFormat:@"@%@", prefix];
+    for (NSString* mxId in identifiers)
+    {
+        if ([mxId hasPrefix:idPrefix])
+        {
+            return YES;
+        }
+    }
+    
+    // Check email
+    for (MXKEmail* email in _emailAddresses)
+    {
+        if ([email.emailAddress hasPrefix:prefix])
+        {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
 - (BOOL)matchedWithPatterns:(NSArray*)patterns
 {
     BOOL matched = NO;


### PR DESCRIPTION
Tell whether a component of the contact's displayName, or one of his matrix id/email has the provided prefix.