### PR TITLE
Move Media Loader in Matrix SDK

### DIFF
--- a/MatrixKit/Utils/Media/MXKMediaLoader.h
+++ b/MatrixKit/Utils/Media/MXKMediaLoader.h
@@ -22,10 +22,10 @@
 /**
  Posted to provide download progress.
  The notification object is the media url. The `userInfo` dictionary contains the following keys:
- - kMXKMediaLoaderProgressValueKey: progress value nested in a NSNumber (range 0->1)
- - kMXKMediaLoaderProgressStringKey: progress string XXX KB / XXX MB" (optional)
- - kMXKMediaLoaderProgressRemaingTimeKey: remaining time string "XX s left" (optional)
- - kMXKMediaLoaderProgressRateKey: string like XX MB/s (optional).
+ - kMXKMediaLoaderProgressValueKey: progress value in [0, 1] range (NSNumber object).
+ - kMXKMediaLoaderCompletedBytesCountKey: the number of bytes that have already been completed by the current job (NSNumber object).
+ - kMXKMediaLoaderTotalBytesCountKey: the total number of bytes tracked for the current job (NSNumber object).
+ - kMXKMediaLoaderCurrentDataRateKey: The observed data rate in Bytes/s (NSNumber object).
  */
 extern NSString *const kMXKMediaDownloadProgressNotification;
 
@@ -44,10 +44,10 @@ extern NSString *const kMXKMediaDownloadDidFailNotification;
 /**
  Posted to provide upload progress.
  The notification object is the `uploadId`. The `userInfo` dictionary contains the following keys:
- - kMXKMediaLoaderProgressValueKey: progress value nested in a NSNumber (range 0->1)
- - kMXKMediaLoaderProgressStringKey: progress string XXX KB / XXX MB" (optional)
- - kMXKMediaLoaderProgressRemaingTimeKey: remaining time string "XX s left" (optional)
- - kMXKMediaLoaderProgressRateKey: string like XX MB/s (optional).
+ - kMXKMediaLoaderProgressValueKey: progress value in [0, 1] range (NSNumber object) [The properties `uploadInitialRange` and `uploadRange` are taken into account here].
+ - kMXKMediaLoaderCompletedBytesCountKey: the number of bytes that have already been completed by the current job (NSNumber object).
+ - kMXKMediaLoaderTotalBytesCountKey: the total number of bytes tracked for the current job (NSNumber object).
+ - kMXKMediaLoaderCurrentDataRateKey: The observed data rate in Bytes/s (NSNumber object).
  */
 extern NSString *const kMXKMediaUploadProgressNotification;
 
@@ -67,11 +67,12 @@ extern NSString *const kMXKMediaUploadDidFailNotification;
  Notifications `userInfo` keys
  */
 extern NSString *const kMXKMediaLoaderProgressValueKey;
-extern NSString *const kMXKMediaLoaderProgressStringKey;
-extern NSString *const kMXKMediaLoaderProgressRemaingTimeKey;
-extern NSString *const kMXKMediaLoaderProgressRateKey;
+extern NSString *const kMXKMediaLoaderCompletedBytesCountKey;
+extern NSString *const kMXKMediaLoaderTotalBytesCountKey;
+extern NSString *const kMXKMediaLoaderCurrentDataRateKey;
 extern NSString *const kMXKMediaLoaderFilePathKey;
 extern NSString *const kMXKMediaLoaderErrorKey;
+
 /**
  The callback blocks
  */
@@ -100,8 +101,6 @@ extern NSString *const kMXKMediaUploadIdPrefix;
     
     // Media upload
     MXSession* mxSession;
-    CGFloat initialRange;
-    CGFloat range;
     MXHTTPOperation* operation;
     
     // Statistic info (bitrate, remaining time...)
@@ -122,6 +121,9 @@ extern NSString *const kMXKMediaUploadIdPrefix;
  Default is nil.
  */
 @property (strong, readonly) NSString *uploadId;
+
+@property (readonly) CGFloat uploadInitialRange;
+@property (readonly) CGFloat uploadRange;
 
 /**
  Cancel the operation.

--- a/MatrixKit/Views/MXKImageView.m
+++ b/MatrixKit/Views/MXKImageView.m
@@ -19,6 +19,8 @@
 #import "MXKPieChartView.h"
 #import "MXKAttachment.h"
 
+#import "MXKTools.h"
+
 @interface MXKImageView ()
 {
     NSString *imageURL;
@@ -689,22 +691,29 @@
     
     if (progressInfoLabel)
     {
-        NSString* downloadRate = [downloadStatsDict valueForKey:kMXKMediaLoaderProgressRateKey];
-        NSString* remaingTime = [downloadStatsDict valueForKey:kMXKMediaLoaderProgressRemaingTimeKey];
-        NSString* progressString = [downloadStatsDict valueForKey:kMXKMediaLoaderProgressStringKey];
+        NSNumber* downloadRate = [downloadStatsDict valueForKey:kMXKMediaLoaderCurrentDataRateKey];
+        
+        NSNumber* completedBytesCount = [downloadStatsDict valueForKey:kMXKMediaLoaderCompletedBytesCountKey];
+        NSNumber* totalBytesCount = [downloadStatsDict valueForKey:kMXKMediaLoaderTotalBytesCountKey];
         
         NSMutableString* text = [[NSMutableString alloc] init];
-        
-        [text appendString:progressString];
-        
-        if (remaingTime)
+
+        if (completedBytesCount && totalBytesCount)
         {
-            [text appendFormat:@" (%@)", remaingTime];
+            NSString* progressString = [NSString stringWithFormat:@"%@ / %@", [NSByteCountFormatter stringFromByteCount:completedBytesCount.longLongValue countStyle:NSByteCountFormatterCountStyleFile], [NSByteCountFormatter stringFromByteCount:totalBytesCount.longLongValue countStyle:NSByteCountFormatterCountStyleFile]];
+            
+            [text appendString:progressString];
         }
         
         if (downloadRate)
         {
-            [text appendFormat:@"\n %@", downloadRate];
+            if (completedBytesCount && totalBytesCount)
+            {
+                CGFloat remainimgTime = ((totalBytesCount.floatValue - completedBytesCount.floatValue)) / downloadRate.floatValue;
+                [text appendFormat:@" (%@)", [MXKTools formatSecondsInterval:remainimgTime]];
+            }
+            
+            [text appendFormat:@"\n %@/s", [NSByteCountFormatter stringFromByteCount:downloadRate.longLongValue countStyle:NSByteCountFormatterCountStyleFile]];
         }
         
         progressInfoLabel.text = text;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -18,7 +18,7 @@
 
 #import "NSBundle+MatrixKit.h"
 
-#import "MXRoom.h"
+#import "MXKTools.h"
 
 #pragma mark - Constant definitions
 NSString *const kMXKRoomBubbleCellTapOnMessageTextView = @"kMXKRoomBubbleCellTapOnMessageTextView";
@@ -704,25 +704,29 @@ static BOOL _disableLongPressGestureOnEvent;
 {
     self.progressView.hidden = !statisticsDict;
     
-    NSString* downloadRate = [statisticsDict valueForKey:kMXKMediaLoaderProgressRateKey];
-    NSString* remaingTime = [statisticsDict valueForKey:kMXKMediaLoaderProgressRemaingTimeKey];
-    NSString* progressString = [statisticsDict valueForKey:kMXKMediaLoaderProgressStringKey];
+    NSNumber* downloadRate = [statisticsDict valueForKey:kMXKMediaLoaderCurrentDataRateKey];
+    
+    NSNumber* completedBytesCount = [statisticsDict valueForKey:kMXKMediaLoaderCompletedBytesCountKey];
+    NSNumber* totalBytesCount = [statisticsDict valueForKey:kMXKMediaLoaderTotalBytesCountKey];
     
     NSMutableString* text = [[NSMutableString alloc] init];
     
-    if (progressString)
+    if (completedBytesCount && totalBytesCount)
     {
+        NSString* progressString = [NSString stringWithFormat:@"%@ / %@", [NSByteCountFormatter stringFromByteCount:completedBytesCount.longLongValue countStyle:NSByteCountFormatterCountStyleFile], [NSByteCountFormatter stringFromByteCount:totalBytesCount.longLongValue countStyle:NSByteCountFormatterCountStyleFile]];
+        
         [text appendString:progressString];
     }
     
     if (downloadRate)
     {
-        [text appendFormat:@"\n%@", downloadRate];
-    }
-    
-    if (remaingTime)
-    {
-        [text appendFormat:@"\n%@", remaingTime];
+        [text appendFormat:@"\n%@/s", [NSByteCountFormatter stringFromByteCount:downloadRate.longLongValue countStyle:NSByteCountFormatterCountStyleFile]];
+        
+        if (completedBytesCount && totalBytesCount)
+        {
+            CGFloat remainimgTime = ((totalBytesCount.floatValue - completedBytesCount.floatValue)) / downloadRate.floatValue;
+            [text appendFormat:@"\n%@", [MXKTools formatSecondsInterval:remainimgTime]];
+        }
     }
     
     self.statsLabel.text = text;


### PR DESCRIPTION
- Modify the dictionary of the progress statistics in order to be able to move media loader at SDK level.