### PR TITLE
Use DTCoreText to render HTML

### DIFF
--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |s|
   s.dependency 'MatrixSDK', '~> 0.6.8'
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.8.7'
+  s.dependency 'DTCoreText', '~> 1.6.17'
   s.dependency 'GHMarkdownParser', '~> 0.1.2'
 
 end

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -270,22 +270,10 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIFont *defaultTextFont;
 
 /**
- The CSS font family corresponding to defaultTextFont.
- Default is "'-apple-system', 'HelveticaNeue'"
- */
-@property (nonatomic) NSString *defaultCSSFontFamily;
-
-/**
  Font applied on the event description prefix used to display for example the message sender name.
  Default is SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *prefixTextFont;
-
-/**
- The CSS font family corresponding to prefixTextFont.
- Default is "'-apple-system', 'HelveticaNeue'"
- */
-@property (nonatomic) NSString *prefixCSSFontFamily;
 
 /**
  Text font used when the event must be bing to the end user. This happens when the event
@@ -295,33 +283,15 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIFont *bingTextFont;
 
 /**
- The CSS font family corresponding to bingTextFont.
- Default is "'-apple-system', 'HelveticaNeue'"
- */
-@property (nonatomic) NSString *bingCSSFontFamily;
-
-/**
  Text font used when the event is a state event.
  Default is italic SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *stateEventTextFont;
 
 /**
- The CSS font family corresponding to stateEventTextFont.
- Default is "'-apple-system', 'HelveticaNeue'"
- */
-@property (nonatomic) NSString *stateEventCSSFontFamily;
-
-/**
  Text font used to display call notices (invite, answer, hangup).
  Default is SFUIText-Regular 14.
  */
 @property (nonatomic) UIFont *callNoticesTextFont;
-
-/**
- The CSS font family corresponding to callNoticesTextFont.
- Default is "'-apple-system', 'HelveticaNeue'"
- */
-@property (nonatomic) NSString *callNoticesCSSFontFamily;
 
 @end

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -21,6 +21,7 @@
 
 #import "MXKTools.h"
 
+#import "DTCoreText.h"
 #import "GHMarkdownParser.h"
 
 NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
@@ -67,11 +68,6 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
         _bingTextFont = [UIFont systemFontOfSize:14];
         _stateEventTextFont = [UIFont italicSystemFontOfSize:14];
         _callNoticesTextFont = [UIFont italicSystemFontOfSize:14];
-
-        // -apple-system is available from iOS9 and corresponds to the system font.
-        // Previous iOS versions will fallback to HelveticaNeue
-        _defaultCSSFontFamily = _prefixCSSFontFamily = _bingCSSFontFamily =
-        _stateEventCSSFontFamily = _callNoticesCSSFontFamily = @"'-apple-system', 'HelveticaNeue'";
         
         // Consider the shared app settings by default
         _settings = [MXKAppSettings standardAppSettings];
@@ -599,15 +595,13 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                 BOOL isHTML = NO;
 
                 // Use the HTML formatted string if provided
-
-// FIXME: Disable HTML rendering as NSAttributedString block the UI thread
-//                if ([event.content[@"format"] isEqualToString:kMXRoomMessageFormatHTML]
-//                    && [event.content[@"formatted_body"] isKindOfClass:[NSString class]])
-//                {
-//                    isHTML =YES;
-//                    body = event.content[@"formatted_body"];
-//                }
-//                else if ([event.content[@"body"] isKindOfClass:[NSString class]])
+                if ([event.content[@"format"] isEqualToString:kMXRoomMessageFormatHTML]
+                    && [event.content[@"formatted_body"] isKindOfClass:[NSString class]])
+                {
+                    isHTML =YES;
+                    body = event.content[@"formatted_body"];
+                }
+                else if ([event.content[@"body"] isKindOfClass:[NSString class]])
                 {
                     body = event.content[@"body"];
                 }
@@ -867,22 +861,17 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event
 {
     // Apply the css style that corresponds to the event state
-    NSString *cssStyledHtmlString = [NSString stringWithFormat:@"<span style=\"font-family: %@; color: #%X; font-size: %f; text-decoration: none\">%@</span>",
-            [self cssFontFamilyForEvent:event],
-            [MXKTools rgbValueWithColor:[self textColorForEvent:event]],
-            [self fontForEvent:event].pointSize,
-            htmlString];
-
+    UIFont *font = [self fontForEvent:event];
     NSDictionary *options = @{
-                              NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
-                              NSCharacterEncodingDocumentAttribute: @(NSUTF8StringEncoding)
+                              DTUseiOS6Attributes: @(YES),              // Enable it to be able to display the attributed string in a UITextView
+                              DTDefaultFontFamily: font.familyName,
+                              DTDefaultFontName: font.fontName,
+                              DTDefaultFontSize: @(font.pointSize),
+                              DTDefaultTextColor: [self textColorForEvent:event],
+                              DTDefaultLinkDecoration: @(NO),
                               };
-    NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithData:[cssStyledHtmlString dataUsingEncoding:NSUTF8StringEncoding] options:options documentAttributes:NULL error:NULL];
 
-    // Do not underline links
-    [str addAttribute:NSUnderlineStyleAttributeName value:@(0) range:NSMakeRange(0, str.length)];
-
-    return str;
+    return [[NSAttributedString alloc] initWithHTMLData:[htmlString dataUsingEncoding:NSUTF8StringEncoding] options:options documentAttributes:NULL];
 }
 
 #pragma mark - Conversion private methods
@@ -958,31 +947,6 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
         font = _bingTextFont;
     }
     return font;
-}
-
-/**
- Get the css font family to use according to the event state.
-
- @param event the event.
- @return the css font family.
- */
-- (NSString*)cssFontFamilyForEvent:(MXEvent*)event
-{
-    // Select text font
-    NSString *cssFontFamily = _defaultCSSFontFamily;
-    if (event.isState)
-    {
-        cssFontFamily = _stateEventCSSFontFamily;
-    }
-    else if (event.eventType == MXEventTypeCallInvite || event.eventType == MXEventTypeCallAnswer || event.eventType == MXEventTypeCallHangup)
-    {
-        cssFontFamily = _callNoticesCSSFontFamily;
-    }
-    else if (event.mxkState == MXKEventStateBing)
-    {
-        cssFontFamily = _bingCSSFontFamily;
-    }
-    return cssFontFamily;
 }
 
 #pragma mark - Conversion tools

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -871,6 +871,10 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                               DTDefaultLinkDecoration: @(NO),
                               };
 
+    // Do not use the default HTML renderer of NSAttributedString because this method
+    // runs on the UI thread which we want to avoid because renderHTMLString is called
+    // most of the time from a background thread.
+    // Use DTCoreText HTML renderer instead.
     return [[NSAttributedString alloc] initWithHTMLData:[htmlString dataUsingEncoding:NSUTF8StringEncoding] options:options documentAttributes:NULL];
 }
 


### PR DESCRIPTION
Because the NSAttributedString default HTML renderer uses WebKit on the UI thread. As we need to run in a background task, it created race conditions and the app hang forever.

#124
