### PR TITLE
Feature - Converting existing rooms to/from DMs

### DIFF
--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -396,6 +396,7 @@
                                               invite:@[_mxRoomMember.userId]
                                           invite3PID:nil
                                             isDirect:YES
+                                              preset:kMXRoomPresetTrustedPrivateChat
                                              success:^(MXRoom *room) {
                                                  
                                                  // Delay the call in order to be sure that the room is ready

--- a/MatrixKit/Views/MXKRoomCreationView.m
+++ b/MatrixKit/Views/MXKRoomCreationView.m
@@ -496,16 +496,33 @@
             
             // Check whether some users must be invited
             NSArray *invitedUsers = self.participantsList;
-            BOOL isDirect = ((invitedUsers.count == 1) ? YES : NO);
+            
+            // Prepare room settings
+            MXRoomDirectoryVisibility visibility;
+            BOOL isDirect = NO;
+            
+            if (_roomVisibilityControl.selectedSegmentIndex == 0)
+            {
+                visibility = kMXRoomDirectoryVisibilityPublic;
+            }
+            else
+            {
+                visibility = kMXRoomDirectoryVisibilityPrivate;
+                isDirect = (invitedUsers.count == 1);
+            }
+            
+            // Ensure direct chat are created with equal ops on both sides (the trusted_private_chat preset)
+            MXRoomPreset preset = (isDirect ? kMXRoomPresetTrustedPrivateChat : nil);
             
             // Create new room
             [selectedSession createRoom:roomName
-                             visibility:(_roomVisibilityControl.selectedSegmentIndex == 0) ? kMXRoomDirectoryVisibilityPublic : kMXRoomDirectoryVisibilityPrivate
+                             visibility:visibility
                               roomAlias:self.alias
                                   topic:nil
                                  invite:invitedUsers
                              invite3PID:nil
                                isDirect:isDirect
+                                 preset:preset
                                 success:^(MXRoom *room) {
                                     
                                     // Reset text fields


### PR DESCRIPTION
vector-im/vector-ios#715

Ensure 1:1 rooms are created with equal ops on both sides (the trusted_private_chat preset)