### PR TITLE
Prevent MXKAlert from being retained in action handler

### DIFF
--- a/MatrixKit/Views/MXKAlert.m
+++ b/MatrixKit/Views/MXKAlert.m
@@ -78,13 +78,14 @@
     {
         index = [(UIAlertController *)_alert actions].count;
         
+        __weak typeof(self) weakSelf = self;
         UIAlertAction* action = [UIAlertAction actionWithTitle:title
                                                          style:(UIAlertActionStyle)style
                                                        handler:^(UIAlertAction * action) {
                                                            
                                                            if (handler)
                                                            {
-                                                               handler(self);
+                                                               handler(weakSelf);
                                                            }
                                                            
                                                        }];


### PR DESCRIPTION
I found an interesting case while i was debugging issue with CallViewController. Sometimes instead of calling `dissmis:` method of `MKAlert` to hide alert, an internal variable of view controller is set to nil. And this situation introduced retain cycle. `dismiss` method release it's internal `alert` property while its called and we don't meet any retain cycle. But if the user dismiss alert just by setting variable to nil, we say hello to retain cycle. Instead of finding all of places like in the example below, it's easier to pass `weakSelf` into handler and the problem is gone.

```Objective-C
callActionSheet = [[MXKAlert alloc] initWithTitle:nil message:nil style:MXKAlertStyleActionSheet];

__weak typeof(self) weakSelf = self;
[callActionSheet addActionWithTitle:NSLocalizedStringFromTable(@"voice", @"Vector", nil) style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert) {
     __strong __typeof(weakSelf)strongSelf = weakSelf;
     strongSelf->callActionSheet = nil;

     [strongSelf.delegate roomInputToolbarView:strongSelf placeCallWithVideo:NO];
}];
```

Signed-off-by: Denis Morozov dmorozkn@gmail.com