### PR TITLE
Bug Fix: [MXSession resetRoomsSummariesLastMessage] freezes the app

### DIFF
--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1373,7 +1373,7 @@
             if ([event.sender isEqualToString:lastMessageEvent.sender])
             {
                 // The last message must be recomputed
-                [summary resetLastMessage:nil failure:nil];
+                [summary resetLastMessage:nil failure:nil commit:YES];
                 break;
             }
         }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-ios-sdk/issues/292