### PR TITLE
Switch to e2e attachments spec v1

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		32CEE22B1AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2271AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m */; };
 		32CEE22C1AB1EC9B00F7C74D /* MXKRecentCellData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2291AB1EC9B00F7C74D /* MXKRecentCellData.m */; };
 		32CEE2301AB1EE0900F7C74D /* MXKRecentTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE22F1AB1EE0900F7C74D /* MXKRecentTableViewCell.m */; };
+		550A36BD1DE484DB005C1647 /* EncryptedAttachmentsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */; };
 		71352D551C0ED240001D50B0 /* MXKRoomSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71352D531C0ED240001D50B0 /* MXKRoomSettingsViewController.m */; };
 		71352D561C0ED240001D50B0 /* MXKRoomSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71352D541C0ED240001D50B0 /* MXKRoomSettingsViewController.xib */; };
 		71352D691C1588BE001D50B0 /* MXKTableViewCellWithLabelAndMXKImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71352D671C1588BE001D50B0 /* MXKTableViewCellWithLabelAndMXKImageView.m */; };
@@ -257,6 +258,7 @@
 		32CEE22E1AB1EE0900F7C74D /* MXKRecentTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRecentTableViewCell.h; sourceTree = "<group>"; };
 		32CEE22F1AB1EE0900F7C74D /* MXKRecentTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRecentTableViewCell.m; sourceTree = "<group>"; };
 		392A579537BBF28A9436C420 /* Pods-MatrixKitSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSample/Pods-MatrixKitSample.release.xcconfig"; sourceTree = "<group>"; };
+		550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncryptedAttachmentsTest.m; sourceTree = "<group>"; };
 		665BACA3D253B4407B1C4FD7 /* libPods-MatrixKitSample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixKitSample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71352D521C0ED240001D50B0 /* MXKRoomSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomSettingsViewController.h; sourceTree = "<group>"; };
 		71352D531C0ED240001D50B0 /* MXKRoomSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomSettingsViewController.m; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 			children = (
 				32538D071D2EA100009FE744 /* MXKEventFormatterTests.m */,
 				3203F26C1D2E9CAE0021F170 /* Info.plist */,
+				550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */,
 			);
 			path = MatrixKitTests;
 			sourceTree = "<group>";
@@ -1399,6 +1402,7 @@
 				32952C621D5B2D190039DC0C /* MXKAlert.m in Sources */,
 				F07B9C2B1D3587D3000CB20E /* MXKAppSettings.m in Sources */,
 				F07B9C2A1D3587B0000CB20E /* MXKEventFormatter.m in Sources */,
+				550A36BD1DE484DB005C1647 /* EncryptedAttachmentsTest.m in Sources */,
 				F07B9C2C1D3587E5000CB20E /* MXKTools.m in Sources */,
 				32538D081D2EA100009FE744 /* MXKEventFormatterTests.m in Sources */,
 			);

--- a/MatrixKit/Models/Room/MXEncryptedAttachments.h
+++ b/MatrixKit/Models/Room/MXEncryptedAttachments.h
@@ -92,4 +92,6 @@ extern NSString *const MXEncryptedAttachmentsErrorDomain;
               inputStream:(NSInputStream *)inputStream
              outputStream:(NSOutputStream *)outputStream;
 
++ (NSString *)padBase64:(NSString *)unpadded;
+
 @end

--- a/MatrixKit/Models/Room/MXEncryptedAttachments.m
+++ b/MatrixKit/Models/Room/MXEncryptedAttachments.m
@@ -137,6 +137,7 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXKEncryptedAttachmentsErr
     
     [uploader uploadData:ciphertext filename:nil mimeType:@"application/octet-stream" success:^(NSString *url) {
         success(@{
+                  @"v": @"v1",
                   @"url": url,
                   @"mimetype": mimeType,
                   @"key": @{
@@ -161,27 +162,27 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXKEncryptedAttachmentsErr
 + (NSError *)decryptAttachment:(NSDictionary *)fileInfo
               inputStream:(NSInputStream *)inputStream
              outputStream:(NSOutputStream *)outputStream {
-    if (!fileInfo[@"key"])
+    if (!fileInfo[@"key"] || ![fileInfo[@"key"] isKindOfClass:[NSDictionary class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_key"}];
     }
-    if (![fileInfo[@"key"][@"alg"] isEqualToString:@"A256CTR"])
+    if (![fileInfo[@"key"][@"alg"] isKindOfClass:[NSString class]] || ![fileInfo[@"key"][@"alg"] isEqualToString:@"A256CTR"])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_or_incorrect_key_alg"}];
     }
-    if (!fileInfo[@"key"][@"k"])
+    if (!fileInfo[@"key"][@"k"] || ![fileInfo[@"key"][@"k"] isKindOfClass:[NSString class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_key_data"}];
     }
-    if (!fileInfo[@"iv"])
+    if (!fileInfo[@"iv"] || ![fileInfo[@"iv"] isKindOfClass:[NSString class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_iv"}];
     }
-    if (!fileInfo[@"hashes"])
+    if (!fileInfo[@"hashes"] || ![fileInfo[@"hashes"] isKindOfClass:[NSDictionary class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_hashes"}];
     }
-    if (!fileInfo[@"hashes"][@"sha256"])
+    if (![fileInfo[@"hashes"][@"sha256"] isKindOfClass:[NSString class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_sha256_hash"}];
     }
@@ -274,7 +275,7 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXKEncryptedAttachmentsErr
 + (NSString *)padBase64:(NSString *)unpadded {
     NSString *ret = unpadded;
     
-    while (ret.length % 3) {
+    while (ret.length % 4) {
         ret = [ret stringByAppendingString:@"="];
     }
     return ret;

--- a/MatrixKit/Models/Room/MXEncryptedAttachments.m
+++ b/MatrixKit/Models/Room/MXEncryptedAttachments.m
@@ -162,6 +162,9 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXKEncryptedAttachmentsErr
 + (NSError *)decryptAttachment:(NSDictionary *)fileInfo
               inputStream:(NSInputStream *)inputStream
              outputStream:(NSOutputStream *)outputStream {
+    // NB. We don;t check the 'v' field here: future versions should be backwards compatible so we try to decode
+    // whatever the version is. We can only really decode v1, but the difference is the IV wraparound so we can try
+    // decoding v0 attachments and the worst that will happen is that it won't work.
     if (!fileInfo[@"key"] || ![fileInfo[@"key"] isKindOfClass:[NSDictionary class]])
     {
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"missing_key"}];

--- a/MatrixKitTests/EncryptedAttachmentsTest.m
+++ b/MatrixKitTests/EncryptedAttachmentsTest.m
@@ -1,0 +1,97 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MXEncryptedAttachments.h"
+
+@interface EncryptedAttachmentsTest : XCTestCase
+
+@end
+
+
+@implementation EncryptedAttachmentsTest
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testDecrypt {
+    NSArray *testVectors =
+        @[
+             @[@"", @{
+                 @"v": @"v1",
+                 @"hashes": @{
+                     @"sha256": @"47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"
+                 },
+                 @"key": @{
+                     @"alg": @"A256CTR",
+                     @"k": @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                     @"key_ops": @[@"encrypt", @"decrypt"],
+                     @"kty": @"oct"
+                 },
+                 @"iv": @"AAAAAAAAAAAAAAAAAAAAAA"
+             }, @""],
+             @[@"nZxRAVw962fwUQ5/", @{
+                 @"v": @"v1",
+                 @"hashes": @{
+                     @"sha256": @"geLWS2ptBew5aPLJRTK+QnI3Krdl3UaxN8qfahHWhfc"
+                 }, @"key": @{
+                     @"alg": @"A256CTR",
+                     @"k": @"__________________________________________8",
+                     @"key_ops": @[@"encrypt", @"decrypt"],
+                     @"kty": @"oct"
+                 }, @"iv": @"/////////////////////w"
+             }, @"SGVsbG8sIFdvcmxk"],
+             @[@"tJVNBVJ/vl36UQt4Y5e5m84bRUrQHhcdLPvS/7EkDvlkDLZXamBB6k8THbiawiKZ5Mnq9PZMSSbgOCvmnUBOMA", @{
+                @"v": @"v1",
+                @"hashes": @{
+                        @"sha256": @"LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
+                        },
+                @"key": @{
+                        @"kty": @"oct",
+                        @"key_ops": @[@"encrypt",@"decrypt"],
+                        @"k": @"__________________________________________8",
+                        @"alg": @"A256CTR"
+                        },
+                @"iv": @"/////////////////////w"
+                }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
+     ];
+    
+    for (NSArray *vector in testVectors) {
+        NSString *inputCiphertext = vector[0];
+        NSDictionary *inputInfo = vector[1];
+        NSString *want = vector[2];
+        
+        NSData *ctData = [[NSData alloc] initWithBase64EncodedString:[MXEncryptedAttachments padBase64:inputCiphertext] options:0];
+        NSInputStream *inputStream = [NSInputStream inputStreamWithData:ctData];
+        NSOutputStream *outputStream = [NSOutputStream outputStreamToMemory];
+        
+        NSError *err = [MXEncryptedAttachments decryptAttachment:inputInfo inputStream:inputStream outputStream:outputStream];
+        XCTAssertNil(err);
+        NSData *gotData = [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+        
+        NSData *wantData = [[NSData alloc] initWithBase64EncodedString:[MXEncryptedAttachments padBase64:want] options:0];
+        
+        XCTAssertEqualObjects(wantData, gotData, "Decrypted data did not match expectation.");
+    }
+}
+
+@end

--- a/MatrixKitTests/EncryptedAttachmentsTest.m
+++ b/MatrixKitTests/EncryptedAttachmentsTest.m
@@ -49,21 +49,21 @@
                  },
                  @"iv": @"AAAAAAAAAAAAAAAAAAAAAA"
              }, @""],
-             @[@"nZxRAVw962fwUQ5/", @{
+             @[@"5xJZTt5cQicm+9f4", @{
                  @"v": @"v1",
                  @"hashes": @{
-                     @"sha256": @"geLWS2ptBew5aPLJRTK+QnI3Krdl3UaxN8qfahHWhfc"
+                     @"sha256": @"YzF08lARDdOCzJpzuSwsjTNlQc4pHxpdHcXiD/wpK6k"
                  }, @"key": @{
                      @"alg": @"A256CTR",
                      @"k": @"__________________________________________8",
                      @"key_ops": @[@"encrypt", @"decrypt"],
                      @"kty": @"oct"
-                 }, @"iv": @"/////////////////////w"
+                 }, @"iv": @"//////////8AAAAAAAAAAA"
              }, @"SGVsbG8sIFdvcmxk"],
-             @[@"tJVNBVJ/vl36UQt4Y5e5m84bRUrQHhcdLPvS/7EkDvlkDLZXamBB6k8THbiawiKZ5Mnq9PZMSSbgOCvmnUBOMA", @{
-                @"v": @"v1",
+             @[@"zhtFStAeFx0s+9L/sSQO+WQMtldqYEHqTxMduJrCIpnkyer09kxJJuA4K+adQE4w+7jZe/vR9kIcqj9rOhDR8Q", @{
+                @"v": @"v2",
                 @"hashes": @{
-                        @"sha256": @"LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
+                        @"sha256": @"IOq7/dHHB+mfHfxlRY5XMeCWEwTPmlf4cJcgrkf6fVU"
                         },
                 @"key": @{
                         @"kty": @"oct",
@@ -71,8 +71,21 @@
                         @"k": @"__________________________________________8",
                         @"alg": @"A256CTR"
                         },
-                @"iv": @"/////////////////////w"
-                }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
+                @"iv": @"//////////8AAAAAAAAAAA"
+                }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"],
+             @[@"tJVNBVJ/vl36UQt4Y5e5m84bRUrQHhcdLPvS/7EkDvlkDLZXamBB6k8THbiawiKZ5Mnq9PZMSSbgOCvmnUBOMA", @{
+                   @"v": @"v1",
+                   @"hashes": @{
+                           @"sha256": @"LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
+                           },
+                   @"key": @{
+                           @"kty": @"oct",
+                           @"key_ops": @[@"encrypt",@"decrypt"],
+                           @"k": @"__________________________________________8",
+                           @"alg": @"A256CTR"
+                           },
+                   @"iv": @"/////////////////////w"
+                   }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
      ];
     
     for (NSArray *vector in testVectors) {


### PR DESCRIPTION

* v1 uses 64 bits of the IV rather than all 128. It turns out
   commoncrypto does this anyway and has no option to change it,
   so iOS has always done this, so this is basically adding the
   v: "v1" to the attachment info.
 * Add unit test testing the IV wraparound behaviour (this is what
   tests how many bits of the IV we're using)
* Fix base64 padder
 * Check type of things we get out of the attachment dict to avoid
   crashes due to unknown selectors.