### PR TITLE
Should fix - Sync has got stuck while the app was backgrounded

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -641,8 +641,9 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         [initialServerSyncTimer invalidate];
         initialServerSyncTimer = nil;
         
-        if (mxSession.state == MXSessionStateSyncInProgress)
+        if (mxSession.state == MXSessionStateSyncInProgress || mxSession.state == MXSessionStateInitialised || mxSession.state == MXSessionStateStoreDataReady)
         {
+            NSLog(@"[MXKAccount] Pause is delayed at the end of sync (current state %tu)", mxSession.state);
             isPauseRequested = YES;
         }
     }
@@ -984,6 +985,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         // Check if pause has been requested
         if (isPauseRequested)
         {
+            NSLog(@"[MXKAccount] Apply the pending pause.");
             [self pauseInBackgroundTask];
             return;
         }


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/506

According to the logs (attached to the emailed report), the applicationDidEnterBackground was ignored during the session state handling. The session was running whereas the app was backgrounded.