### PR TITLE
BF: When the last message is redacted, [MXKRecentCellData update] mak…

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -120,11 +120,6 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
 @property (nonatomic, readonly) BOOL isPeeking;
 
 /**
- The last event in the room that matches the `eventsFilterForMessages` property.
- */
-@property (nonatomic, readonly) MXEvent *lastMessage;
-
-/**
  The list of the attachments with thumbnail in the current available bubbles (MXKAttachment instances).
  */
 @property (nonatomic, readonly) NSArray *attachmentsWithThumbnail;
@@ -474,5 +469,20 @@ extern NSString *const kMXKRoomDataSourceSyncStatusChanged;
  By default, they are added to the end of the timeline.
  */
 - (void)handleUnsentMessages;
+
+/**
+ The last event in the room.
+ 
+ This event must match several criteria:
+     - its type must be in `eventsFilterForMessages`
+     - it must follow the mxSession.ignoreProfileChangesDuringLastMessageProcessing
+       setting
+     - it must be displayable, ie the passed eventFormatter must return a non empty
+       string for it
+
+ @param eventFormatter the event formatter in order to check the displayability of events.
+ @param onComplete a block call when the operation completes. The provided lastMessage can be nil.
+ */
+- (void)lastMessageWithEventFormatter:(MXKEventFormatter*)eventFormatter onComplete:(void(^)(MXEvent *lastMessage))onComplete;
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -98,6 +98,11 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     MXPeekingRoom *peekingRoom;
     
     /**
+     The cache for the last message returned by [self lastMessageWithEventFormatter:]
+     */
+    MXEvent *lastMessage;
+    
+    /**
      Observe UIApplicationSignificantTimeChangeNotification to trigger cell change on time formatting change.
      */
     id UIApplicationSignificantTimeChangeNotificationObserver;
@@ -378,6 +383,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
         
         [bubbles removeAllObjects];
         [eventIdToBubbleMap removeAllObjects];
+        lastMessage = nil;
         
         _room = nil;
     }
@@ -447,6 +453,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     
     eventsToProcess = nil;
     bubbles = nil;
+    lastMessage = nil;
     eventIdToBubbleMap = nil;
 
     [_timeline destroy];
@@ -583,50 +590,6 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     }
 }
 
-- (MXEvent *)lastMessage
-{
-    MXEvent *lastMessage;
-    
-    // Look for the most recent message (ignore events without timestamp).
-    id<MXKRoomBubbleCellDataStoring> bubbleData;
-    @synchronized(bubbles)
-    {
-        NSInteger index = bubbles.count;
-        while (index--)
-        {
-            bubbleData = bubbles[index];
-            if (bubbleData.date)
-            {
-                break;
-            }
-        }
-    }
-    
-    if (bubbleData)
-    {
-        NSInteger index = bubbleData.events.count;
-        while (index--)
-        {
-            lastMessage = bubbleData.events[index];
-            if (lastMessage.originServerTs != kMXUndefinedTimestamp)
-            {
-                break;
-            }
-            lastMessage = nil;
-        }
-    }
-    
-    if (!lastMessage)
-    {
-        // Use here the stored data for this room
-        lastMessage = [_room lastMessageWithTypeIn:_eventsFilterForMessages];
-        
-        // Check if this event is a bing event
-        [self checkBing:lastMessage];
-    }
-    return lastMessage;
-}
-
 - (NSArray *)attachmentsWithThumbnail
 {
     NSMutableArray *attachments = [NSMutableArray array];
@@ -730,13 +693,13 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
                 {
                     BOOL shouldRemoveBubbleData = NO;
                     BOOL hasChanged = NO;
-                    
+                    MXEvent *redactedEvent = nil;
+
                     @synchronized (bubbleData)
                     {
                         // Retrieve the original event to redact it
                         NSArray *events = bubbleData.events;
-                        MXEvent *redactedEvent = nil;
-                        
+
                         for (MXEvent *event in events)
                         {
                             if ([event.eventId isEqualToString:redactionEvent.redacts])
@@ -774,7 +737,13 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
                     {
                         // Update the delegate on main thread
                         dispatch_async(dispatch_get_main_queue(), ^{
-                            
+
+                            // Reset lastMessage if it has been redacted
+                            if ([lastMessage.eventId isEqualToString:redactedEvent.eventId])
+                            {
+                                lastMessage = nil;
+                            }
+
                             if (self.delegate)
                             {
                                 [self.delegate dataSource:self didCellChange:nil];
@@ -1813,6 +1782,12 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
 
         // Remove the event from the outgoing messages storage
         [_room removeOutgoingMessage:eventId];
+
+        // Reset lastMessage if it has been removed
+        if ([lastMessage.eventId isEqualToString:eventId])
+        {
+            lastMessage = nil;
+        }
     
         // Update the delegate
         if (self.delegate)
@@ -1874,6 +1849,98 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     if (shouldProcessQueuedEvents)
     {
         [self processQueuedEvents:nil];
+    }
+}
+
+- (void)lastMessageWithEventFormatter:(MXKEventFormatter*)eventFormatter onComplete:(void(^)(MXEvent *))onComplete
+{
+    // The last message can
+
+    // Firstly, check if it has been cached
+    if (lastMessage)
+    {
+        NSLog(@"lastMessage: case #1 for %@", self.roomId);
+        onComplete(lastMessage);
+        return;
+    }
+
+    MXEvent *lastDisplayableEvent;
+    MXEvent *event;
+    MXKEventFormatterError *error;
+
+    // Secondly, search for a matching event in the outgoing messages
+    id<MXEventsEnumerator> enumerator = [[MXEventsByTypesEnumeratorOnArray alloc] initWithMessages:_room.outgoingMessages
+                                                                                        andTypesIn:self.eventsFilterForMessages
+                                                                        ignoreMemberProfileChanges:self.mxSession.ignoreProfileChangesDuringLastMessageProcessing];
+    while ((event = enumerator.nextEvent))
+    {
+        // Check that the event formatter can display the event
+        NSString *eventTextMessage = [eventFormatter stringFromEvent:event withRoomState:_room.state error:&error];
+        if (eventTextMessage.length)
+        {
+            lastDisplayableEvent = event;
+            NSLog(@"lastMessage: case #2 for %@", self.roomId);
+            break;
+        }
+    }
+
+    if (!lastDisplayableEvent)
+    {
+        // Thirdly, search for a matching event in the messages already in the store
+        // for this room
+        enumerator = [self.room enumeratorForStoredMessagesWithTypeIn:self.eventsFilterForMessages
+                                           ignoreMemberProfileChanges:self.mxSession.ignoreProfileChangesDuringLastMessageProcessing];
+
+        while ((event = enumerator.nextEvent))
+        {
+            // Check that the event formatter can display the event
+            NSString *eventTextMessage = [eventFormatter stringFromEvent:event withRoomState:_room.state error:&error];
+            if (eventTextMessage.length)
+            {
+                lastDisplayableEvent = event;
+                NSLog(@"lastMessage: case #3 for %@", self.roomId);
+                break;
+            }
+        }
+    }
+
+    if (lastDisplayableEvent)
+    {
+        // Cache it for future reuse
+        lastMessage = lastDisplayableEvent;
+        onComplete(lastDisplayableEvent);
+    }
+    else
+    {
+        if ([_timeline canPaginate: MXTimelineDirectionBackwards])
+        {
+            // Finally, as there is no matching events locally, get more messages from 
+            // the homeserver
+            NSLog(@"lastMessage: case #4 for %@", self.roomId);
+
+            // Trigger asynchronously this back pagination to not block the UI thread.
+            dispatch_async(dispatch_get_main_queue(), ^{
+
+                // Make the data source load more messages than available in the store to
+                // force it to get them from the homeserver
+                [self paginate:(self.room.storedMessagesCount + 30) direction:MXTimelineDirectionBackwards onlyFromStore:NO success:^(NSUInteger addedCellNumber) {
+
+                    [self lastMessageWithEventFormatter:eventFormatter onComplete:onComplete];
+
+                } failure:^(NSError *error) {
+                    
+                    onComplete(nil);
+                    
+                }];
+            });
+        }
+        else
+        {
+            // All the room history has been loaded locally but no message matches the
+            // criteria
+            NSLog(@"lastMessage: case #5 for %@", self.roomId);
+            onComplete(nil);
+        }
     }
 }
 
@@ -1964,6 +2031,15 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
     if (0 == remainingEvents)
     {
         [self removeCellData:bubbleData];
+    }
+
+    // Update lastMessage if it has been replaced
+    if ([lastMessage.eventId isEqualToString:localEcho.eventId])
+    {
+        // The new event should have the same characteristics as localEcho: it should
+        // match [self lastMessageWithEventFormatter:] criteria and can replace it as
+        // as the last message
+        lastMessage = event;
     }
     
     // Update the delegate
@@ -2188,6 +2264,7 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
         NSUInteger serverSyncEventCount = 0;
         NSUInteger addedHistoryCellCount = 0;
         NSUInteger addedLiveCellCount = 0;
+        BOOL lastMessageHasChanged = NO;
         
         // Lock on `eventsToProcessSnapshot` to suspend reload or destroy during the process.
         @synchronized(eventsToProcessSnapshot)
@@ -2371,6 +2448,12 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
                             eventIdToBubbleMap[queuedEvent.event.eventId] = bubbleData;
                         }
                     }
+
+                    if (queuedEvent.direction == MXTimelineDirectionForwards)
+                    {
+                        // There is a new last message
+                        lastMessageHasChanged = YES;
+                    }
                 }
             }
             eventsToProcessSnapshot = nil;
@@ -2382,7 +2465,13 @@ NSString *const kMXKRoomDataSourceSyncStatusChanged = @"kMXKRoomDataSourceSyncSt
             // Updated data can be displayed now
             // Block MXKRoomDataSource.processingQueue while the processing is finalised on the main thread
             dispatch_sync(dispatch_get_main_queue(), ^{
-                
+
+                // Reset the last message cache if new live events have been received
+                if (lastMessageHasChanged)
+                {
+                    lastMessage = nil;
+                }
+
                 // Check whether self has not been reloaded or destroyed
                 if (self.state == MXKDataSourceStateReady && bubblesSnapshot)
                 {

--- a/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -47,82 +47,67 @@
 
 - (void)update
 {
-    // Keep ref on displayed last event
-    lastEvent = roomDataSource.lastMessage;
-    roomDisplayname = roomDataSource.room.state.displayname;
-    
-    // Check whether the user profile changes are ignored during the last message handling
-    if (lastEvent.isUserProfileChange && recentsDataSource.mxSession.ignoreProfileChangesDuringLastMessageProcessing)
-    {
-        lastEvent = nil;
-    }
-    
-    if (lastEvent)
-    {
-        lastEventDate = [recentsDataSource.eventFormatter dateStringFromEvent:lastEvent withTime:YES];
-        
-        // Compute the text message
-        MXKEventFormatterError error;
-        lastEventTextMessage = [recentsDataSource.eventFormatter stringFromEvent:lastEvent withRoomState:roomDataSource.room.state error:&error];
-        
-        // Manage error
-        if (error != MXKEventFormatterErrorNone)
+    // Let the room data source return the last displayable message
+    [roomDataSource lastMessageWithEventFormatter:recentsDataSource.eventFormatter onComplete:^(MXEvent *lastMessage) {
+
+        // Keep ref on displayed last event
+        lastEvent = lastMessage;
+        roomDisplayname = roomDataSource.room.state.displayname;
+
+        if (lastEvent)
         {
-            switch (error)
+            lastEventDate = [recentsDataSource.eventFormatter dateStringFromEvent:lastEvent withTime:YES];
+
+            // Compute the text message
+            MXKEventFormatterError error;
+            lastEventTextMessage = [recentsDataSource.eventFormatter stringFromEvent:lastEvent withRoomState:roomDataSource.room.state error:&error];
+
+            // Manage error
+            if (error != MXKEventFormatterErrorNone)
             {
-                case MXKEventFormatterErrorUnsupported:
-                    lastEvent.mxkState = MXKEventStateUnsupported;
-                    break;
-                case MXKEventFormatterErrorUnexpected:
-                    lastEvent.mxkState = MXKEventStateUnexpected;
-                    break;
-                case MXKEventFormatterErrorUnknownEventType:
-                    lastEvent.mxkState = MXKEventStateUnknownType;
-                    break;
+                switch (error)
+                {
+                    case MXKEventFormatterErrorUnsupported:
+                        lastEvent.mxkState = MXKEventStateUnsupported;
+                        break;
+                    case MXKEventFormatterErrorUnexpected:
+                        lastEvent.mxkState = MXKEventStateUnexpected;
+                        break;
+                    case MXKEventFormatterErrorUnknownEventType:
+                        lastEvent.mxkState = MXKEventStateUnknownType;
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+
+        if (0 == lastEventTextMessage.length)
+        {
+            lastEventTextMessage = @"";
+            lastEventAttributedTextMessage = [[NSAttributedString alloc] initWithString:@""];
+        }
+        else
+        {
+            // Check whether the sender name has to be added
+            NSString *prefix = nil;
+
+            if (lastEvent.eventType == MXEventTypeRoomMessage)
+            {
+                NSString *msgtype = lastEvent.content[@"msgtype"];
+                if ([msgtype isEqualToString:kMXMessageTypeEmote] == NO)
+                {
+                    NSString *senderDisplayName = roomDataSource.room.state ? [recentsDataSource.eventFormatter senderDisplayNameForEvent:lastEvent withRoomState:roomDataSource.room.state] : lastEvent.sender;
                     
-                default:
-                    break;
+                    prefix = [NSString stringWithFormat:@"%@: ", senderDisplayName];
+                }
             }
-        }
-    }
-    else
-    {
-        lastEventTextMessage = nil;
-    }
-    
-    if (0 == lastEventTextMessage.length)
-    {
-        lastEventTextMessage = @"";
-        
-        // Trigger a back pagination to retrieve the actual last message.
-        // Trigger asynchronously this back pagination to not block the UI thread.
-        dispatch_async(dispatch_get_main_queue(), ^{
-        
-            [roomDataSource paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO success:nil failure:nil];
             
-        });
-        
-        lastEventAttributedTextMessage = [[NSAttributedString alloc] initWithString: @""];
-    }
-    else
-    {
-        // Check whether the sender name has to be added
-        NSString *prefix = nil;
-        
-        if (lastEvent.eventType == MXEventTypeRoomMessage)
-        {
-            NSString *msgtype = lastEvent.content[@"msgtype"];
-            if ([msgtype isEqualToString:kMXMessageTypeEmote] == NO)
-            {
-                NSString *senderDisplayName = roomDataSource.room.state ? [recentsDataSource.eventFormatter senderDisplayNameForEvent:lastEvent withRoomState:roomDataSource.room.state] : lastEvent.sender;
-                
-                prefix = [NSString stringWithFormat:@"%@: ", senderDisplayName];
-            }
+            // Compute the attribute text message
+            lastEventAttributedTextMessage = [recentsDataSource.eventFormatter renderString:lastEventTextMessage withPrefix:prefix forEvent:lastEvent];
         }
-        
-        // Compute the attribute text message
-        lastEventAttributedTextMessage = [recentsDataSource.eventFormatter renderString:lastEventTextMessage withPrefix:prefix forEvent:lastEvent];
-    }
+    }];
 }
 
 - (void)dealloc


### PR DESCRIPTION
…es paginations loops 
https://github.com/vector-im/vector-ios/issues/520

Use the new MXEventsEnumerator from MatrixSDK to find the right last message to display.