### PR TITLE
Warn unknown devices

### DIFF
--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.h
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.h
@@ -16,6 +16,8 @@
 
 #import <MatrixSDK/MatrixSDK.h>
 
+@protocol MXKEncryptionInfoViewDelegate;
+
 /**
  MXKEncryptionInfoView class may be used to display the available information on a encrypted event.
  The event sender device may be verified, unverified, blocked or unblocked from this view.
@@ -27,6 +29,8 @@
 @property (weak, nonatomic) IBOutlet UIButton *verifyButton;
 @property (weak, nonatomic) IBOutlet UIButton *blockButton;
 @property (weak, nonatomic) IBOutlet UIButton *confirmVerifyButton;
+
+@property (nonatomic) id<MXKEncryptionInfoViewDelegate> delegate;
 
 /**
  Initialise an `MXKEncryptionInfoView` instance based on an encrypted event
@@ -58,3 +62,15 @@
 
 @end
 
+
+@protocol MXKEncryptionInfoViewDelegate <NSObject>
+
+/**
+ Called when the user changes the verified state of a device.
+ 
+ @param encryptionInfoView the view.
+ @param deviceInfo the device that has changed.
+ */
+- (void)encryptionInfoView:(MXKEncryptionInfoView*)encryptionInfoView didDeviceInfoVerifiedChange:(MXDeviceInfo*)deviceInfo;
+
+@end

--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.h
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -293,6 +293,7 @@ static NSAttributedString *verticalWhitespace = nil;
         
         switch (mxDeviceInfo.verified)
         {
+            case MXDeviceUnknown:
             case MXDeviceUnverified:
             {
                 verification = [[NSMutableAttributedString alloc]

--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -403,8 +403,18 @@ static NSAttributedString *verticalWhitespace = nil;
     // Note: Verify and Block buttons are hidden when the deviceInfo is not available
     else if (sender == _confirmVerifyButton && mxDeviceInfo)
     {
-        [mxSession.crypto setDeviceVerification:MXDeviceVerified forDevice:mxDeviceInfo.deviceId ofUser:mxDeviceInfo.userId success:nil failure:nil];
-        [self removeFromSuperview];
+        [mxSession.crypto setDeviceVerification:MXDeviceVerified forDevice:mxDeviceInfo.deviceId ofUser:mxDeviceInfo.userId success:^{
+
+            mxDeviceInfo.verified = MXDeviceVerified;
+            if (_delegate)
+            {
+                [_delegate encryptionInfoView:self didDeviceInfoVerifiedChange:mxDeviceInfo];
+            }
+            [self removeFromSuperview];
+
+        } failure:^(NSError *error) {
+            [self removeFromSuperview];
+        }];
     }
     else if (mxDeviceInfo)
     {
@@ -448,8 +458,19 @@ static NSAttributedString *verticalWhitespace = nil;
         }
         else
         {
-            [mxSession.crypto setDeviceVerification:verificationStatus forDevice:mxDeviceInfo.deviceId ofUser:mxDeviceInfo.userId success:nil failure:nil];
-            [self removeFromSuperview];
+            [mxSession.crypto setDeviceVerification:verificationStatus forDevice:mxDeviceInfo.deviceId ofUser:mxDeviceInfo.userId success:^{
+
+                mxDeviceInfo.verified = verificationStatus;
+                if (_delegate)
+                {
+                    [_delegate encryptionInfoView:self didDeviceInfoVerifiedChange:mxDeviceInfo];
+                }
+
+                [self removeFromSuperview];
+
+            } failure:^(NSError *error) {
+                [self removeFromSuperview];
+            }];
         }
     }
 }


### PR DESCRIPTION
- Updated code to follow changes due to https://github.com/matrix-org/matrix-ios-sdk/pull/244.
- Added MXKEncryptionInfoViewDelegate to be notified when the device has been verified