### PR TITLE
MXKEventFormatter: Change how the kick reason is displayed

### DIFF
--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -225,6 +225,7 @@
 "notice_room_unban" = "%@ unbanned %@";
 "notice_room_ban" = "%@ banned %@";
 "notice_room_withdraw" = "%@ withdrew %@'s invitation";
+"notice_room_reason" = ". Reason: %@";
 "notice_avatar_url_changed" = "%@ changed their avatar";
 "notice_display_name_set" = "%@ set their display name to %@";
 "notice_display_name_changed_from" = "%@ changed their display name from %@ to %@";

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -541,13 +541,18 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                         if ([prevMembership isEqualToString:@"invite"])
                         {
                             displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_withdraw"], senderDisplayName, targetDisplayName];
+                            if (event.content[@"reason"])
+                            {
+                                displayText = [displayText stringByAppendingString:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_reason"], event.content[@"reason"]]];
+                            }
+
                         }
                         else if ([prevMembership isEqualToString:@"join"])
                         {
                             displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_kick"], senderDisplayName, targetDisplayName];
                             if (event.content[@"reason"])
                             {
-                                displayText = [NSString stringWithFormat:@"%@: %@", displayText, event.content[@"reason"]];
+                                displayText = [displayText stringByAppendingString:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_reason"], event.content[@"reason"]]];
                             }
                         }
                         else if ([prevMembership isEqualToString:@"ban"])
@@ -561,7 +566,7 @@ NSString *const kMXKEventFormatterLocalEventIdPrefix = @"MXKLocalId_";
                     displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_ban"], senderDisplayName, targetDisplayName];
                     if (event.content[@"reason"])
                     {
-                        displayText = [NSString stringWithFormat:@"%@: %@", displayText, event.content[@"reason"]];
+                        displayText = [displayText stringByAppendingString:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_room_reason"], event.content[@"reason"]]];
                     }
                 }
                 


### PR DESCRIPTION
It fixes "kick reason should displayed like the webclient" (https://github.com/vector-im/vector-ios/issues/549)