### PR TITLE
Fix incorrect language code on iOS 9

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -840,7 +840,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
                                @"url": self.pushGatewayURL,
                                };
     
-    NSString *deviceLang = [NSLocale preferredLanguages][0];
+    NSString *deviceLang = [[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode];;
     
     NSString * profileTag = [[NSUserDefaults standardUserDefaults] valueForKey:@"pusherProfileTag"];
     if (!profileTag)


### PR DESCRIPTION
On iOS 9, preferredLanguages values now include the country code. As a result, they can look like zh-Hans-CN, which is not a valid language code and is longer than 8 characters, causing errors in Synapse's database when using Postgres, which assumes the "lang" field is no longer than that. (SQLite doesn't enforce max lengths on strings, so has no issues aside from the language string being wrong.)

According to [this post](http://stackoverflow.com/a/36012440), this patch should solve the issue by returning zh-Hans instead of zh-Hans-CN, though I have no way of testing it. Testing should be done with an iOS 9 device in Simplified Chinese, against a Synapse running Postgres.