### PR TITLE
Replace GHMarkdownParser with CommonMark

### DIFF
--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -27,6 +27,6 @@ Pod::Spec.new do |s|
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.8.14'
   s.dependency 'DTCoreText', '~> 1.6.17'
-  s.dependency 'GHMarkdownParser', '~> 0.1.2'
+  s.dependency 'cmark', '~> 0.24.1'
 
 end

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1440,9 +1440,15 @@
 - (NSString *)htmlStringFromMarkdownString:(NSString *)markdownString
 {
     const char *cstr = [markdownString cStringUsingEncoding: NSUTF8StringEncoding];
-    const char *htmlCString = cmark_markdown_to_html(cstr, strlen(cstr), 0);
+    const char *htmlCString = cmark_markdown_to_html(cstr, strlen(cstr), CMARK_OPT_HARDBREAKS);
     NSString *htmlString = [[NSString alloc] initWithCString:htmlCString encoding:NSUTF8StringEncoding];
 
+    // Strip off the trailing newline, if it exists.
+    if ([htmlString hasSuffix:@"\n"])
+    {
+        htmlString = [htmlString substringToIndex:htmlString.length - 1];
+    }
+    
     // Strip start and end <p> tags else you get 'orrible spacing
     if ([htmlString hasPrefix:@"<p>"])
     {

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1439,14 +1439,7 @@
 
 - (NSString *)htmlStringFromMarkdownString:(NSString *)markdownString
 {
-    // In GitHub Flavored Mardown, the '#' sign creates an HTML header only if it is
-    // followed by the space char.
-    // But GHMarkdownParser creates an HTML header everytime it finds a '#' sign which
-    // kills room aliases (like #matrix:matrix.org).
-    // So, escape them if they are not followed by a space
-    NSString *str = [markdownString stringByReplacingOccurrencesOfString:@"(#+)[^( |#)]" withString:@"\\\\$0" options:NSRegularExpressionSearch range:NSMakeRange(0, markdownString.length)];
-
-    const char *cstr = [str cStringUsingEncoding: NSUTF8StringEncoding];
+    const char *cstr = [markdownString cStringUsingEncoding: NSUTF8StringEncoding];
     const char *htmlCString = cmark_markdown_to_html(cstr, strlen(cstr), 0);
     NSString *htmlString = [[NSString alloc] initWithCString:htmlCString encoding:NSUTF8StringEncoding];
 

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -22,7 +22,7 @@
 #import "MXKTools.h"
 
 #import "DTCoreText.h"
-#import "GHMarkdownParser.h"
+#import "cmark.h"
 
 #import "MXDecryptionResult.h"
 
@@ -32,11 +32,6 @@
      The matrix session. Used to get contextual data.
      */
     MXSession *mxSession;
-
-    /**
-     The Markdown to HTML parser.
-     */
-    GHMarkdownParser *markdownParser;
 
     /**
      The default CSS converted in DTCoreText object.
@@ -63,10 +58,6 @@
         mxSession = matrixSession;
         
         [self initDateTimeFormatters];
-
-        markdownParser = [[GHMarkdownParser alloc] init];
-        markdownParser.options = kGHMarkdownAutoLink | kGHMarkdownNoSmartQuotes;
-        markdownParser.githubFlavored = YES;        // This is the Markdown flavor we use in Matrix apps
 
         // Use the same list as matrix-react-sdk ( https://github.com/matrix-org/matrix-react-sdk/blob/24223ae2b69debb33fa22fcda5aeba6fa93c93eb/src/HtmlUtils.js#L25 )
         _allowedHTMLTags = @[
@@ -1455,7 +1446,9 @@
     // So, escape them if they are not followed by a space
     NSString *str = [markdownString stringByReplacingOccurrencesOfString:@"(#+)[^( |#)]" withString:@"\\\\$0" options:NSRegularExpressionSearch range:NSMakeRange(0, markdownString.length)];
 
-    NSString *htmlString = [markdownParser HTMLStringFromMarkdownString:str];
+    const char *cstr = [str cStringUsingEncoding: NSUTF8StringEncoding];
+    const char *htmlCString = cmark_markdown_to_html(cstr, strlen(cstr), 0);
+    NSString *htmlString = [[NSString alloc] initWithCString:htmlCString encoding:NSUTF8StringEncoding];
 
     // Strip start and end <p> tags else you get 'orrible spacing
     if ([htmlString hasPrefix:@"<p>"])

--- a/MatrixKitTests/MXKEventFormatterTests.m
+++ b/MatrixKitTests/MXKEventFormatterTests.m
@@ -71,6 +71,19 @@
     }];
 
 }
+    
+- (void)testMarkdownFormatting
+{
+    NSString *html = [eventFormatter htmlStringFromMarkdownString:@"Line One.\nLine Two."];
+    
+    BOOL hardBreakExists =      [html rangeOfString:@"<br />"].location != NSNotFound;
+    BOOL openParagraphExists =  [html rangeOfString:@"<p>"].location != NSNotFound;
+    BOOL closeParagraphExists = [html rangeOfString:@"</p>"].location != NSNotFound;
+    
+    // Check for some known error cases
+    XCTAssert(hardBreakExists, "The soft break (\\n) must be converted to a hard break (<br />).");
+    XCTAssert(!openParagraphExists && !closeParagraphExists, "The html must not contain any opening or closing paragraph tags.");
+}
 
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -24,7 +24,7 @@ pod 'libPhoneNumber-iOS', '~> 0.9.2'
 pod 'HPGrowingTextView', '~> 1.1'
 pod 'JSQMessagesViewController', '~> 7.2.0'
 pod 'DTCoreText', '~> 1.6.17'
-pod 'GHMarkdownParser', '~> 0.1.2'
+pod 'cmark', '~> 0.24.1'
 
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,6 +14,7 @@ PODS:
   - AFNetworking/Serialization (3.1.0)
   - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
+  - cmark (0.24.1)
   - DTCoreText (1.6.19):
     - DTCoreText/Core (= 1.6.19)
     - DTFoundation/Core (~> 1.7.5)
@@ -31,7 +32,6 @@ PODS:
     - DTFoundation/Core
   - DTFoundation/UIKit (1.7.11):
     - DTFoundation/Core
-  - GHMarkdownParser (0.1.2)
   - HPGrowingTextView (1.1)
   - JSQMessagesViewController (7.2.0):
     - JSQSystemSoundPlayer (~> 2.0.1)
@@ -41,8 +41,8 @@ PODS:
     - AFNetworking (~> 3.1.0)
 
 DEPENDENCIES:
+  - cmark (~> 0.24.1)
   - DTCoreText (~> 1.6.17)
-  - GHMarkdownParser (~> 0.1.2)
   - HPGrowingTextView (~> 1.1)
   - JSQMessagesViewController (~> 7.2.0)
   - libPhoneNumber-iOS (~> 0.9.2)
@@ -50,15 +50,15 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
+  cmark: ec0275215b504780287b6fca360224e384368af8
   DTCoreText: 184cc2f460c2177108e8700dfb0eb1b1cb72c99d
   DTFoundation: 0ef29c70a9814e15518694862bd739347abe2a50
-  GHMarkdownParser: 14cbf59d0ab9450017d843dffd4a3ef691e5bd77
   HPGrowingTextView: 88a716d97fb853bcb08a4a08e4727da17efc9b19
   JSQMessagesViewController: 73cab48aa92fc2d512f3b6724f3425cc47a19eb5
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: a8bffdec18c37728360f6771fe021302f1e0b497
   MatrixSDK: a638135ef6058d42bae9539649c2b45184155fdb
 
-PODFILE CHECKSUM: 1bc87109be03c1cb6ba9567d95c5d0f52f99a8b8
+PODFILE CHECKSUM: c25b8bd197c8750ecc7011feeec004b93348c1fc
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
This replaces with the GHMarkdownParser library with the cmark (CommonMark) library.

This also resolves #188.

signed-off-by: Avery Pierce <aapierce0@gmail.com>