### PR TITLE
MXKRoomViewController: Add option to custom scroll on keyboard presen…

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -123,6 +123,13 @@ extern NSString *const kCmdChangeRoomTopic;
 @property BOOL autoJoinInvitedRoom;
 
 /**
+ Tell whether the room history is automatically scrolled to the most recent messages
+ when a keyboard is presented. YES by default.
+ This option is ignored when an alert is presented.
+ */
+@property BOOL scrollHistoryToTheBottomOnKeyboardPresentation;
+
+/**
  This object is defined when the displayed room is left. It is added into the bubbles table header.
  This label is used to display the reason why the room has been left.
  */

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -207,6 +207,9 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
     // Do not take ownership of room data source by default
     _hasRoomDataSourceOwnership = NO;
+    
+    // Scroll to the bottom when a keyboard is presented
+    _scrollHistoryToTheBottomOnKeyboardPresentation = YES;
 }
 
 #pragma mark -
@@ -463,7 +466,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     inputToolbarView.maxHeight = visibleArea - MXKROOMVIEWCONTROLLER_MESSAGES_TABLE_MINIMUM_HEIGHT;
     
     // Scroll the tableview content when a new keyboard is presented (except if an alert is presented).
-    if (!super.keyboardHeight && keyboardHeight && !currentAlert)
+    if (_scrollHistoryToTheBottomOnKeyboardPresentation && !super.keyboardHeight && keyboardHeight && !currentAlert)
     {
         [self scrollBubblesTableViewToBottomAnimated:NO];
     }


### PR DESCRIPTION
…tation.

'scrollHistoryToTheBottomOnKeyboardPresentation': Tell whether the room history is automatically scrolled to the most recent messages when a keyboard is presented.