### PR TITLE
Read markers should be synchronised across clients

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -88,6 +88,12 @@ extern NSString *const kCmdChangeRoomTopic;
 @property (nonatomic) BOOL hasRoomDataSourceOwnership;
 
 /**
+ Tell whether the room read marker must be updated when an event is acknowledged with a read receipt.
+ Default is NO.
+ */
+@property (nonatomic) BOOL updateRoomReadMarker;
+
+/**
  The current title view defined into the view controller.
  */
 @property (nonatomic, readonly) MXKRoomTitleView* titleView;

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -218,6 +218,9 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     // Do not take ownership of room data source by default
     _hasRoomDataSourceOwnership = NO;
     
+    // Do not update the read marker by default.
+    _updateRoomReadMarker = NO;
+    
     // Scroll to the bottom when a keyboard is presented
     _scrollHistoryToTheBottomOnKeyboardPresentation = YES;
 }
@@ -661,12 +664,6 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
             // Remove the input toolbar in case of peeking.
             // We do not let the user type message in this case.
             [self setRoomInputToolbarViewClass:nil];
-        }
-        else
-        {
-            // The view controller is going to display all unread messages
-            // Automatically reset the counters
-            [dataSource markAllAsRead];
         }
         
         roomDataSource = dataSource;
@@ -1690,6 +1687,11 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                 isScrollingToBottom = YES;
                 [_bubblesTableView setContentOffset:CGPointMake(0, wantedOffsetY) animated:animated];
             }
+            else
+            {
+                // upateCurrentEventIdAtTableBottom must be called here (it is usually called by the scrollview delegate at the end of scrolling).
+                [self updateCurrentEventIdAtTableBottom:YES];
+            }
         }
         else
         {
@@ -2281,8 +2283,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                         
                         if (acknowledge)
                         {
-                            // Indicate to the homeserver that the user has read up to this event.
-                            [self.roomDataSource.room acknowledgeEvent:component.event];
+                            // Indicate to the homeserver that the user has read this event.
+                            [self.roomDataSource.room acknowledgeEvent:component.event andUpdateReadMarker:_updateRoomReadMarker];
                         }
                         
                         break;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -166,6 +166,11 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic) BOOL useCustomDateTimeLabel;
 
 /**
+ Show the read marker (if any) in the rendered room bubble cells. YES by default.
+ */
+@property (nonatomic) BOOL showReadMarker;
+
+/**
  Show the receipts in rendered bubble cell. YES by default.
  */
 @property (nonatomic) BOOL showBubbleReceipts;
@@ -425,7 +430,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  The echo message corresponding to the event will be removed and a new echo message
  will be added at the end of the room history.
 
- @param the id of the event to resend.
+ @param eventId of the event to resend.
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the home server
  @param failure A block object called when the operation fails.
@@ -439,7 +444,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 /**
  Get an event loaded in this room datasource.
 
- @param the id of the event to retrieve.
+ @param eventId of the event to retrieve.
  @return the MXEvent object or nil if not found.
  */
 - (MXEvent *)eventWithEventId:(NSString *)eventId;
@@ -447,7 +452,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 /**
  Remove an event from the events loaded by room datasource.
 
- @param the id of the event to remove.
+ @param eventId of the event to remove.
  */
 - (void)removeEventWithEventId:(NSString *)eventId;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -148,6 +148,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         // display the read receips by default
         self.showBubbleReceipts = YES;
         
+        // show the read marker by default
+        self.showReadMarker = YES;
+        
         // Disable typing notification in cells by default.
         self.showTypingNotifications = NO;
         

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -209,8 +209,19 @@ extern NSString *const kMXKRoomBubbleCellUrl;
  */
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *bubbleInfoContainerTopConstraint;
 
-- (void)startProgressUI;
+/**
+ The read marker view and its layout constraints (nil by default).
+ */
+@property (nonatomic) UIView *readMarkerView;
+@property (nonatomic) NSLayoutConstraint *readMarkerViewTopConstraint;
+@property (nonatomic) NSLayoutConstraint *readMarkerViewLeadingConstraint;
+@property (nonatomic) NSLayoutConstraint *readMarkerViewTrailingConstraint;
+@property (nonatomic) NSLayoutConstraint *readMarkerViewHeightConstraint;
 
+/**
+ Handle progressView display.
+ */
+- (void)startProgressUI;
 - (void)updateProgressUI:(NSDictionary*)statisticsDict;
 
 #pragma mark - Original Xib values

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -649,9 +649,26 @@ static BOOL _disableLongPressGestureOnEvent;
     return rowHeight;
 }
 
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    
+    [self didEndDisplay];
+}
+
 - (void)didEndDisplay
 {
     bubbleData = nil;
+    
+    if (_readMarkerView)
+    {
+        [_readMarkerView removeFromSuperview];
+        _readMarkerView = nil;
+        _readMarkerViewTopConstraint = nil;
+        _readMarkerViewLeadingConstraint = nil;
+        _readMarkerViewTrailingConstraint = nil;
+        _readMarkerViewHeightConstraint = nil;
+    }
     
     if (self.attachmentView)
     {


### PR DESCRIPTION
- MXKRoomViewController: Remove the historic counters reset when a room data source is set. The counters are updated automatically when the table view is rendered (by acknowledging the last displayed event). Add the `updateRoomReadMarker` property to tell whether the read marker should follow the event acknowledgement.
- MXKRoomDataSource: add `showReadMarker` property to handle read marker display.
- MXKRoomBubbleTableViewCell: add a `readMarkerView` property to track the potential marker added into a room bubble.

Note: Nothing is done FTM at the matrix-ios-kit level to render the read marker.

vector-im/riot-meta#8