### PR TITLE
Bug Fix - Screen still tries to turn off when on a VC

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.h
+++ b/MatrixKit/Controllers/MXKCallViewController.h
@@ -155,6 +155,11 @@ extern NSString *const kMXKCallViewControllerBackToAppNotification;
 - (void)showOverlayContainer:(BOOL)isShown;
 
 /**
+ Set up or teardown the promixity monitoring and enable/disable the idle timer according to call type, state & audio route.
+ */
+- (void)updateProximityAndSleep;
+
+/**
  Action registered on the event 'UIControlEventTouchUpInside' for each UIButton instance.
  */
 - (IBAction)onButtonPressed:(id)sender;


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/521

Set up or teardown the promixity monitoring and enable/disable the idle timer according to call type, state & audio route.
TODO: handle the case where an headset is used.