### PR TITLE
Clean headers to be able to build MatrixKit pod as a module

### DIFF
--- a/MatrixKit/Models/Contact/MXKPhoneNumber.h
+++ b/MatrixKit/Models/Contact/MXKPhoneNumber.h
@@ -19,7 +19,7 @@
 
 #import "MXKContactField.h"
 
-#import "NBPhoneNumberUtil.h"
+@class NBPhoneNumber;
 
 @interface MXKPhoneNumber : MXKContactField
 

--- a/MatrixKit/Models/Contact/MXKPhoneNumber.m
+++ b/MatrixKit/Models/Contact/MXKPhoneNumber.m
@@ -16,6 +16,7 @@
  */
 
 #import "MXKPhoneNumber.h"
+#import "NBPhoneNumberUtil.h"
 
 @implementation MXKPhoneNumber
 

--- a/MatrixKit/Models/Room/MXKRoomCreationInputs.h
+++ b/MatrixKit/Models/Room/MXKRoomCreationInputs.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MXSession.h"
+#import <MatrixSDK/MXSession.h>
 
 /**
  `MXKRoomCreationInputs` objects lists all the fields considered for a new room creation.

--- a/MatrixKit/Models/Room/MXKRoomCreationInputs.m
+++ b/MatrixKit/Models/Room/MXKRoomCreationInputs.m
@@ -15,6 +15,7 @@
  */
 
 #import "MXKRoomCreationInputs.h"
+#import "MXSession.h"
 
 @interface MXKRoomCreationInputs ()
 {

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -19,7 +19,6 @@
 #import "MXKCellRendering.h"
 
 #import "MXKRoomBubbleCellData.h"
-#import "MXMediaManager.h"
 
 #import "MXKImageView.h"
 #import "MXKPieChartView.h"

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.h
@@ -16,7 +16,8 @@
 
 #import "MXKRoomInputToolbarView.h"
 
-#import "HPGrowingTextView.h"
+@class HPGrowingTextView;
+@protocol HPGrowingTextViewDelegate;
 
 /**
  `MXKRoomInputToolbarViewWithHPGrowingText` is a MXKRoomInputToolbarView-inherited class in which message

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
@@ -15,6 +15,7 @@
  */
 
 #import "MXKRoomInputToolbarViewWithHPGrowingText.h"
+#import <HPGrowingTextView/HPGrowingTextView.h>
 
 @interface MXKRoomInputToolbarViewWithHPGrowingText()
 {

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.h
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.h
@@ -20,8 +20,7 @@
 #import "MXKPieChartView.h"
 
 #import "MXKCellRendering.h"
-
-#import "MXUser.h"
+@class MXUser, MXSession;
 
 /**
  `MXKRoomMemberTableViewCell` instances display a user in the context of the room member list.

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
@@ -26,6 +26,7 @@
 #import "NSBundle+MatrixKit.h"
 
 #import "MXKTools.h"
+#import <MatrixSDK/MXUser.h>
 
 @interface MXKRoomMemberTableViewCell ()
 {


### PR DESCRIPTION
Oserwise, you can't use MatrixKit files in swift files