### PR TITLE
Converting existing rooms to/from DMs

### DIFF
--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -378,9 +378,7 @@
                 {
                     [self addPendingActionMask];
                     
-                    NSString *directRoomId = self.mainSession.directRooms[_mxRoomMember.userId].firstObject;
-                    
-                    MXRoom* directRoom = [self.mainSession roomWithRoomId:directRoomId];
+                    MXRoom* directRoom = [self.mainSession directJoinedRoomWithUserId:_mxRoomMember.userId];
                     
                     // Place the call directly if the room exists
                     if (directRoom)
@@ -682,8 +680,8 @@
         
         // offer to start a new chat only if the room is not the first direct chat with this user
         // it does not make sense : it would open the same room
-        NSString* directRoomId = self.mainSession.directRooms[_mxRoomMember.userId].firstObject;
-        if (!directRoomId || (![directRoomId isEqualToString:mxRoom.state.roomId]))
+        MXRoom* directRoom = [self.mainSession directJoinedRoomWithUserId:_mxRoomMember.userId];
+        if (!directRoom || (![directRoom.roomId isEqualToString:mxRoom.state.roomId]))
         {
             [actionsArray addObject:@(MXKRoomMemberDetailsActionStartChat)];
         }

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -378,12 +378,14 @@
                 {
                     [self addPendingActionMask];
                     
-                    MXRoom* oneToOneRoom = [self.mainSession privateOneToOneRoomWithUserId:_mxRoomMember.userId];
+                    NSString *directRoomId = self.mainSession.directRooms[_mxRoomMember.userId].firstObject;
+                    
+                    MXRoom* directRoom = [self.mainSession roomWithRoomId:directRoomId];
                     
                     // Place the call directly if the room exists
-                    if (oneToOneRoom)
+                    if (directRoom)
                     {
-                        [oneToOneRoom placeCallWithVideo:isVideoCall success:nil failure:nil];
+                        [directRoom placeCallWithVideo:isVideoCall success:nil failure:nil];
                         [self removePendingActionMask];
                     }
                     else
@@ -678,10 +680,10 @@
             [actionsArray addObject:@(MXKRoomMemberDetailsActionSetCustomPowerLevel)];
         }
         
-        // offer to start a new chat only if the room is not a 1:1 room with this user
+        // offer to start a new chat only if the room is not the first direct chat with this user
         // it does not make sense : it would open the same room
-        MXRoom* room = [self.mainSession privateOneToOneRoomWithUserId:_mxRoomMember.userId];
-        if (!room || (![room.state.roomId isEqualToString:mxRoom.state.roomId]))
+        NSString* directRoomId = self.mainSession.directRooms[_mxRoomMember.userId].firstObject;
+        if (!directRoomId || (![directRoomId isEqualToString:mxRoom.state.roomId]))
         {
             [actionsArray addObject:@(MXKRoomMemberDetailsActionStartChat)];
         }

--- a/MatrixKit/Models/Contact/MXKContactManager.h
+++ b/MatrixKit/Models/Contact/MXKContactManager.h
@@ -66,7 +66,7 @@ extern NSString *const kMXKContactManagerDidInternationalizeNotification;
  */
 typedef NS_ENUM(NSInteger, MXKContactManagerMXRoomSource) {
     MXKContactManagerMXRoomSourceNone        = 0,   // the MXMember does not create any new contact.
-    MXKContactManagerMXRoomSourceOneToOne    = 1,   // the 1:1 room members have their own contact even if they are not defined in the device contacts book
+    MXKContactManagerMXRoomSourceOneToOne    = 1,   // the direct chat users have their own contact even if they are not defined in the device contacts book
     MXKContactManagerMXRoomSourceAll         = 2,   // all the room members have their own contact even if they are not defined in the device contacts book
 };
 
@@ -121,9 +121,9 @@ typedef NS_ENUM(NSInteger, MXKContactManagerMXRoomSource) {
 @property (nonatomic, readonly) NSArray *localEmailContacts;
 
 /**
- The current list of the contacts for whom a 1:1 room exists.
+ The current list of the contacts for whom a direct chat exists.
  */
-@property (nonatomic, readonly) NSArray *oneToOneMatrixContacts;
+@property (nonatomic, readonly) NSArray *directMatrixContacts;
 
 /**
  List the contacts who share at least a private room with the current user of the provided matrix session.

--- a/MatrixKit/Models/Contact/MXKContactManager.h
+++ b/MatrixKit/Models/Contact/MXKContactManager.h
@@ -66,7 +66,7 @@ extern NSString *const kMXKContactManagerDidInternationalizeNotification;
  */
 typedef NS_ENUM(NSInteger, MXKContactManagerMXRoomSource) {
     MXKContactManagerMXRoomSourceNone        = 0,   // the MXMember does not create any new contact.
-    MXKContactManagerMXRoomSourceOneToOne    = 1,   // the direct chat users have their own contact even if they are not defined in the device contacts book
+    MXKContactManagerMXRoomSourceDirectChats = 1,   // the direct chat users have their own contact even if they are not defined in the device contacts book
     MXKContactManagerMXRoomSourceAll         = 2,   // all the room members have their own contact even if they are not defined in the device contacts book
 };
 
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSInteger, MXKContactManagerMXRoomSource) {
 
 /**
  Define if the room member must have their dedicated contact even if they are not define in the device contacts book.
- The default value is MXKContactManagerMXRoomSourceOneToOne;
+ The default value is MXKContactManagerMXRoomSourceDirectChats;
  */
 @property (nonatomic) MXKContactManagerMXRoomSource contactManagerMXRoomSource;
 

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -108,7 +108,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
         // to avoid resync the whole phonebook
         lastSyncDate = nil;
         
-        self.contactManagerMXRoomSource = MXKContactManagerMXRoomSourceOneToOne;
+        self.contactManagerMXRoomSource = MXKContactManagerMXRoomSourceDirectChats;
         
         // Observe related settings change
         [[MXKAppSettings standardAppSettings]  addObserver:self forKeyPath:@"syncLocalContacts" options:0 context:nil];
@@ -219,7 +219,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
                     
                     // Consider only 1:1 chat for MXKMemberContactCreationOneToOneRoom
                     // or adding all
-                    if (((roomMembers.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
+                    if (((roomMembers.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
                     {
                         NSString* myUserId = room.mxSession.myUser.userId;
                         
@@ -1012,7 +1012,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
                 // Check whether this user has already been added
                 if (![updatedMatrixContactByMatrixID objectForKey:user.userId])
                 {
-                    if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && mxSession.directRooms[user.userId]))
+                    if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats) && mxSession.directRooms[user.userId]))
                     {
                         // Check whether a contact is already defined for this id in previous dictionary
                         // (avoid delete and create the same ones, it could save thumbnail downloads).
@@ -1052,7 +1052,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
     NSArray *mxSessions = self.mxSessions;
     for (MXSession *mxSession in mxSessions)
     {
-        if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && mxSession.directRooms[matrixId]))
+        if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats) && mxSession.directRooms[matrixId]))
         {
             // Retrieve the user object related to this contact
             MXUser* user = [mxSession userWithUserId:matrixId];

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -366,16 +366,16 @@ static MXKContactManager* sharedMXKContactManager = nil;
     return localEmailContacts;
 }
 
-- (NSArray*)oneToOneMatrixContacts
+- (NSArray*)directMatrixContacts
 {
-    NSMutableDictionary *oneToOneContacts = [NSMutableDictionary dictionary];
+    NSMutableDictionary *directContacts = [NSMutableDictionary dictionary];
     
     NSArray *mxSessions = self.mxSessions;
     
     for (MXSession *mxSession in mxSessions)
     {
-        // Check all existing users for whom a 1:1 room exists
-        NSArray *mxUserIds = mxSession.privateOneToOneUsers;
+        // Check all existing users for whom a direct chat exists
+        NSArray *mxUserIds = mxSession.directRooms.allKeys;
         
         for (NSString *mxUserId in mxUserIds)
         {
@@ -384,12 +384,12 @@ static MXKContactManager* sharedMXKContactManager = nil;
             // Sanity check - the contact must be already defined here
             if (contact)
             {
-                [oneToOneContacts setValue:contact forKey:mxUserId];
+                [directContacts setValue:contact forKey:mxUserId];
             }
         }
     }
     
-    return oneToOneContacts.allValues;
+    return directContacts.allValues;
 }
 
 - (NSArray*)privateMatrixContacts:(MXSession *)mxSession
@@ -1012,7 +1012,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
                 // Check whether this user has already been added
                 if (![updatedMatrixContactByMatrixID objectForKey:user.userId])
                 {
-                    if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && [mxSession privateOneToOneRoomWithUserId:user.userId]))
+                    if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && mxSession.directRooms[user.userId]))
                     {
                         // Check whether a contact is already defined for this id in previous dictionary
                         // (avoid delete and create the same ones, it could save thumbnail downloads).
@@ -1052,7 +1052,7 @@ static MXKContactManager* sharedMXKContactManager = nil;
     NSArray *mxSessions = self.mxSessions;
     for (MXSession *mxSession in mxSessions)
     {
-        if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && [mxSession privateOneToOneRoomWithUserId:matrixId]))
+        if ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll) || ((self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceOneToOne) && mxSession.directRooms[matrixId]))
         {
             // Retrieve the user object related to this contact
             MXUser* user = [mxSession userWithUserId:matrixId];


### PR DESCRIPTION
vector-im/vector-ios#715

Apply MatrixSDK changes (https://github.com/matrix-org/matrix-ios-sdk/pull/158): Remove privateOneToOneRoomWithUserId: and privateOneToOneUsers (the developer must use the directRooms property instread).