### PR TITLE
Improvements for PR #282

### DIFF
--- a/MatrixKit/Models/Contact/MXKPhoneNumber.m
+++ b/MatrixKit/Models/Contact/MXKPhoneNumber.m
@@ -16,6 +16,7 @@
  */
 
 #import "MXKPhoneNumber.h"
+
 #import "NBPhoneNumberUtil.h"
 
 @implementation MXKPhoneNumber

--- a/MatrixKit/Models/Room/MXKRoomCreationInputs.h
+++ b/MatrixKit/Models/Room/MXKRoomCreationInputs.h
@@ -15,8 +15,11 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIImage.h>
 
-#import <MatrixSDK/MXSession.h>
+#import <MatrixSDK/MXEnumConstants.h>
+
+@class MXSession;
 
 /**
  `MXKRoomCreationInputs` objects lists all the fields considered for a new room creation.

--- a/MatrixKit/Models/Room/MXKRoomCreationInputs.m
+++ b/MatrixKit/Models/Room/MXKRoomCreationInputs.m
@@ -15,7 +15,8 @@
  */
 
 #import "MXKRoomCreationInputs.h"
-#import "MXSession.h"
+
+#import <MatrixSDK/MXSession.h>
 
 @interface MXKRoomCreationInputs ()
 {

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -15,14 +15,12 @@
  */
 
 #import "MXKTableViewCell.h"
-
 #import "MXKCellRendering.h"
-
-#import "MXKRoomBubbleCellData.h"
-
-#import "MXKImageView.h"
-#import "MXKPieChartView.h"
 #import "MXKReceiptSendersContainer.h"
+
+@class MXKImageView;
+@class MXKPieChartView;
+@class MXKRoomBubbleCellData;
 
 #pragma mark - MXKCellRenderingDelegate cell tap locations
 

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -16,9 +16,12 @@
 
 #import "MXKRoomBubbleTableViewCell.h"
 
-#import "NSBundle+MatrixKit.h"
-
+#import "MXKImageView.h"
+#import "MXKPieChartView.h"
+#import "MXKRoomBubbleCellData.h"
 #import "MXKTools.h"
+
+#import "NSBundle+MatrixKit.h"
 
 #pragma mark - Constant definitions
 NSString *const kMXKRoomBubbleCellTapOnMessageTextView = @"kMXKRoomBubbleCellTapOnMessageTextView";

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.h
@@ -16,8 +16,7 @@
 
 #import "MXKRoomInputToolbarView.h"
 
-@class HPGrowingTextView;
-@protocol HPGrowingTextViewDelegate;
+#import <HPGrowingTextView/HPGrowingTextView.h>
 
 /**
  `MXKRoomInputToolbarViewWithHPGrowingText` is a MXKRoomInputToolbarView-inherited class in which message

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
@@ -15,7 +15,6 @@
  */
 
 #import "MXKRoomInputToolbarViewWithHPGrowingText.h"
-#import <HPGrowingTextView/HPGrowingTextView.h>
 
 @interface MXKRoomInputToolbarViewWithHPGrowingText()
 {

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.h
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.h
@@ -15,12 +15,11 @@
  */
 
 #import "MXKTableViewCell.h"
-
-#import "MXKImageView.h"
-#import "MXKPieChartView.h"
-
 #import "MXKCellRendering.h"
-@class MXUser, MXSession;
+
+@class MXKImageView;
+@class MXKPieChartView;
+@class MXSession;
 
 /**
  `MXKRoomMemberTableViewCell` instances display a user in the context of the room member list.

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
@@ -16,17 +16,17 @@
 
 #import "MXKRoomMemberTableViewCell.h"
 
-#import "MXKRoomMemberCellDataStoring.h"
-
-#import "MXKRoomMemberListDataSource.h"
-
-#import "MXMediaManager.h"
 #import "MXKAccount.h"
+#import "MXKImageView.h"
+#import "MXMediaManager.h"
+#import "MXKPieChartView.h"
+#import "MXKRoomMemberCellDataStoring.h"
+#import "MXKRoomMemberListDataSource.h"
+#import "MXKTools.h"
 
 #import "NSBundle+MatrixKit.h"
 
-#import "MXKTools.h"
-#import <MatrixSDK/MXUser.h>
+#import <MatrixSDK/MXSession.h>
 
 @interface MXKRoomMemberTableViewCell ()
 {


### PR DESCRIPTION
There is an issue with PR #282. The problem is `MXKRoomInputToolbarViewWithHPGrowingText`.  Code from this PR is incorrect since we can't use forward declaration while putting protocol conformance into the header. This is why Riot builds with fails on develop branch.

I tried to put protocol conformance into implementation file but then i figured out that in Riot in the `RoomInputToolbarView` class `HPGrowingTextViewDelegate` methods are overloaded and one of them calls parent implementation, so we can't hide protocol conformance. So i decided to revert changes in this file.

As for other files, i make the most of forward declaration in these files.

I test all my changes on Riot app and everything works fine.