### PR TITLE
Bug Fix - Profile changes shouldn't reorder the room list

### DIFF
--- a/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -51,6 +51,12 @@
     lastEvent = roomDataSource.lastMessage;
     roomDisplayname = roomDataSource.room.state.displayname;
     
+    // Check whether the user profile changes are ignored during the last message handling
+    if (lastEvent.isUserProfileChange && recentsDataSource.mxSession.ignoreProfileChangesDuringLastMessageProcessing)
+    {
+        lastEvent = nil;
+    }
+    
     if (lastEvent)
     {
         lastEventDate = [recentsDataSource.eventFormatter dateStringFromEvent:lastEvent withTime:YES];

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -347,18 +347,8 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
         {
             // Presently only change on membership, display name and avatar are supported
             
-            // Retrieve membership
-            NSString* membership;
-            MXJSONModelSetString(membership, event.content[@"membership"]);
-            
-            NSString *prevMembership = nil;
-            if (event.prevContent)
-            {
-                MXJSONModelSetString(prevMembership, event.prevContent[@"membership"]);
-            }
-            
-            // Check whether the sender has updated his profile (the membership is then unchanged)
-            if (prevMembership && membership && [membership isEqualToString:prevMembership])
+            // Check whether the sender has updated his profile
+            if (event.isUserProfileChange)
             {
                 // Is redacted event?
                 if (isRedacted)
@@ -431,6 +421,10 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
             }
             else
             {
+                // Retrieve membership
+                NSString* membership;
+                MXJSONModelSetString(membership, event.content[@"membership"]);
+                
                 // Consider here a membership change
                 if ([membership isEqualToString:@"invite"])
                 {
@@ -463,6 +457,12 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                 }
                 else if ([membership isEqualToString:@"leave"])
                 {
+                    NSString *prevMembership = nil;
+                    if (event.prevContent)
+                    {
+                        MXJSONModelSetString(prevMembership, event.prevContent[@"membership"]);
+                    }
+                    
                     if ([event.sender isEqualToString:event.stateKey])
                     {
                         if ([MXCallManager isConferenceUser:event.stateKey])


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/494

- Ignore members profile changes during last message handling.