### PR TITLE
Formatted body display support

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -104,7 +104,7 @@
             MXKRoomBubbleComponent *roomBubbleComponent = [bubbleComponents objectAtIndex:index];
             if ([roomBubbleComponent.event.eventId isEqualToString:eventId])
             {
-                [roomBubbleComponent updateWithEvent:event];
+                [roomBubbleComponent updateWithEvent:event andRoomState:roomDataSource.room.state];
                 if (!roomBubbleComponent.textMessage.length)
                 {
                     [bubbleComponents removeObjectAtIndex:index];

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -72,3 +72,4 @@
 - (void)updateWithEvent:(MXEvent*)event andRoomState:(MXRoomState*)roomState;
 
 @end
+

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -66,10 +66,9 @@
 /**
  Update the event because its mxkState changed or it is has been redacted.
 
- @see [MXKRoomBubbleCellDataStoring updateWithEvent:].
-
  @param event the new event data.
+ @param roomState the up-to-date state of the room.
  */
-- (void)updateWithEvent:(MXEvent*)event;
+- (void)updateWithEvent:(MXEvent*)event andRoomState:(MXRoomState*)roomState;
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -27,7 +27,8 @@
         // Build text component related to this event
         _eventFormatter = formatter;
         MXKEventFormatterError error;
-        NSString *eventString = [_eventFormatter stringFromEvent:event withRoomState:roomState error:&error];
+
+        NSAttributedString *eventString = [_eventFormatter attributedStringFromEvent:event withRoomState:roomState error:&error];
         if (eventString.length)
         {
             // Manage error
@@ -44,15 +45,15 @@
                     case MXKEventFormatterErrorUnknownEventType:
                         event.mxkState = MXKEventStateUnknownType;
                         break;
-                        
+
                     default:
                         break;
                 }
             }
-            
-            _textMessage = eventString;
-            _attributedTextMessage = nil;
-            
+
+            _textMessage = nil;
+            _attributedTextMessage = eventString;
+
             // Set date time
             if (event.originServerTs != kMXUndefinedTimestamp)
             {
@@ -98,14 +99,13 @@
     }
 }
 
-- (NSAttributedString*)attributedTextMessage
+- (NSString *)textMessage
 {
-    if (!_attributedTextMessage)
+    if (!_textMessage)
     {
-        _attributedTextMessage = [_eventFormatter attributedStringFromString:_textMessage forEvent:_event withPrefix:nil];
+        _textMessage = _attributedTextMessage.string;
     }
-    
-    return _attributedTextMessage;
+    return _textMessage;
 }
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -94,8 +94,6 @@
     // Other calls to updateWithEvent are made to update the state of an event (ex: MXKEventStateSending to MXKEventStateDefault).
     // They occur in live so we can use the room up-to-date state without making huge errors
 
-    // Reset the attributed string to take into account the new font and color that correspond
-    // to the new event
     MXKEventFormatterError error;
     _attributedTextMessage = [_eventFormatter attributedStringFromEvent:event withRoomState:roomState error:&error];
 }

--- a/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -116,7 +116,7 @@
         }
         
         // Compute the attribute text message
-        lastEventAttributedTextMessage = [recentsDataSource.eventFormatter attributedStringFromString:lastEventTextMessage forEvent:lastEvent withPrefix:prefix];
+        lastEventAttributedTextMessage = [recentsDataSource.eventFormatter renderString:lastEventTextMessage forEvent:lastEvent];
     }
 }
 

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -143,14 +143,24 @@ typedef enum : NSUInteger {
 - (NSAttributedString*)attributedStringFromEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState error:(MXKEventFormatterError*)error;
 
 /**
- Return attributed string for the displayable string representing the event.
- 
- @param text pre-computed text representation of the event
- @param event the event.
- @param prefix this string defines the potential prefix on which the prefix attributes (font and color) are applied (used to customized message sender name if any).
- @return NSAttributedString for displaying the event.
+ Render a string into an attributed string with the font and the text color
+ that correspond to the passed event.
+
+ @param string the string to render.
+ @param event the event associated to the string.
+ @return an attributed string.
  */
-- (NSAttributedString *)attributedStringFromString:(NSString *)text forEvent:(MXEvent*)event withPrefix:(NSString*)prefix;
+- (NSAttributedString*)renderString:(NSString*)string forEvent:(MXEvent*)event;
+
+/**
+ Render an html string into an attributed string with the font and the text color
+ that correspond to the passed event.
+
+ @param htmlString the HTLM string to render.
+ @param event the event associated to the string.
+ @return an attributed string.
+ */
+- (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event
 
 #pragma mark - Fake event objects creation
 

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -133,6 +133,16 @@ typedef enum : NSUInteger {
 - (NSString*)stringFromEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState error:(MXKEventFormatterError*)error;
 
 /**
+ Generate a displayable attributed string representating the event.
+
+ @param event the event to format.
+ @param roomState the room state right before the event.
+ @param error the error code. In case of formatting error, the formatter may return non nil string as a proposal.
+ @return the attributed string for the event.
+ */
+- (NSAttributedString*)attributedStringFromEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState error:(MXKEventFormatterError*)error;
+
+/**
  Return attributed string for the displayable string representing the event.
  
  @param text pre-computed text representation of the event

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -250,10 +250,22 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIFont *defaultTextFont;
 
 /**
+ The CSS font family corresponding to defaultTextFont.
+ Default is "'-apple-system', 'HelveticaNeue'"
+ */
+@property (nonatomic) NSString *defaultCSSFontFamily;
+
+/**
  Font applied on the event description prefix used to display for example the message sender name.
  Default is SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *prefixTextFont;
+
+/**
+ The CSS font family corresponding to prefixTextFont.
+ Default is "'-apple-system', 'HelveticaNeue'"
+ */
+@property (nonatomic) NSString *prefixCSSFontFamily;
 
 /**
  Text font used when the event must be bing to the end user. This happens when the event
@@ -263,15 +275,33 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIFont *bingTextFont;
 
 /**
+ The CSS font family corresponding to bingTextFont.
+ Default is "'-apple-system', 'HelveticaNeue'"
+ */
+@property (nonatomic) NSString *bingCSSFontFamily;
+
+/**
  Text font used when the event is a state event.
- Default is italic SFUIText-Regular 14.
+ Default is SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *stateEventTextFont;
 
 /**
- Text font used to display call notices (invite, answer, hangup.
- Default is italic SFUIText-Regular 14.
+ The CSS font family corresponding to stateEventTextFont.
+ Default is "'-apple-system', 'HelveticaNeue'"
+ */
+@property (nonatomic) NSString *stateEventCSSFontFamily;
+
+/**
+ Text font used to display call notices (invite, answer, hangup).
+ Default is SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *callNoticesTextFont;
+
+/**
+ The CSS font family corresponding to callNoticesTextFont.
+ Default is "'-apple-system', 'HelveticaNeue'"
+ */
+@property (nonatomic) NSString *callNoticesCSSFontFamily;
 
 @end

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -143,7 +143,7 @@ typedef enum : NSUInteger {
 - (NSAttributedString*)attributedStringFromEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState error:(MXKEventFormatterError*)error;
 
 /**
- Render a string into an attributed string with the font and the text color
+ Render a random string into an attributed string with the font and the text color
  that correspond to the passed event.
 
  @param string the string to render.
@@ -153,14 +153,14 @@ typedef enum : NSUInteger {
 - (NSAttributedString*)renderString:(NSString*)string forEvent:(MXEvent*)event;
 
 /**
- Render an html string into an attributed string with the font and the text color
+ Render a random html string into an attributed string with the font and the text color
  that correspond to the passed event.
 
  @param htmlString the HTLM string to render.
  @param event the event associated to the string.
  @return an attributed string.
  */
-- (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event
+- (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event;
 
 #pragma mark - Fake event objects creation
 
@@ -292,7 +292,7 @@ typedef enum : NSUInteger {
 
 /**
  Text font used when the event is a state event.
- Default is SFUIText-Regular 14.
+ Default is italic SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *stateEventTextFont;
 

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -56,6 +56,11 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
         _bingTextFont = [UIFont systemFontOfSize:14];
         _stateEventTextFont = [UIFont italicSystemFontOfSize:14];
         _callNoticesTextFont = [UIFont italicSystemFontOfSize:14];
+
+        // -apple-system is available from iOS9 and corresponds to the system font.
+        // Previous iOS versions will fallback to HelveticaNeue
+        _defaultCSSFontFamily = _prefixCSSFontFamily = _bingCSSFontFamily =
+        _stateEventCSSFontFamily = _callNoticesCSSFontFamily = @"'-apple-system', 'HelveticaNeue'";
         
         // Consider the shared app settings by default
         _settings = [MXKAppSettings standardAppSettings];
@@ -973,10 +978,10 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event
 {
     // Apply the css style that corresponds to the event state
-    // @TODO: use the defined font
-    NSString *cssStyledHtmlString = [NSString stringWithFormat:@"<span style=\"font-family: '-apple-system', 'HelveticaNeue'; color: #%X; font-size: %f; text-decoration: none\">%@</span>",
-            [MXKTools rgbValueWithColor:_defaultTextColor],
-            _defaultTextFont.pointSize,
+    NSString *cssStyledHtmlString = [NSString stringWithFormat:@"<span style=\"font-family: %@; color: #%X; font-size: %f; text-decoration: none\">%@</span>",
+            [self cssFontFamilyForEvent:event],
+            [MXKTools rgbValueWithColor:[self textColorForEvent:event]],
+            [self fontForEvent:event].pointSize,
             htmlString];
 
     NSDictionary *options = @{
@@ -1062,6 +1067,31 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
         font = _bingTextFont;
     }
     return font;
+}
+
+/**
+ Get the css font family to use according to the event state.
+
+ @param event the event.
+ @return the css font family.
+ */
+- (NSString*)cssFontFamilyForEvent:(MXEvent*)event
+{
+    // Select text font
+    NSString *cssFontFamily = _defaultCSSFontFamily;
+    if (event.isState)
+    {
+        cssFontFamily = _stateEventCSSFontFamily;
+    }
+    else if (event.eventType == MXEventTypeCallInvite || event.eventType == MXEventTypeCallAnswer || event.eventType == MXEventTypeCallHangup)
+    {
+        cssFontFamily = _callNoticesCSSFontFamily;
+    }
+    else if (event.mxkState == MXKEventStateBing)
+    {
+        cssFontFamily = _bingCSSFontFamily;
+    }
+    return cssFontFamily;
 }
 
 

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -588,7 +588,7 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                 BOOL isHTML = NO;
 
                 // Use the HTML formatted string if provided
-                if ([event.content[@"format"] isEqualToString:@"org.matrix.custom.html"]
+                if ([event.content[@"format"] isEqualToString:kMXRoomMessageFormatHTML]
                     && [event.content[@"formatted_body"] isKindOfClass:[NSString class]])
                 {
                     isHTML =YES;

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -686,7 +686,7 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                     }
                     else
                     {
-                        // Build the attributed string with the right font and color from the string
+                        // Build the attributed string with the right font and color for the event
                         attributedDisplayText = [self renderString:body forEvent:event];
                     }
                 }
@@ -754,7 +754,7 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
 
     if (!attributedDisplayText && displayText)
     {
-        // Build the attributed string with the right font and color from the string
+        // Build the attributed string with the right font and color for the event
         attributedDisplayText = [self renderString:displayText forEvent:event];
     }
     
@@ -797,7 +797,7 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                 displayText = shortDescription;
             }
 
-            // Build the attributed string with the right font and color from the string
+            // Build the attributed string with the right font for the event
             attributedDisplayText = [self renderString:displayText forEvent:event];
         }
     }

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -805,124 +805,6 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
     return attributedDisplayText;
 }
 
-- (NSAttributedString *)attributedStringFromString:(NSString *)text forEvent:(MXEvent*)event withPrefix:(NSString*)prefix
-{
-    NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString: text];
-    NSRange wholeString;
-
-    if (prefix.length)
-    {
-        wholeString = NSMakeRange(prefix.length, str.length - prefix.length);
-
-        // Apply prefix attributes
-        [str addAttribute:NSForegroundColorAttributeName value:_prefixTextColor range:NSMakeRange(0, prefix.length)];
-        [str addAttribute:NSFontAttributeName value:_prefixTextFont range:NSMakeRange(0, prefix.length)];
-    }
-    else
-    {
-        wholeString = NSMakeRange(0, str.length);
-    }
-
-    // Select the text color
-    UIColor *textColor;
-    switch (event.mxkState)
-    {
-        case MXKEventStateDefault:
-            if (_isForSubtitle)
-            {
-                textColor = _subTitleTextColor;
-            }
-            else
-            {
-                textColor = _defaultTextColor;
-            }
-            break;
-        case MXKEventStateBing:
-            textColor = _bingTextColor;
-            break;
-        case MXKEventStateSending:
-            textColor = _sendingTextColor;
-            break;
-        case MXKEventStateSendingFailed:
-        case MXKEventStateUnsupported:
-        case MXKEventStateUnexpected:
-        case MXKEventStateUnknownType:
-            textColor = _errorTextColor;
-            break;
-        default:
-            if (_isForSubtitle)
-            {
-                textColor = _subTitleTextColor;
-            }
-            else
-            {
-                textColor = _defaultTextColor;
-            }
-            break;
-    }
-
-    // Select text font
-    UIFont *font = _defaultTextFont;
-    if (event.isState)
-    {
-        font = _stateEventTextFont;
-    }
-    else if (event.eventType == MXEventTypeCallInvite || event.eventType == MXEventTypeCallAnswer || event.eventType == MXEventTypeCallHangup)
-    {
-        font = _callNoticesTextFont;
-    }
-    else if (event.mxkState == MXKEventStateBing)
-    {
-        font = _bingTextFont;
-    }
-
-    // Apply selected color and font
-    [str addAttribute:NSForegroundColorAttributeName value:textColor range:wholeString];
-    [str addAttribute:NSFontAttributeName value:font range:wholeString];
-
-    if (!([[_settings httpLinkScheme] isEqualToString: @"http"] &&
-          [[_settings httpsLinkScheme] isEqualToString: @"https"]))
-    {
-        NSError *error = NULL;
-        NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:&error];
-
-        NSArray *matches = [detector matchesInString:[str string] options:0 range:wholeString];
-        for (NSTextCheckingResult *match in matches)
-        {
-            NSRange matchRange = [match range];
-            NSURL *matchUrl = [match URL];
-            NSURLComponents *url = [[NSURLComponents new] initWithURL:matchUrl resolvingAgainstBaseURL:NO];
-
-            if (url)
-            {
-                if ([url.scheme isEqualToString: @"http"])
-                {
-                    url.scheme = [_settings httpLinkScheme];
-                }
-                else if ([url.scheme isEqualToString: @"https"])
-                {
-                    url.scheme = [_settings httpsLinkScheme];
-                }
-
-                if (url.URL)
-                {
-                    [str addAttribute:NSLinkAttributeName value:url.URL range:matchRange];
-                }
-            }
-        }
-    }
-    
-    return str;
-}
-
-#pragma mark - Conversion private methods
-
-/**
- Apply the right font and the text color to a string.
-
- @param event the event associated to the string.
- @return an attributed string.
- */
 - (NSAttributedString*)renderString:(NSString*)string forEvent:(MXEvent*)event
 {
     NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:string];
@@ -969,12 +851,6 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
     return str;
 }
 
-/**
- Render an html string into an attributed string.
-
- @param event the event associated to the string.
- @return an attributed string.
- */
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event
 {
     // Apply the css style that corresponds to the event state
@@ -995,6 +871,8 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
 
     return str;
 }
+
+#pragma mark - Conversion private methods
 
 /**
  Get the text color to use according to the event state.
@@ -1093,7 +971,6 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
     }
     return cssFontFamily;
 }
-
 
 #pragma mark - Fake event objects creation
 


### PR DESCRIPTION
#124
This PR concerns only display of formatted html body. This allows to display markdown typed from another Matrix client.

MD typing support on iOS will be another PR.