### PR TITLE
Support for encrypting attachments

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -27,6 +27,8 @@
 
 #import "NSData+MatrixKit.h"
 
+#import "MXEncryptedAttachments.h"
+
 #pragma mark - Constant definitions
 
 NSString *const kMXKRoomBubbleCellDataIdentifier = @"kMXKRoomBubbleCellDataIdentifier";
@@ -1378,13 +1380,27 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                  };
     MXEvent *localEcho = [self addLocalEchoForMessageContent:msgContent withState:MXKEventStateUploading];
     
+    if (self.mxSession.crypto && self.room.state.isEncrypted) {
+        [MXEncryptedAttachments encryptAttachment:uploader mimeType:mimetype localUrl:imageLocalURL success:^(NSDictionary *result) {
+            NSMutableDictionary *msgContentToSend = [NSMutableDictionary dictionaryWithDictionary:msgContent];
+            [msgContentToSend removeObjectForKey:@"url"];
+            msgContentToSend[@"file"] = result;
+            // TODO: We should update the local echo event with the actual event once we can decrypt attachments too.
+            [self sendRawImageContent:msgContentToSend localEcho:localEcho success:success failure:failure];
+        } failure:^(NSError *error) {
+            localEcho.mxkState = MXKEventStateSendingFailed;
+            [self updateLocalEcho:localEcho];
+            
+            if (failure)
+            {
+                failure(error);
+            }
+        }];
+        return;
+    }
+    
     // Launch the upload to the Matrix Content repository
     [uploader uploadData:imageData filename:filename mimeType:mimetype success:^(NSString *url) {
-        
-        // Update the local echo state: move from content uploading to event sending
-        localEcho.mxkState = MXKEventStateSending;
-        [self updateLocalEcho:localEcho];
-        
         // Copy the cached file to the actual cacheFile path
         NSString *absoluteURL = [self.mxSession.matrixRestClient urlOfContent:url];
         NSString *actualCacheFilePath = [MXKMediaManager cachePathForMediaWithURL:absoluteURL andType:mimetype inFolder:self.roomId];
@@ -1400,31 +1416,40 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         [_room updateOutgoingMessage:localEcho.eventId withOutgoingMessage:localEcho];
 
         // Make the final request that posts the image event
-        [_room sendMessageOfType:kMXMessageTypeImage content:msgContent2 success:^(NSString *eventId) {
-            
-            // Update the local echo with its actual identifier. The echo will be removed when the corresponding event will come through the server sync.
-            // We keep this event here as local echo to handle correctly outgoing messages from multiple devices.
-            MXEvent *updatedLocalEcho = [_eventFormatter fakeRoomMessageEventForRoomId:_roomId withEventId:eventId andContent:localEcho.content];
-            [self.room updateOutgoingMessage:localEcho.eventId withOutgoingMessage:updatedLocalEcho];
-            // Replace the local echo by the new one
-            [self replaceLocalEcho:localEcho withEvent:updatedLocalEcho];
-            
-            if (success)
-            {
-                success(eventId);
-            }
-            
-        } failure:^(NSError *error) {
-            
-            // Update the local echo with the error state
-            localEcho.mxkState = MXKEventStateSendingFailed;
-            [self updateLocalEcho:localEcho];
-            
-            if (failure)
-            {
-                failure(error);
-            }
-        }];
+        [self sendRawImageContent:msgContent2 localEcho:localEcho success:success failure:failure];
+        
+    } failure:^(NSError *error) {
+        // Update the local echo with the error state
+        localEcho.mxkState = MXKEventStateSendingFailed;
+        [self updateLocalEcho:localEcho];
+        
+        if (failure)
+        {
+            failure(error);
+        }
+    }];
+}
+
+- (void)sendRawImageContent:(NSDictionary *)content
+                  localEcho:(MXEvent *)localEcho
+                    success:(void (^)(NSString *))success
+                    failure:(void (^)(NSError *))failure {
+    // Update the local echo state: move from content uploading to event sending
+    localEcho.mxkState = MXKEventStateSending;
+    [self updateLocalEcho:localEcho];
+    
+    [_room sendMessageOfType:kMXMessageTypeImage content:content success:^(NSString *eventId) {
+        // Update the local echo with its actual identifier. The echo will be removed when the corresponding event will come through the server sync.
+        // We keep this event here as local echo to handle correctly outgoing messages from multiple devices.
+        MXEvent *updatedLocalEcho = [_eventFormatter fakeRoomMessageEventForRoomId:_roomId withEventId:eventId andContent:localEcho.content];
+        [self.room updateOutgoingMessage:localEcho.eventId withOutgoingMessage:updatedLocalEcho];
+        // Replace the local echo by the new one
+        [self replaceLocalEcho:localEcho withEvent:updatedLocalEcho];
+        
+        if (success)
+        {
+            success(eventId);
+        }
         
     } failure:^(NSError *error) {
         // Update the local echo with the error state

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1248,11 +1248,14 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     NSString *mimetype = @"image/jpeg";
     NSData *imageData = UIImageJPEGRepresentation(image, 0.9);
     
+    double endRange = 1.0;
+    if (self.mxSession.crypto && self.room.state.isEncrypted) endRange = 0.9;
+    
     // Use the uploader id as fake URL for this image data
     // The URL does not need to be valid as the MediaManager will get the data
     // directly from its cache
     // Pass this id in the URL is a nasty trick to retrieve it later
-    MXKMediaLoader *uploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:1];
+    MXKMediaLoader *uploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:endRange];
     NSString *fakeMediaManagerURL = uploader.uploadId;
     
     NSString *cacheFilePath = [MXKMediaManager cachePathForMediaWithURL:fakeMediaManagerURL andType:mimetype inFolder:self.roomId];
@@ -1280,6 +1283,41 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                          }
                                  };
     MXEvent *localEcho = [self addLocalEchoForMessageContent:msgContent withState:MXKEventStateUploading];
+    
+    void(^onFailure)(NSError *) = ^(NSError *error) {
+        localEcho.mxkState = MXKEventStateSendingFailed;
+        [self updateLocalEcho:localEcho];
+        
+        if (failure) {
+            failure(error);
+        }
+    };
+    
+    if (self.mxSession.crypto && self.room.state.isEncrypted) {
+        [MXEncryptedAttachments encryptAttachment:uploader mimeType:mimetype data:imageData success:^(NSDictionary *result) {
+            NSMutableDictionary *msgContentToSend = [NSMutableDictionary dictionaryWithDictionary:msgContent];
+            [msgContentToSend removeObjectForKey:@"url"];
+            msgContentToSend[@"file"] = result;
+            
+            // TODO: We should update the local echo event with the actual event once we can decrypt attachments too.
+            
+            void(^doUpload)() = ^{
+                [self sendContentMessage:msgContentToSend localEcho:localEcho success:success failure:failure];
+            };
+            
+            UIImage *thumbnail = [MXKTools reduceImage:image toFitInSize:CGSizeMake(800, 600)];
+            if (thumbnail == image) {
+                doUpload();
+            } else {
+                MXKMediaLoader *thumbUploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0.9 andRange:1];
+                [MXEncryptedAttachments encryptAttachment:thumbUploader mimeType:@"image/png" data:UIImagePNGRepresentation(thumbnail) success:^(NSDictionary *result) {
+                    msgContentToSend[@"thumbnail_file"] = result;
+                    doUpload();
+                } failure:onFailure];
+            }
+        } failure:onFailure];
+        return;
+    }
     
     // Launch the upload to the Matrix Content repository
     [uploader uploadData:imageData filename:filename mimeType:mimetype success:^(NSString *url) {
@@ -1346,11 +1384,14 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     NSData *imageData = [NSData dataWithContentsOfFile:imageLocalURL.path];
     UIImage *image = [UIImage imageWithData:imageData];
     
+    double endRange = 1.0;
+    if (self.mxSession.crypto && self.room.state.isEncrypted) endRange = 0.9;
+    
     // Use the uploader id as fake URL for this image data
     // The URL does not need to be valid as the MediaManager will get the data
     // directly from its cache
     // Pass this id in the URL is a nasty trick to retrieve it later
-    MXKMediaLoader *uploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:1];
+    MXKMediaLoader *uploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:0.9];
     NSString *fakeMediaManagerURL = uploader.uploadId;
     
     NSString *cacheFilePath = [MXKMediaManager cachePathForMediaWithURL:fakeMediaManagerURL andType:mimetype inFolder:self.roomId];
@@ -1398,14 +1439,15 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
             // TODO: We should update the local echo event with the actual event once we can decrypt attachments too.
             
             void(^doUpload)() = ^{
-                [self sendRawImageContent:msgContentToSend localEcho:localEcho success:success failure:failure];
+                [self sendContentMessage:msgContentToSend localEcho:localEcho success:success failure:failure];
             };
             
             UIImage *thumbnail = [MXKTools reduceImage:image toFitInSize:CGSizeMake(800, 600)];
             if (thumbnail == image) {
                 doUpload();
             } else {
-                [MXEncryptedAttachments encryptAttachment:uploader mimeType:@"image/png" data:UIImagePNGRepresentation(thumbnail) success:^(NSDictionary *result) {
+                MXKMediaLoader *thumbUploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0.9 andRange:1];
+                [MXEncryptedAttachments encryptAttachment:thumbUploader mimeType:@"image/png" data:UIImagePNGRepresentation(thumbnail) success:^(NSDictionary *result) {
                     msgContentToSend[@"thumbnail_file"] = result;
                     doUpload();
                 } failure:onFailure];
@@ -1431,7 +1473,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         [_room updateOutgoingMessage:localEcho.eventId withOutgoingMessage:localEcho];
 
         // Make the final request that posts the image event
-        [self sendRawImageContent:msgContent2 localEcho:localEcho success:success failure:failure];
+        [self sendContentMessage:msgContent2 localEcho:localEcho success:success failure:failure];
         
     } failure:^(NSError *error) {
         // Update the local echo with the error state
@@ -1445,7 +1487,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }];
 }
 
-- (void)sendRawImageContent:(NSDictionary *)content
+- (void)sendContentMessage:(NSDictionary *)content
                   localEcho:(MXEvent *)localEcho
                     success:(void (^)(NSString *))success
                     failure:(void (^)(NSError *))failure {
@@ -1486,8 +1528,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     // The URL does not need to be valid as the MediaManager will get the data
     // directly from its cache
     // Pass this id in the URL is a nasty trick to retrieve it later
-    MXKMediaLoader *uploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:0.1];
-    NSString *fakeMediaManagerThumbnailURL = uploader.uploadId;
+    MXKMediaLoader *thumbUploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0 andRange:0.1];
+    NSString *fakeMediaManagerThumbnailURL = thumbUploader.uploadId;
     
     NSString *cacheFilePath = [MXKMediaManager cachePathForMediaWithURL:fakeMediaManagerThumbnailURL andType:@"image/jpeg" inFolder:self.roomId];
     [MXKMediaManager writeMediaData:videoThumbnailData toFilePath:cacheFilePath];
@@ -1509,14 +1551,60 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                          } mutableCopy];
     MXEvent *localEcho = [self addLocalEchoForMessageContent:msgContent withState:MXKEventStateUploading];
     
+    void(^onFailure)(NSError *) = ^(NSError *error) {
+        localEcho.mxkState = MXKEventStateSendingFailed;
+        [self updateLocalEcho:localEcho];
+        
+        if (failure) {
+            failure(error);
+        }
+    };
+    
     // Before sending data to the server, convert the video to MP4
-    [MXKTools convertVideoToMP4:videoLocalURL success:^(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
+    [MXKTools convertVideoToMP4:videoLocalURL success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
+        if (![[NSFileManager defaultManager] fileExistsAtPath:convertedLocalURL.path]) {
+            failure(nil);
+            return;
+        }
+        // update metadata with result of converter output
+        msgContent[@"info"][@"mimetype"] = mimetype;
+        msgContent[@"info"][@"w"] = @(size.width);
+        msgContent[@"info"][@"h"] = @(size.height);
+        msgContent[@"info"][@"duration"] = @(durationInMs);
+        
+        if (self.mxSession.crypto && self.room.state.isEncrypted) {
+            [MXEncryptedAttachments encryptAttachment:thumbUploader mimeType:mimetype data:videoThumbnailData success:^(NSDictionary *result) {
+                NSMutableDictionary *msgContentToSend = [NSMutableDictionary dictionaryWithDictionary:msgContent];
+                msgContentToSend[@"thumbnail_file"] = result;
+                [msgContent[@"info"] removeObjectForKey:@"thumbnail_url"];
+                
+                // TODO: We should update the local echo event with the actual event once we can decrypt attachments too.
+                
+                MXKMediaLoader *videoUploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0.1 andRange:1];
+                
+                // Self-proclaimed, "nasty trick" cargoculted from below...
+                // Apply the nasty trick again so that the cell can monitor the upload progress
+                msgContent[@"url"] = videoUploader.uploadId;
+                localEcho.wireContent = msgContent;
+                [_room updateOutgoingMessage:localEcho.eventId withOutgoingMessage:localEcho];
+                [self updateLocalEcho:localEcho];
+                
+                [MXEncryptedAttachments encryptAttachment:videoUploader mimeType:mimetype localUrl:convertedLocalURL success:^(NSDictionary *result) {
+                    [msgContentToSend removeObjectForKey:@"url"];
+                    msgContentToSend[@"file"] = result;
+                    
+                    [self sendContentMessage:msgContentToSend localEcho:localEcho success:success failure:failure];
+                } failure:onFailure];
+            } failure:onFailure];
+            return;
+        }
+        
         
         // Upload thumbnail
-        [uploader uploadData:videoThumbnailData filename:nil mimeType:@"image/jpeg" success:^(NSString *thumbnailUrl) {
+        [thumbUploader uploadData:videoThumbnailData filename:nil mimeType:@"image/jpeg" success:^(NSString *thumbnailUrl) {
             
             // Upload video
-            NSData* videoData = [NSData dataWithContentsOfFile:videoLocalURL.path];
+            NSData* videoData = [NSData dataWithContentsOfFile:convertedLocalURL.path];
             if (videoData)
             {  
                 MXKMediaLoader *videoUploader = [MXKMediaManager prepareUploaderWithMatrixSession:self.mxSession initialRange:0.1 andRange:0.9];
@@ -1549,12 +1637,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     NSString *cacheFilePath = [MXKMediaManager cachePathForMediaWithURL:absoluteURL andType:mimetype inFolder:self.roomId];
                     [MXKMediaManager writeMediaData:videoData toFilePath:cacheFilePath];
                     
-                    // Finalise msgContent
+                    // Update URLs with the actual mxc: URLs
                     msgContent[@"url"] = videoUrl;
-                    msgContent[@"info"][@"mimetype"] = mimetype;
-                    msgContent[@"info"][@"w"] = @(size.width);
-                    msgContent[@"info"][@"h"] = @(size.height);
-                    msgContent[@"info"][@"duration"] = @(durationInMs);
                     msgContent[@"info"][@"thumbnail_url"] = thumbnailUrl;
                     
                     localEcho.wireContent = msgContent;
@@ -1673,6 +1757,28 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                          }
                                  };
     MXEvent *localEcho = [self addLocalEchoForMessageContent:msgContent withState:MXKEventStateUploading];
+    
+    void(^onFailure)(NSError *) = ^(NSError *error) {
+        localEcho.mxkState = MXKEventStateSendingFailed;
+        [self updateLocalEcho:localEcho];
+        
+        if (failure) {
+            failure(error);
+        }
+    };
+    
+    if (self.mxSession.crypto && self.room.state.isEncrypted) {
+        [MXEncryptedAttachments encryptAttachment:uploader mimeType:mimetype localUrl:fileLocalURL success:^(NSDictionary *result) {
+            NSMutableDictionary *msgContentToSend = [NSMutableDictionary dictionaryWithDictionary:msgContent];
+            [msgContentToSend removeObjectForKey:@"url"];
+            msgContentToSend[@"file"] = result;
+            
+            // TODO: We should update the local echo event with the actual event once we can decrypt attachments too.
+            
+            [self sendContentMessage:msgContentToSend localEcho:localEcho success:success failure:failure];
+        } failure:onFailure];
+        return;
+    }
     
     // Launch the upload to the Matrix Content repository
     [uploader uploadData:fileData filename:filename mimeType:mimetype success:^(NSString *url) {


### PR DESCRIPTION
Use the classes in https://github.com/matrix-org/matrix-ios-sdk/pull/164 to encrypt attachments. Also generate client-side thumbnails for encrypted attachments.