### PR TITLE
Bug Fix: Riot looks to me like I'm sending the same message twice.

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -206,7 +206,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic) BOOL useCustomUnsentButton;
 
 /**
- Show the typing notifications of other room members in the chat history (YES by default).
+ Show the typing notifications of other room members in the chat history (NO by default).
  */
 @property (nonatomic) BOOL showTypingNotifications;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -153,8 +153,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         // display the read receips by default
         self.showBubbleReceipts = YES;
         
-        // display keyboard icon in cells.
-        _showTypingNotifications = YES;
+        // Disable typing notification in cells by default.
+        self.showTypingNotifications = NO;
         
         self.useCustomDateTimeLabel = NO;
         self.useCustomReceipts = NO;
@@ -1807,9 +1807,6 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
 - (void)replaceLocalEcho:(NSString*)localEchoEventId withEvent:(MXEvent*)event
 {
-    // Remove the event from the pending local echo list if any.
-    [self.room removePendingLocalEcho:localEchoEventId];
-    
     // Retrieve the cell data hosting the local echo
     id<MXKRoomBubbleCellDataStoring> bubbleData = [self cellDataOfEventWithEventId:localEchoEventId];
     if (!bubbleData)


### PR DESCRIPTION
vector-im/riot-ios#894

Move the local echo suppression from `MXKRoomDataSource` to `MXEventTimeline` class.