### PR TITLE
Bug Fix - Use contains_url filter for navigating files and showing a …

### DIFF
--- a/MatrixKit/Models/Search/MXKSearchCellData.m
+++ b/MatrixKit/Models/Search/MXKSearchCellData.m
@@ -30,7 +30,15 @@
     {
         searchResult = searchResult2;
 
-        if (nil == searchDataSource.roomId)
+        if (searchDataSource.roomEventFilter.rooms.count == 1)
+        {
+            // We are displaying a search within a room
+            // As title, display the user id
+            title = searchResult.result.sender;
+            
+            roomId = searchDataSource.roomEventFilter.rooms[0];
+        }
+        else
         {
             // We are displaying a search over all user's rooms
             // As title, display the room name of this search result
@@ -43,12 +51,6 @@
             {
                 title = searchResult.result.roomId;
             }
-        }
-        else
-        {
-            // We are displaying a search within a room
-            // As title, display the user id
-            title = searchResult.result.sender;
         }
 
         date = [searchDataSource.eventFormatter dateStringFromEvent:searchResult.result withTime:YES];

--- a/MatrixKit/Models/Search/MXKSearchDataSource.h
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.h
@@ -75,7 +75,7 @@ extern NSString *const kMXKSearchCellDataIdentifier;
 /**
  Launch a message search homeserver side.
 
- @discussion The result depends on the 'mediaFilter' propertie.
+ @discussion The result depends on the 'roomEventFilter' propertie.
  
  @param textPattern the text to search in messages data.
  @param force tell whether the search must be launched even if the text pattern is unchanged.

--- a/MatrixKit/Models/Search/MXKSearchDataSource.h
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.h
@@ -46,15 +46,9 @@ extern NSString *const kMXKSearchCellDataIdentifier;
 @property (nonatomic, readonly) NSString *searchText;
 
 /**
- Tells whether the messages with url (the attachments) are concerned or not by the search session.
- MXMessagesSearchMediaFilterUndefined by default.
+ The room events filter which is applied during the messages search.
  */
-@property (nonatomic) MXMessagesSearchMediaFilter mediaFilter;
-
-/**
- If any the id of the room where the search is made.
- */
-@property (nonatomic, readonly) NSString *roomId;
+@property (nonatomic) MXRoomEventFilter *roomEventFilter;
 
 /**
  Total number of results available on the server.
@@ -77,14 +71,6 @@ extern NSString *const kMXKSearchCellDataIdentifier;
  */
 @property (nonatomic) BOOL shouldShowRoomDisplayName;
 
-/**
- Initialise the data source to search messages in the passed room.
-
- @param roomId the id of the room to search for.
- @param mxSession the Matrix session to get data from.
- @return the newly created instance.
- */
-- (instancetype)initWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession;
 
 /**
  Launch a message search homeserver side.

--- a/MatrixKit/Models/Search/MXKSearchDataSource.h
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.h
@@ -46,10 +46,10 @@ extern NSString *const kMXKSearchCellDataIdentifier;
 @property (nonatomic, readonly) NSString *searchText;
 
 /**
- Tells whether only the messages with url (the attachments) are concerned by the search session.
- NO by default.
+ Tells whether the messages with url (the attachments) are concerned or not by the search session.
+ MXMessagesSearchMediaFilterUndefined by default.
  */
-@property (nonatomic) BOOL containsURL;
+@property (nonatomic) MXMessagesSearchMediaFilter mediaFilter;
 
 /**
  If any the id of the room where the search is made.
@@ -89,7 +89,7 @@ extern NSString *const kMXKSearchCellDataIdentifier;
 /**
  Launch a message search homeserver side.
 
- @discussion The result depends on the 'containsURL' propertie.
+ @discussion The result depends on the 'mediaFilter' propertie.
  
  @param textPattern the text to search in messages data.
  @param force tell whether the search must be launched even if the text pattern is unchanged.

--- a/MatrixKit/Models/Search/MXKSearchDataSource.m
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.m
@@ -178,9 +178,9 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
 
     NSDate *startDate = [NSDate date];
 
-    searchRequest = [self.mxSession.matrixRestClient searchMessagesWithText:_searchText inRooms:rooms beforeLimit:0 afterLimit:0 nextBatch:nextBatch containsURL:_containsURL success:^(MXSearchRoomEventResults *roomEventResults) {
+    searchRequest = [self.mxSession.matrixRestClient searchMessagesWithText:_searchText inRooms:rooms beforeLimit:0 afterLimit:0 nextBatch:nextBatch mediaFilter:_mediaFilter success:^(MXSearchRoomEventResults *roomEventResults) {
 
-        NSLog(@"[MXKSearchDataSource] searchMessages: %@ (%d). Done in %.3fms - Got %tu / %tu messages", _searchText, _containsURL, [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomEventResults.results.count, roomEventResults.count);
+        NSLog(@"[MXKSearchDataSource] searchMessages: %@ (%d). Done in %.3fms - Got %tu / %tu messages", _searchText, _mediaFilter, [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomEventResults.results.count, roomEventResults.count);
 
         searchRequest = nil;
         _serverCount = roomEventResults.count;

--- a/MatrixKit/Models/Search/MXKSearchDataSource.m
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.m
@@ -50,18 +50,10 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
 
         // Set default MXEvent -> NSString formatter
         _eventFormatter = [[MXKEventFormatter alloc] initWithMatrixSession:mxSession];
+        
+        _roomEventFilter = [[MXRoomEventFilter alloc] init];
 
         cellDataArray = [NSMutableArray array];
-    }
-    return self;
-}
-
-- (instancetype)initWithRoomId:(NSString *)roomId andMatrixSession:(MXSession *)mxSession
-{
-    self = [self initWithMatrixSession:mxSession];
-    if (self)
-    {
-        _roomId = roomId;
     }
     return self;
 }
@@ -70,6 +62,8 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
 {
     cellDataArray = nil;
     _eventFormatter = nil;
+    
+    _roomEventFilter = nil;
     
     [super destroy];
 }
@@ -169,18 +163,11 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
         return;
     }
 
-    // Search in one room?
-    NSArray *rooms;
-    if (_roomId)
-    {
-        rooms = @[_roomId];
-    }
-
     NSDate *startDate = [NSDate date];
 
-    searchRequest = [self.mxSession.matrixRestClient searchMessagesWithText:_searchText inRooms:rooms beforeLimit:0 afterLimit:0 nextBatch:nextBatch mediaFilter:_mediaFilter success:^(MXSearchRoomEventResults *roomEventResults) {
+    searchRequest = [self.mxSession.matrixRestClient searchMessagesWithText:_searchText roomEventFilter:_roomEventFilter beforeLimit:0 afterLimit:0 nextBatch:nextBatch success:^(MXSearchRoomEventResults *roomEventResults) {
 
-        NSLog(@"[MXKSearchDataSource] searchMessages: %@ (%d). Done in %.3fms - Got %tu / %tu messages", _searchText, _mediaFilter, [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomEventResults.results.count, roomEventResults.count);
+        NSLog(@"[MXKSearchDataSource] searchMessages: %@ (%d). Done in %.3fms - Got %tu / %tu messages", _searchText, _roomEventFilter.containsURL, [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomEventResults.results.count, roomEventResults.count);
 
         searchRequest = nil;
         _serverCount = roomEventResults.count;


### PR DESCRIPTION
…file index for a room.

vector-im/vector-ios#652

MXRestClient: Support 3 filtering modes on attachments during the messages search (see `MXMessagesSearchMediaFilter`):
- Default value. No limitation.
- Only the messages which contain an URL are concerned by the search request.
- The messages which contain an URL are not concerned by the search request.