### PR TITLE
Keys export

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		32CEE22C1AB1EC9B00F7C74D /* MXKRecentCellData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2291AB1EC9B00F7C74D /* MXKRecentCellData.m */; };
 		32CEE2301AB1EE0900F7C74D /* MXKRecentTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE22F1AB1EE0900F7C74D /* MXKRecentTableViewCell.m */; };
 		32FBDAF81E4484C40033C519 /* MXKEncryptionKeysImportView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FBDAF71E4484C40033C519 /* MXKEncryptionKeysImportView.m */; };
+		32FBDAFB1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FBDAFA1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m */; };
 		550A36BD1DE484DB005C1647 /* EncryptedAttachmentsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */; };
 		71352D551C0ED240001D50B0 /* MXKRoomSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71352D531C0ED240001D50B0 /* MXKRoomSettingsViewController.m */; };
 		71352D561C0ED240001D50B0 /* MXKRoomSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71352D541C0ED240001D50B0 /* MXKRoomSettingsViewController.xib */; };
@@ -261,6 +262,8 @@
 		32CEE22F1AB1EE0900F7C74D /* MXKRecentTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRecentTableViewCell.m; sourceTree = "<group>"; };
 		32FBDAF61E4484C40033C519 /* MXKEncryptionKeysImportView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKEncryptionKeysImportView.h; sourceTree = "<group>"; };
 		32FBDAF71E4484C40033C519 /* MXKEncryptionKeysImportView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKEncryptionKeysImportView.m; sourceTree = "<group>"; };
+		32FBDAF91E44B0FC0033C519 /* MXKEncryptionKeysExportView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKEncryptionKeysExportView.h; sourceTree = "<group>"; };
+		32FBDAFA1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKEncryptionKeysExportView.m; sourceTree = "<group>"; };
 		392A579537BBF28A9436C420 /* Pods-MatrixKitSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSample/Pods-MatrixKitSample.release.xcconfig"; sourceTree = "<group>"; };
 		550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncryptedAttachmentsTest.m; sourceTree = "<group>"; };
 		665BACA3D253B4407B1C4FD7 /* libPods-MatrixKitSample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixKitSample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -828,6 +831,8 @@
 			children = (
 				32FBDAF61E4484C40033C519 /* MXKEncryptionKeysImportView.h */,
 				32FBDAF71E4484C40033C519 /* MXKEncryptionKeysImportView.m */,
+				32FBDAF91E44B0FC0033C519 /* MXKEncryptionKeysExportView.h */,
+				32FBDAFA1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m */,
 			);
 			path = EncryptionKeys;
 			sourceTree = "<group>";
@@ -1486,6 +1491,7 @@
 				F00FA8551C0864FA00E25826 /* MXKRoomIncomingTextMsgBubbleCell.m in Sources */,
 				F093BCAD1C21BDD80010D05F /* MXKReceiptSendersContainer.m in Sources */,
 				F07D74AC1AC5A29800D83B98 /* MXKEventDetailsView.m in Sources */,
+				32FBDAFB1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m in Sources */,
 				F0EA4CB11ADD6E5D007197D2 /* MXKAlert.m in Sources */,
 				F01449AD1B53FA7600EA7D73 /* MXKPushRuleCreationTableViewCell.m in Sources */,
 				3235CD771C32DC8A0084EA40 /* MXKSearchDataSource.m in Sources */,

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -243,7 +243,7 @@
 
 // E2E export
 "e2e_export_room_keys" = "Export room keys";
-"e2e_export_prompt" = "This process allows you to export the keys for messages you have received in encrypted rooms to a local file. You will then be able to import the file into another Matrix client in the future, so that client will also be able to decrypt these messages.\nThe exported file will allow anyone who can read it to decrypt any encrypted messages that you can see, so you should be careful to keep it secure. To help with this, you should enter a passphrase below, which will be used to encrypt the exported data. It will only be possible to import the data by using the same passphrase.";
+"e2e_export_prompt" = "This process allows you to export the keys for messages you have received in encrypted rooms to a local file. You will then be able to import the file into another Matrix client in the future, so that client will also be able to decrypt these messages.\nThe exported file will allow anyone who can read it to decrypt any encrypted messages that you can see, so you should be careful to keep it secure.";
 "e2e_export" = "Export";
 "e2e_passphrase_confirm" = "Confirm passphrase";
 "e2e_passphrase_empty" = "Passphrase must not be empty";

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -235,11 +235,19 @@
 "format_time_h" = "h";
 "format_time_d" = "d";
 
-// E2E import/export
+// E2E import
 "e2e_import_room_keys" = "Import room keys";
 "e2e_import_prompt" = "This process allows you to import encryption keys that you had previously exported from another Matrix client. You will then be able to decrypt any messages that the other client could decrypt.\nThe export file is protected with a passphrase. You should enter the passphrase here, to decrypt the file.";
 "e2e_import" = "Import";
 "e2e_passphrase_enter" = "Enter passphrase";
+
+// E2E export
+"e2e_export_room_keys" = "Export room keys";
+"e2e_export_prompt" = "This process allows you to export the keys for messages you have received in encrypted rooms to a local file. You will then be able to import the file into another Matrix client in the future, so that client will also be able to decrypt these messages.\nThe exported file will allow anyone who can read it to decrypt any encrypted messages that you can see, so you should be careful to keep it secure. To help with this, you should enter a passphrase below, which will be used to encrypt the exported data. It will only be possible to import the data by using the same passphrase.";
+"e2e_export" = "Export";
+"e2e_passphrase_confirm" = "Confirm passphrase";
+"e2e_passphrase_empty" = "Passphrase must not be empty";
+"e2e_passphrase_not_match" = "Passphrases must match";
 
 // Others
 "user_id_title" = "User ID:";

--- a/MatrixKit/Views/EncryptionKeys/MXKEncryptionKeysExportView.h
+++ b/MatrixKit/Views/EncryptionKeys/MXKEncryptionKeysExportView.h
@@ -1,0 +1,44 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+#import "MXKAlert.h"
+
+@class MXSession, MXKViewController, MXKRoomDataSource;
+
+/**
+ `MXKEncryptionKeysExportView` is a MXKAlert dialog to export encryption keys from
+ the user's crypto store.
+ */
+@interface MXKEncryptionKeysExportView : MXKAlert
+
+/**
+ Create the `MXKEncryptionKeysExportView` instance.
+
+ @param mxSession the mxSession to export keys from.
+ @return the newly created MXKEncryptionKeysImportView instance.
+ */
+- (instancetype)initWithMatrixSession:(MXSession*)mxSession;
+
+/**
+ Show the dialog in a given view controller.
+
+ @param mxkViewController the mxkViewController where to show the dialog.
+ @param keyFile the path where to export keys to.
+ @param onComplete a block called when the operation is done.
+ */
+- (void)showInViewController:(MXKViewController*)mxkViewController toExportKeysToFile:(NSURL*)keyFile onComplete:(void(^)(BOOL success))onComplete;
+
+@end
+

--- a/MatrixKit/Views/EncryptionKeys/MXKEncryptionKeysExportView.m
+++ b/MatrixKit/Views/EncryptionKeys/MXKEncryptionKeysExportView.m
@@ -1,0 +1,149 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKEncryptionKeysExportView.h"
+
+#import "MXKViewController.h"
+#import "MXKRoomDataSource.h"
+#import "NSBundle+MatrixKit.h"
+
+#import <MatrixSDK/MatrixSDK.h>
+
+@interface MXKEncryptionKeysExportView ()
+{
+    MXSession *mxSession;
+}
+
+@end
+
+@implementation MXKEncryptionKeysExportView
+
+- (instancetype)initWithMatrixSession:(MXSession *)matrixSession
+{
+    // Reuse MXKAlert dialog
+    self = [super initWithTitle:[NSBundle mxk_localizedStringForKey:@"e2e_export_room_keys"]
+                        message:[NSBundle mxk_localizedStringForKey:@"e2e_export_prompt"]
+                          style:MXKAlertStyleAlert];
+
+    if (self)
+    {
+        mxSession = matrixSession;
+    }
+    return self;
+}
+
+
+- (void)showInViewController:(MXKViewController *)mxkViewController toExportKeysToFile:(NSURL *)keyFile onComplete:(void (^)(BOOL success))onComplete
+{
+    __weak typeof(self) weakSelf = self;
+
+    // Finalise the dialog
+    [self addTextFieldWithConfigurationHandler:^(UITextField *textField)
+     {
+         textField.secureTextEntry = YES;
+         textField.placeholder = [NSBundle mxk_localizedStringForKey:@"e2e_passphrase_enter"];
+         [textField resignFirstResponder];
+     }];
+
+    [self addTextFieldWithConfigurationHandler:^(UITextField *textField)
+     {
+         textField.secureTextEntry = YES;
+         textField.placeholder = [NSBundle mxk_localizedStringForKey:@"e2e_passphrase_confirm"];
+         [textField resignFirstResponder];
+     }];
+
+    self.cancelButtonIndex = [self addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"] style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert)
+                              {
+                                  if (weakSelf)
+                                  {
+                                      onComplete(NO);
+                                  }
+                              }];
+
+    [self addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"e2e_export"] style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert)
+     {
+         if (weakSelf)
+         {
+             typeof(self) self = weakSelf;
+
+             // Retrieve the password and confirmation
+             UITextField *textField = [self textFieldAtIndex:0];
+             NSString *password = textField.text;
+
+             textField = [self textFieldAtIndex:1];
+             NSString *confirmation = textField.text;
+
+             // Check they are valid
+             if (password.length == 0 || ![password isEqualToString:confirmation])
+             {
+                 NSString *error = password.length ? [NSBundle mxk_localizedStringForKey:@"e2e_passphrase_not_match"] : [NSBundle mxk_localizedStringForKey:@"e2e_passphrase_empty"];
+
+                 MXKAlert *otherAlert = [[MXKAlert alloc] initWithTitle:[NSBundle mxk_localizedStringForKey:@"error"] message:error style:MXKAlertStyleAlert];
+
+                 otherAlert.cancelButtonIndex = [otherAlert addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"] style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert) {
+
+                     if (weakSelf)
+                     {
+                        onComplete(NO);
+                     }
+                 }];
+
+                 [otherAlert showInViewController:mxkViewController];
+             }
+             else
+             {
+                 // Start the export process
+                 [mxkViewController startActivityIndicator];
+
+                 [self->mxSession.crypto exportRoomKeysWithPassword:password success:^(NSData *keyFileData) {
+
+                     if (weakSelf)
+                     {
+                        [mxkViewController stopActivityIndicator];
+
+                        // Write the result to the passed file
+                        [keyFileData writeToURL:keyFile atomically:YES];
+                         onComplete(YES);
+                     }
+
+                 } failure:^(NSError *error) {
+
+                     if (weakSelf)
+                     {
+                         [mxkViewController stopActivityIndicator];
+                     
+                         // TODO: i18n the error
+                         MXKAlert *otherAlert = [[MXKAlert alloc] initWithTitle:[NSBundle mxk_localizedStringForKey:@"error"] message:error.localizedDescription style:MXKAlertStyleAlert];
+                         
+                         otherAlert.cancelButtonIndex = [otherAlert addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"] style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert) {
+                             
+                             onComplete(NO);
+                         }];
+                         
+                         [otherAlert showInViewController:mxkViewController];
+                     }
+                 }];
+             }
+         }
+     }];
+    
+    // And show it
+    [self showInViewController:mxkViewController];
+}
+
+
+@end
+


### PR DESCRIPTION
Add MXKEncryptionKeysExportView dialog.

The export action is done at the app level.

Note that the export message is huge to be correctly displayed on a 5s form factor. It can be easily improved later.

