### PR TITLE
MXKCallViewController: remove `isPresented` property

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.h
+++ b/MatrixKit/Controllers/MXKCallViewController.h
@@ -105,11 +105,6 @@ extern NSString *const kMXKCallViewControllerBackToAppNotification;
 @property (nonatomic, readonly) MXUser *peer;
 
 /**
- YES when the presentation of the view controller is complete.
- */
-@property (nonatomic) BOOL isPresented;
-
-/**
  The delegate.
  */
 @property (nonatomic, weak) id<MXKCallViewControllerDelegate> delegate;


### PR DESCRIPTION
The developer should use the `isBeingPresented` method and the `presentingViewController` property defined in the `UIViewController` class.

https://github.com/vector-im/vector-ios/issues/764