### PR TITLE
Attachment viewcontroller interactive animations

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		71EBE6631C04608100E7D953 /* MXKRoomActivitiesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71EBE6621C04608100E7D953 /* MXKRoomActivitiesView.m */; };
 		79FA5AB121247287B85FA151 /* libPods-MatrixKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */; };
 		ACD9DAA6B4DCFC7E33E12A97 /* libPods-MatrixKitSample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665BACA3D253B4407B1C4FD7 /* libPods-MatrixKitSample.a */; };
+		CE14CA661E80122600E329A3 /* MXKAttachmentAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = CE14CA631E80122600E329A3 /* MXKAttachmentAnimator.m */; };
+		CE14CA671E80122600E329A3 /* MXKAttachmentInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE14CA651E80122600E329A3 /* MXKAttachmentInteractionController.m */; };
 		F0026B661C91EED1001D2C04 /* MXKWebViewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0026B651C91EED1001D2C04 /* MXKWebViewViewController.m */; };
 		F0036EEF1AB98DC40008E432 /* MXKRoomInputToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = F0036EED1AB98DC40008E432 /* MXKRoomInputToolbarView.m */; };
 		F0036EF01AB98DC40008E432 /* MXKRoomInputToolbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F0036EEE1AB98DC40008E432 /* MXKRoomInputToolbarView.xib */; };
@@ -283,6 +285,10 @@
 		9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFDF88630F521F8C5854F64F /* Pods-MatrixKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1C97E32A7F1D6C4B99A47EF /* Pods-MatrixKitSample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSample/Pods-MatrixKitSample.debug.xcconfig"; sourceTree = "<group>"; };
+		CE14CA621E80122600E329A3 /* MXKAttachmentAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKAttachmentAnimator.h; sourceTree = "<group>"; };
+		CE14CA631E80122600E329A3 /* MXKAttachmentAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKAttachmentAnimator.m; sourceTree = "<group>"; };
+		CE14CA641E80122600E329A3 /* MXKAttachmentInteractionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKAttachmentInteractionController.h; sourceTree = "<group>"; };
+		CE14CA651E80122600E329A3 /* MXKAttachmentInteractionController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKAttachmentInteractionController.m; sourceTree = "<group>"; };
 		F0026B641C91EED1001D2C04 /* MXKWebViewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKWebViewViewController.h; sourceTree = "<group>"; };
 		F0026B651C91EED1001D2C04 /* MXKWebViewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKWebViewViewController.m; sourceTree = "<group>"; };
 		F0036EEC1AB98DC40008E432 /* MXKRoomInputToolbarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomInputToolbarView.h; sourceTree = "<group>"; };
@@ -590,6 +596,7 @@
 		3219CB6A1AA6F2780027D7E2 /* MatrixKit */ = {
 			isa = PBXGroup;
 			children = (
+				CE14CA611E8011EC00E329A3 /* Animators */,
 				F09E28921AC2007000C51E44 /* Assets */,
 				F07E18111ABC563900DE3766 /* Categories */,
 				3219CBBB1AA6FB1C0027D7E2 /* Controllers */,
@@ -863,6 +870,17 @@
 				9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CE14CA611E8011EC00E329A3 /* Animators */ = {
+			isa = PBXGroup;
+			children = (
+				CE14CA621E80122600E329A3 /* MXKAttachmentAnimator.h */,
+				CE14CA631E80122600E329A3 /* MXKAttachmentAnimator.m */,
+				CE14CA641E80122600E329A3 /* MXKAttachmentInteractionController.h */,
+				CE14CA651E80122600E329A3 /* MXKAttachmentInteractionController.m */,
+			);
+			path = Animators;
 			sourceTree = "<group>";
 		};
 		F00BB4471AB840B300AE388E /* RoomInputToolbar */ = {
@@ -1455,6 +1473,7 @@
 				F0F148C61AB31240005F5D4A /* MXKTools.m in Sources */,
 				3230A3721ACA835400CC57F5 /* MXKSampleJSQMessageMediaData.m in Sources */,
 				F0868E0D1B18FC01004CBE80 /* MXKRoomCreationView.m in Sources */,
+				CE14CA671E80122600E329A3 /* MXKAttachmentInteractionController.m in Sources */,
 				3235CD7B1C32DEBF0084EA40 /* MXKSearchViewController.m in Sources */,
 				F00FA8791C08A51B00E25826 /* MXKRoomOutgoingTextMsgWithoutSenderInfoBubbleCell.m in Sources */,
 				F07E180F1ABC2EDA00DE3766 /* MXKRoomBubbleCellDataWithAppendingMode.m in Sources */,
@@ -1496,6 +1515,7 @@
 				F00FA85E1C0867F900E25826 /* MXKRoomIncomingTextMsgWithoutSenderInfoBubbleCell.m in Sources */,
 				32FBDAF81E4484C40033C519 /* MXKEncryptionKeysImportView.m in Sources */,
 				F0CF98E21B0B7FDC00EAE373 /* MXKTableViewCellWithTextFieldAndButton.m in Sources */,
+				CE14CA661E80122600E329A3 /* MXKAttachmentAnimator.m in Sources */,
 				F0E0CE6B1AD6B3BA00A7FD45 /* MXKSampleRoomMembersViewController.m in Sources */,
 				F0316E361B7DEA5300F03620 /* MXKTableViewCellWithSearchBar.m in Sources */,
 				F00FA8551C0864FA00E25826 /* MXKRoomIncomingTextMsgBubbleCell.m in Sources */,

--- a/MatrixKit/Animators/MXKAttachmentAnimator.h
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.h
@@ -1,0 +1,38 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, PhotoBrowserAnimationType) {
+    PhotoBrowserZoomInAnimation,
+    PhotoBrowserZoomOutAnimation
+};
+
+@protocol MXKAttachmentAnimatorDelegate <NSObject>
+
+@required
+- (UIImageView *)imageViewForAnimations;
+
+@end
+
+@interface MXKAttachmentAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
+- (instancetype)initWithAnimationType:(PhotoBrowserAnimationType)animationType originalImageView:(UIImageView *)originalImageView convertedFrame:(CGRect)frame;
+
++ (CGRect)aspectFitImage:(UIImage *)image inFrame:(CGRect)targetFrame;
+
+@end

--- a/MatrixKit/Animators/MXKAttachmentAnimator.h
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.h
@@ -22,16 +22,27 @@ typedef NS_ENUM(NSInteger, PhotoBrowserAnimationType) {
     PhotoBrowserZoomOutAnimation
 };
 
-@protocol MXKAttachmentAnimatorDelegate <NSObject>
+@protocol MXKSourceAttachmentAnimatorDelegate <NSObject>
 
 @required
-- (UIImageView *)imageViewForAnimations;
+
+- (UIImageView *)originalImageView;
+
+- (CGRect)convertedFrameForOriginalImageView;
+
+@end
+
+@protocol MXKDestinationAttachmentAnimatorDelegate <NSObject>
+
+@required
+
+- (UIImageView *)finalImageView;
 
 @end
 
 @interface MXKAttachmentAnimator : NSObject <UIViewControllerAnimatedTransitioning>
 
-- (instancetype)initWithAnimationType:(PhotoBrowserAnimationType)animationType originalImageView:(UIImageView *)originalImageView convertedFrame:(CGRect)frame;
+- (instancetype)initWithAnimationType:(PhotoBrowserAnimationType)animationType sourceViewController:(UIViewController <MXKSourceAttachmentAnimatorDelegate> *)viewController;
 
 + (CGRect)aspectFitImage:(UIImage *)image inFrame:(CGRect)targetFrame;
 

--- a/MatrixKit/Animators/MXKAttachmentAnimator.h
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Aram Sargsyan
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixKit/Animators/MXKAttachmentAnimator.m
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.m
@@ -1,0 +1,157 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKAttachmentAnimator.h"
+
+@interface MXKAttachmentAnimator ()
+
+@property PhotoBrowserAnimationType animationType;
+@property UIImageView *originalImageView;
+@property CGRect convertedFrame;
+
+@end
+
+@implementation MXKAttachmentAnimator
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithAnimationType:(PhotoBrowserAnimationType)animationType originalImageView:(UIImageView *)originalImageView convertedFrame:(CGRect)frame
+{
+    self = [self init];
+    if (self) {
+        self.animationType = animationType;
+        self.originalImageView = originalImageView;
+        self.convertedFrame = frame;
+    }
+    return self;
+}
+
+#pragma mark - Public
+
++ (CGRect)aspectFitImage:(UIImage *)image inFrame:(CGRect)targetFrame
+{
+    if (CGSizeEqualToSize(image.size, targetFrame.size)) {
+        return targetFrame;
+    }
+    CGFloat targetWidth = CGRectGetWidth(targetFrame);
+    CGFloat targetHeight = CGRectGetHeight(targetFrame);
+    CGFloat imageWidth = image.size.width;
+    CGFloat imageHeight = image.size.height;
+    
+    CGFloat factor = MIN(targetWidth/imageWidth, targetHeight/imageHeight);
+    
+    CGSize finalSize = CGSizeMake(imageWidth * factor, imageHeight * factor);
+    CGRect finalFrame = CGRectMake((targetWidth - finalSize.width)/2 + 0, (targetHeight - finalSize.height)/2 + targetFrame.origin.y, finalSize.width, finalSize.height);
+    
+    return finalFrame;
+}
+
+#pragma mark - Animations
+
+- (void)animateZoomInAnimation:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    self.originalImageView.hidden = YES;
+    
+    //toViewController
+    UIViewController<MXKAttachmentAnimatorDelegate> *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
+    [[transitionContext containerView] addSubview:toViewController.view];
+    toViewController.view.alpha = 0.0;
+    
+    if ([toViewController conformsToProtocol:@protocol(MXKAttachmentAnimatorDelegate)]) {
+        NSLog(@"conforms");
+    } else {
+        NSLog(@"doesnt conform");
+    }
+    
+    UIImageView *destinationImageView = [toViewController imageViewForAnimations];
+    destinationImageView.hidden = YES;
+    
+    //transitioningImageView
+    UIImageView *transitioningImageView = [[UIImageView alloc] initWithImage:self.originalImageView.image];
+    transitioningImageView.frame = self.convertedFrame;
+    [[transitionContext containerView] addSubview:transitioningImageView];
+    CGRect finalFrameForTransitioningView = [[self class] aspectFitImage:self.originalImageView.image inFrame:toViewController.view.frame];
+    
+    
+    //animation
+    [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
+        toViewController.view.alpha = 1.0;
+        transitioningImageView.frame = finalFrameForTransitioningView;
+    } completion:^(BOOL finished) {
+        [transitioningImageView removeFromSuperview];
+        destinationImageView.hidden = NO;
+        self.originalImageView.hidden = NO;
+        [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+    }];
+}
+
+- (void)animateZoomOutAnimation:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    //fromViewController
+    UIViewController<MXKAttachmentAnimatorDelegate> *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIImageView *destinationImageView = [fromViewController imageViewForAnimations];
+    destinationImageView.hidden = YES;
+    
+    //toViewController
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
+    [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
+    self.originalImageView.hidden = YES;
+    
+    //transitioningImageView
+    UIImageView *transitioningImageView = [[UIImageView alloc] initWithImage:destinationImageView.image];
+    transitioningImageView.frame = [[self class] aspectFitImage:destinationImageView.image inFrame:destinationImageView.frame];
+    [[transitionContext containerView] addSubview:transitioningImageView];
+    
+    if (fromViewController.navigationController) {
+        [fromViewController.navigationController setNavigationBarHidden:YES animated:YES];
+    }
+    
+    //animation
+    [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
+        fromViewController.view.alpha = 0.0;
+        transitioningImageView.frame = self.convertedFrame;
+    } completion:^(BOOL finished) {
+        [transitioningImageView removeFromSuperview];
+        destinationImageView.hidden = NO;
+        self.originalImageView.hidden = NO;
+        [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+    }];
+}
+
+#pragma mark - UIViewControllerAnimatedTransitioning
+
+- (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    return 0.3;
+}
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    switch (self.animationType) {
+        case PhotoBrowserZoomInAnimation:
+            [self animateZoomInAnimation:transitionContext];
+            break;
+            
+        case PhotoBrowserZoomOutAnimation:
+            [self animateZoomOutAnimation:transitionContext];
+            break;
+    }
+}
+
+
+@end

--- a/MatrixKit/Animators/MXKAttachmentAnimator.m
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Aram Sargsyan
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@
     CGFloat factor = MIN(targetWidth/imageWidth, targetHeight/imageHeight);
     
     CGSize finalSize = CGSizeMake(imageWidth * factor, imageHeight * factor);
-    CGRect finalFrame = CGRectMake((targetWidth - finalSize.width)/2 + 0, (targetHeight - finalSize.height)/2 + targetFrame.origin.y, finalSize.width, finalSize.height);
+    CGRect finalFrame = CGRectMake((targetWidth - finalSize.width)/2 + targetFrame.origin.x, (targetHeight - finalSize.height)/2 + targetFrame.origin.y, finalSize.width, finalSize.height);
     
     return finalFrame;
 }

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.h
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Aram Sargsyan
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.h
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.h
@@ -15,11 +15,12 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "MXKAttachmentAnimator.h"
 
 @interface MXKAttachmentInteractionController : UIPercentDrivenInteractiveTransition
 
 @property BOOL interactionInProgress;
 
-- (instancetype)initWithViewController:(UIViewController *)viewController originalImageView:(UIImageView *)imageView convertedFrame:(CGRect)frame;
+- (instancetype)initWithDestinationViewController:(UIViewController <MXKDestinationAttachmentAnimatorDelegate> *)viewController sourceViewController:(UIViewController <MXKSourceAttachmentAnimatorDelegate> *)sourceViewController;
 
 @end

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.h
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.h
@@ -1,0 +1,25 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface MXKAttachmentInteractionController : UIPercentDrivenInteractiveTransition
+
+@property BOOL interactionInProgress;
+
+- (instancetype)initWithViewController:(UIViewController *)viewController originalImageView:(UIImageView *)imageView convertedFrame:(CGRect)frame;
+
+@end

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Aram Sargsyan
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -1,0 +1,191 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKAttachmentInteractionController.h"
+#import "MXKAttachmentAnimator.h"
+
+@interface MXKAttachmentInteractionController ()
+
+@property (weak, atomic) UIViewController<MXKAttachmentAnimatorDelegate> *viewController;
+@property (weak) UIImageView *originalImageViewReference;
+@property CGRect originalImageViewConvertedFrame;
+
+@property UIImageView *transitioningImageView;
+@property id <UIViewControllerContextTransitioning> transitionContext;
+
+@property CGPoint translation;
+@property CGPoint delta;
+
+@end
+
+@implementation MXKAttachmentInteractionController
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithViewController:(UIViewController<MXKAttachmentAnimatorDelegate> *)viewController originalImageView:(UIImageView *)imageView convertedFrame:(CGRect)frame
+{
+    self = [super init];
+    if (self) {
+        self.viewController = viewController;
+        self.originalImageViewReference = imageView;
+        self.originalImageViewConvertedFrame = frame;
+        self.interactionInProgress = NO;
+        
+        [self preparePanGestureRecognizerInView:viewController.view];
+    }
+    return self;
+}
+
+#pragma mark - Gesture recognizer
+
+- (void)preparePanGestureRecognizerInView:(UIView *)view
+{
+    UIPanGestureRecognizer *recognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+    recognizer.minimumNumberOfTouches = 1;
+    recognizer.maximumNumberOfTouches = 3;
+    [view addGestureRecognizer:recognizer];
+}
+
+- (void)handleGesture:(UIPanGestureRecognizer *)recognizer
+{
+    CGPoint translation = [recognizer translationInView:self.viewController.view];
+    self.delta = CGPointMake(translation.x - self.translation.x, translation.y - self.translation.y);
+    self.translation = translation;
+    
+    switch (recognizer.state) {
+        case UIGestureRecognizerStateBegan:
+            
+            self.interactionInProgress = YES;
+            
+            if (self.viewController.navigationController) {
+                [self.viewController.navigationController popViewControllerAnimated:YES];
+            } else {
+                [self.viewController dismissViewControllerAnimated:YES completion:nil];
+            }
+            
+            break;
+            
+        case UIGestureRecognizerStateChanged:
+            
+            [self updateInteractiveTransition:(ABS(translation.y) / (CGRectGetHeight(self.viewController.view.frame) / 2))];
+            
+            break;
+            
+        case UIGestureRecognizerStateCancelled:
+            
+            self.interactionInProgress = NO;
+            [self cancelInteractiveTransition];
+            
+            break;
+            
+        case UIGestureRecognizerStateEnded:
+            
+            self.interactionInProgress = NO;
+            if (ABS(self.translation.y) < CGRectGetHeight(self.viewController.view.frame)/6) {
+                [self cancelInteractiveTransition];
+            } else {
+                [self finishInteractiveTransition];
+            }
+            
+            break;
+            
+        default:
+            NSLog(@"UIGestureRecognizerState not handled");
+            break;
+    }
+}
+
+#pragma mark - UIPercentDrivenInteractiveTransition
+
+- (void)startInteractiveTransition:(id <UIViewControllerContextTransitioning>)transitionContext
+{
+    self.transitionContext = transitionContext;
+    
+    UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIImageView *destinationImageView = [self.viewController imageViewForAnimations];
+    destinationImageView.hidden = YES;
+
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
+    [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
+    self.originalImageViewReference.hidden = YES;
+    
+    if (self.viewController.navigationController) {
+        [self.viewController.navigationController setNavigationBarHidden:YES animated:NO];
+    }
+
+    self.transitioningImageView = [[UIImageView alloc] initWithImage:destinationImageView.image];
+    self.transitioningImageView.frame = [MXKAttachmentAnimator aspectFitImage:destinationImageView.image inFrame:destinationImageView.frame];
+    [[transitionContext containerView] addSubview:self.transitioningImageView];
+}
+
+- (void)updateInteractiveTransition:(CGFloat)percentComplete {
+    self.viewController.view.alpha = MAX(0, (1 - percentComplete));
+    
+    CGRect newFrame = CGRectMake(self.transitioningImageView.frame.origin.x, self.transitioningImageView.frame.origin.y + self.delta.y, CGRectGetWidth(self.transitioningImageView.frame), CGRectGetHeight(self.transitioningImageView.frame));
+    self.transitioningImageView.frame = newFrame;
+}
+
+- (void)cancelInteractiveTransition {
+    UIViewController *fromViewController = [self.transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIImageView *destinationImageView = [self.viewController imageViewForAnimations];
+    
+    [UIView animateWithDuration:([self transitionDuration:self.transitionContext]/2) animations:^{
+        fromViewController.view.alpha = 1;
+        self.transitioningImageView.frame = [MXKAttachmentAnimator aspectFitImage:destinationImageView.image inFrame:destinationImageView.frame];
+    } completion:^(BOOL finished) {
+        destinationImageView.hidden = NO;
+        self.originalImageViewReference.hidden = NO;
+        [self.transitioningImageView removeFromSuperview];
+        
+        [self.transitionContext cancelInteractiveTransition];
+        [self.transitionContext completeTransition:NO];
+    }];
+}
+
+- (void)finishInteractiveTransition
+{
+    UIViewController *fromViewController = [self.transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIImageView *destinationImageView = [self.viewController imageViewForAnimations];
+    
+    UIViewController *toViewController = [self.transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    
+    
+    [UIView animateWithDuration:[self transitionDuration:self.transitionContext] animations:^{
+        fromViewController.view.alpha = 0.0;
+        self.transitioningImageView.frame = self.originalImageViewConvertedFrame;
+    } completion:^(BOOL finished) {
+        [self.transitioningImageView removeFromSuperview];
+        destinationImageView.hidden = NO;
+        self.originalImageViewReference.hidden = NO;
+        if (toViewController.navigationController) {
+            [toViewController.navigationController setNavigationBarHidden:NO animated:YES];
+        }
+        
+        [self.transitionContext finishInteractiveTransition];
+        [self.transitionContext completeTransition:YES];
+    }];
+}
+
+#pragma mark - UIViewControllerAnimatedTransitioning
+
+- (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    return 0.3;
+}
+
+
+@end

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.h
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.h
@@ -103,4 +103,10 @@ limitations under the License.
  @return a boolean which tells whether some new attachments may be added or not.
  */
 - (BOOL)attachmentsViewController:(MXKAttachmentsViewController*)attachmentsViewController paginateAttachmentBefore:(NSString*)eventId;
+
+@optional
+
+- (void)displayedNewAttachmentWithEventId:(NSString *)eventId;
+
+
 @end

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.h
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #import "MXKViewController.h"
 #import "MXKAttachment.h"
+#import "MXKAttachmentAnimator.h"
 
 @protocol MXKAttachmentsViewControllerDelegate;
 
@@ -25,7 +26,7 @@ limitations under the License.
  This view controller is used to display attachments of a room.
  Only one attachment is displayed at once, the user is able to swipe one by one the attachment.
  */
-@interface MXKAttachmentsViewController : MXKViewController <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UIDocumentInteractionControllerDelegate>
+@interface MXKAttachmentsViewController : MXKViewController <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UIDocumentInteractionControllerDelegate, MXKAttachmentAnimatorDelegate>
 
 @property (nonatomic) IBOutlet UICollectionView *attachmentsCollection;
 
@@ -65,6 +66,11 @@ limitations under the License.
  @return An initialized `MXKAttachmentsViewController` object if successful, `nil` otherwise.
  */
 + (instancetype)attachmentsViewController;
+
+/**
+ Creates and returns a new `MXKAttachmentsViewController` object, also sets sets up environment for animated interactive transitions.
+ */
++ (instancetype)animatedAttachmentsViewControllerWithOriginViewController:(UIViewController *)vc referenceImageView:(UIImageView *)referenceImageView convertedFrame:(CGRect)convertedFrame;
 
 /**
  Display attachments of a room.

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.h
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.h
@@ -26,7 +26,7 @@ limitations under the License.
  This view controller is used to display attachments of a room.
  Only one attachment is displayed at once, the user is able to swipe one by one the attachment.
  */
-@interface MXKAttachmentsViewController : MXKViewController <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UIDocumentInteractionControllerDelegate, MXKAttachmentAnimatorDelegate>
+@interface MXKAttachmentsViewController : MXKViewController <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UIDocumentInteractionControllerDelegate, MXKDestinationAttachmentAnimatorDelegate>
 
 @property (nonatomic) IBOutlet UICollectionView *attachmentsCollection;
 
@@ -70,7 +70,7 @@ limitations under the License.
 /**
  Creates and returns a new `MXKAttachmentsViewController` object, also sets sets up environment for animated interactive transitions.
  */
-+ (instancetype)animatedAttachmentsViewControllerWithOriginViewController:(UIViewController *)vc referenceImageView:(UIImageView *)referenceImageView convertedFrame:(CGRect)convertedFrame;
++ (instancetype)animatedAttachmentsViewControllerWithSourceViewController:(UIViewController <MXKSourceAttachmentAnimatorDelegate> *)sourceViewController;
 
 /**
  Display attachments of a room.

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.h
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.h
@@ -106,6 +106,10 @@ limitations under the License.
 
 @optional
 
+/**
+ Informs the delegate that a new attachment has been shown
+ the parameter eventId is used by the delegate to identify the attachment
+ */
 - (void)displayedNewAttachmentWithEventId:(NSString *)eventId;
 
 

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -1078,12 +1078,6 @@
             }
         }
     }
-  
-    //tell the delegate that a new Attachment has been shown and pass eventId
-    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
-    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
-        [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
-    }
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
@@ -1113,6 +1107,14 @@
             [self refreshCurrentVisibleCell];
         }
     }
+    
+    //tell the delegate that a new Attachment has been shown and pass eventId
+    MXKMediaCollectionViewCell* cell = [[self.attachmentsCollection visibleCells] firstObject];
+    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
+    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
+        [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
+    }
+    
 }
 
 #pragma mark - UICollectionViewDelegateFlowLayout
@@ -1374,7 +1376,7 @@
 
 - (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:(id<UIViewControllerAnimatedTransitioning>)animator
 {
-    //if there is no interaction, just finish the animation using the animationController
+    //if there is an interaction, use the custom interaction controller to handle it
     if (self.interactionController.interactionInProgress)
     {
         return self.interactionController;

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -503,7 +503,7 @@
     MXKMediaCollectionViewCell* cell = [[self.attachmentsCollection visibleCells] firstObject];
     NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
     if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
-        if ((isBackPaginationInProgress == YES) && (currentVisibleItemIndex == 0)) {
+        if (((isBackPaginationInProgress == YES) && (currentVisibleItemIndex == 0)) || currentVisibleItemIndex == NSNotFound) {
             [self.delegate displayedNewAttachmentWithEventId:nil];
         } else {
             [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -119,18 +119,24 @@
                                           bundle:[NSBundle bundleForClass:[MXKAttachmentsViewController class]]];
 }
 
-+ (instancetype)animatedAttachmentsViewControllerWithOriginViewController:(UIViewController *)vc referenceImageView:(UIImageView *)referenceImageView convertedFrame:(CGRect)convertedFrame
++ (instancetype)animatedAttachmentsViewControllerWithOriginViewController:(UIViewController *)originViewController referenceImageView:(UIImageView *)referenceImageView convertedFrame:(CGRect)convertedFrame
 {
     MXKAttachmentsViewController *attachmentsController = [[[self class] alloc] initWithNibName:NSStringFromClass([MXKAttachmentsViewController class])
                                                                                          bundle:[NSBundle bundleForClass:[MXKAttachmentsViewController class]]];
     
-    
+    //create an interactionController for it to handle the gestue recognizer and control the interactions
     attachmentsController.interactionController = [[MXKAttachmentInteractionController alloc] initWithViewController:attachmentsController originalImageView:referenceImageView convertedFrame:convertedFrame];
+    
+    //we use the animationsEnabled property to enable/disable animations. Instances created not using this method should use the default animations
     attachmentsController.animationsEnabled = YES;
+    
+    //this properties will be needed by animationControllers in order to perform the animations
     attachmentsController.originalImageView = referenceImageView;
     attachmentsController.convertedFrame = convertedFrame;
+    
+    //setting transitioningDelegate and navigationController.delegate so that the animations will work for present/dismiss as well as push/pop
     attachmentsController.transitioningDelegate = attachmentsController;
-    vc.navigationController.delegate = attachmentsController;
+    originViewController.navigationController.delegate = attachmentsController;
     
     
     return attachmentsController;
@@ -1383,6 +1389,7 @@
 
 - (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:(id<UIViewControllerAnimatedTransitioning>)animator
 {
+    //if there is no interaction, just finish the animation using the animationController
     if (self.interactionController.interactionInProgress)
     {
         return self.interactionController;

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -499,6 +499,17 @@
     
     [self refreshCurrentVisibleItemIndex];
     
+    // Tell the delegate that a new Attachment has been shown and pass eventId
+    MXKMediaCollectionViewCell* cell = [[self.attachmentsCollection visibleCells] firstObject];
+    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
+    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
+        if ((isBackPaginationInProgress == YES) && (currentVisibleItemIndex == 0)) {
+            [self.delegate displayedNewAttachmentWithEventId:nil];
+        } else {
+            [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
+        }
+    }
+    
     if (currentVisibleItemIndex != NSNotFound)
     {
         NSInteger item = currentVisibleItemIndex;
@@ -1107,14 +1118,6 @@
             [self refreshCurrentVisibleCell];
         }
     }
-    
-    //tell the delegate that a new Attachment has been shown and pass eventId
-    MXKMediaCollectionViewCell* cell = [[self.attachmentsCollection visibleCells] firstObject];
-    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
-    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
-        [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
-    }
-    
 }
 
 #pragma mark - UICollectionViewDelegateFlowLayout

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -499,24 +499,26 @@
     
     [self refreshCurrentVisibleItemIndex];
     
-    // Tell the delegate that a new Attachment has been shown and pass eventId
-    MXKMediaCollectionViewCell* cell = [[self.attachmentsCollection visibleCells] firstObject];
-    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
-    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
-        if (((isBackPaginationInProgress == YES) && (currentVisibleItemIndex == 0)) || currentVisibleItemIndex == NSNotFound) {
+    if (currentVisibleItemIndex == NSNotFound) {
+        // Tell the delegate that no attachment is displayed for the moment
+        if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)])
+        {
             [self.delegate displayedNewAttachmentWithEventId:nil];
-        } else {
-            [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
         }
     }
-    
-    if (currentVisibleItemIndex != NSNotFound)
+    else
     {
         NSInteger item = currentVisibleItemIndex;
         if (isBackPaginationInProgress)
         {
             if (item == 0)
             {
+                // Tell the delegate that no attachment is displayed for the moment
+                if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)])
+                {
+                    [self.delegate displayedNewAttachmentWithEventId:nil];
+                }
+                
                 return;
             }
             
@@ -528,6 +530,12 @@
             MXKAttachment *attachment = attachments[item];
             NSString *attachmentURL = attachment.actualURL;
             NSString *mimeType = attachment.contentInfo[@"mimetype"];
+            
+            // Tell the delegate which attachment has been shown using its eventId
+            if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)])
+            {
+                [self.delegate displayedNewAttachmentWithEventId:attachment.eventId];
+            }
             
             // Check attachment type
             if (attachment.type == MXKAttachmentTypeImage && attachmentURL.length && ![mimeType isEqualToString:@"image/gif"])

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -1094,6 +1094,12 @@
         }
     }
     
+    //tell the delegate that a new Attachment has been shown and pass eventId
+    NSString *attachmentEventId = ((MXKAttachment *)attachments[cell.tag]).eventId;
+    if ([self.delegate respondsToSelector:@selector(displayedNewAttachmentWithEventId:)]) {
+        [self.delegate displayedNewAttachmentWithEventId:attachmentEventId];
+    }
+    
     // Remove all gesture recognizers
     while (cell.gestureRecognizers.count)
     {

--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -24,6 +24,7 @@ limitations under the License.
 #import "MXKEventDetailsView.h"
 
 #import "MXKAttachmentsViewController.h"
+#import "MXKAttachmentAnimator.h"
 
 extern NSString *const kCmdChangeDisplayName;
 extern NSString *const kCmdEmote;
@@ -40,7 +41,7 @@ extern NSString *const kCmdChangeRoomTopic;
 /**
  This view controller displays messages of a room. Only one matrix session is handled by this view controller.
  */
-@interface MXKRoomViewController : MXKViewController <MXKDataSourceDelegate, MXKRoomTitleViewDelegate, MXKRoomInputToolbarViewDelegate, UITableViewDelegate, UIDocumentInteractionControllerDelegate, MXKAttachmentsViewControllerDelegate, MXKRoomActivitiesViewDelegate>
+@interface MXKRoomViewController : MXKViewController <MXKDataSourceDelegate, MXKRoomTitleViewDelegate, MXKRoomInputToolbarViewDelegate, UITableViewDelegate, UIDocumentInteractionControllerDelegate, MXKAttachmentsViewControllerDelegate, MXKRoomActivitiesViewDelegate, MXKSourceAttachmentAnimatorDelegate>
 {
 @protected
     /**

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -147,6 +147,11 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     BOOL restartConnection;
 }
 
+@property NSString *openedAttachmentEventId;
+@property NSString *closedAttachmentEventId;
+
+@property UIImageView *openedAttachmentImageView;
+
 @end
 
 @implementation MXKRoomViewController
@@ -3295,17 +3300,20 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     // Present an attachment viewer
                     if (attachmentsViewerClass)
                     {
-                        attachmentsViewer = [attachmentsViewerClass attachmentsViewController];
+                        attachmentsViewer = [attachmentsViewerClass animatedAttachmentsViewControllerWithSourceViewController:self];
                     }
                     else
                     {
-                        attachmentsViewer = [MXKAttachmentsViewController attachmentsViewController];
+                        attachmentsViewer = [MXKAttachmentsViewController animatedAttachmentsViewControllerWithSourceViewController:self];
                     }
                     
                     attachmentsViewer.delegate = self;
                     attachmentsViewer.complete = ([roomDataSource.timeline canPaginate:MXTimelineDirectionBackwards] == NO);
                     attachmentsViewer.hidesBottomBarWhenPushed = YES;
                     [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:selectedAttachment.eventId];
+                    
+                    self.openedAttachmentEventId = selectedAttachment.eventId;
+                    self.openedAttachmentImageView = ((MXKRoomBubbleTableViewCell *)cell).attachmentView.imageView;
                     
                     [self.navigationController pushViewController:attachmentsViewer animated:YES];
                 }
@@ -3430,6 +3438,10 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     [self triggerAttachmentBackPagination:eventId];
     
     return [self.roomDataSource.timeline canPaginate:MXTimelineDirectionBackwards];
+}
+
+- (void)displayedNewAttachmentWithEventId:(NSString *)eventId {
+    self.closedAttachmentEventId = eventId;
 }
 
 #pragma mark - MXKRoomActivitiesViewDelegate
@@ -3583,5 +3595,22 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     }
 }
 
+#pragma mark - MXKSourceAttachmentAnimatorDelegate
+
+- (UIImageView *)originalImageView {
+    if ([self.openedAttachmentEventId isEqualToString:self.closedAttachmentEventId]) {
+        return self.openedAttachmentImageView;
+    }
+    return nil;
+}
+
+
+- (CGRect)convertedFrameForOriginalImageView {
+    if ([self.openedAttachmentEventId isEqualToString:self.closedAttachmentEventId]) {
+        return [self.openedAttachmentImageView convertRect:self.openedAttachmentImageView.frame toView:nil];
+    }
+    //default frame which will be used if the user scrolls to other attachments in MXKAttachmentsViewController
+    return CGRectMake(CGRectGetWidth(self.view.frame)/2, 0.0, 0.0, 0.0);
+}
 
 @end

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -147,7 +147,14 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     BOOL restartConnection;
 }
 
+/**
+ The eventId of the Attachment that was used to open the Attachments ViewController
+ */
 @property NSString *openedAttachmentEventId;
+
+/**
+ The eventId of the Attachment from which the Attachments ViewController was closed
+ */
 @property NSString *closedAttachmentEventId;
 
 @property UIImageView *openedAttachmentImageView;

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -3319,8 +3319,11 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     attachmentsViewer.hidesBottomBarWhenPushed = YES;
                     [attachmentsViewer displayAttachments:attachmentsWithThumbnail focusOn:selectedAttachment.eventId];
                     
-                    self.openedAttachmentEventId = selectedAttachment.eventId;
                     self.openedAttachmentImageView = ((MXKRoomBubbleTableViewCell *)cell).attachmentView.imageView;
+                    self.openedAttachmentEventId = selectedAttachment.eventId;
+                    
+                    // "Initializing" closedAttachmentEventId so it is equal to openedAttachmentEventId at the beginning
+                    self.closedAttachmentEventId = self.openedAttachmentEventId;
                     
                     [self.navigationController pushViewController:attachmentsViewer animated:YES];
                 }


### PR DESCRIPTION
I have added animation and interaction controllers, which are reusable. Also added an option to make MXKAttachmentsViewController animatable. This pull request is the first step of https://github.com/vector-im/riot-ios/issues/1064 this issue. Afterwards, the reusable UI Elements created here will be used in Riot iOS to finish the improvement mentioned above. Please review my code.