### PR TITLE
Read marker - MXKRoomViewController: Improve bubbles table view display.

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -99,8 +99,8 @@ extern NSString *const kCmdChangeRoomTopic;
 @property (nonatomic) BOOL updateRoomReadMarker;
 
 /**
- When the room view controller displays a room data source based on a timeline with an initial event.
- The bubble table view content is scrolled by default to display the top of this event at the center of the screen
+ When the room view controller displays a room data source based on a timeline with an initial event,
+ the bubble table view content is scrolled by default to display the top of this event at the center of the screen
  the first time it appears.
  Use this property to force the table view to center its content on the bottom part of the event.
  Default is NO.

--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -99,6 +99,15 @@ extern NSString *const kCmdChangeRoomTopic;
 @property (nonatomic) BOOL updateRoomReadMarker;
 
 /**
+ When the room view controller displays a room data source based on a timeline with an initial event.
+ The bubble table view content is scrolled by default to display the top of this event at the center of the screen
+ the first time it appears.
+ Use this property to force the table view to center its content on the bottom part of the event.
+ Default is NO.
+ */
+@property (nonatomic) BOOL centerBubblesTableViewContentOnTheInitialEventBottom;
+
+/**
  The current title view defined into the view controller.
  */
 @property (nonatomic, readonly) MXKRoomTitleView* titleView;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -272,4 +272,14 @@ extern NSString *const kMXKRoomBubbleCellUrl;
  */
 - (CGFloat)topPositionOfEvent:(NSString*)eventId;
 
+/**
+ The bottom position of an event in the cell.
+ 
+ A cell can display several events. The method returns the vertical position of the bottom part
+ of a given event in the cell.
+ 
+ @return the y position (in pixel) of the bottom part of the event in the cell.
+ */
+- (CGFloat)bottomPositionOfEvent:(NSString*)eventId;
+
 @end

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -249,6 +249,30 @@ static BOOL _disableLongPressGestureOnEvent;
     return topPositionOfEvent;
 }
 
+- (CGFloat)bottomPositionOfEvent:(NSString*)eventId
+{
+    CGFloat bottomPositionOfEvent = self.frame.size.height - self.msgTextViewBottomConstraint.constant;
+    
+    // Parse each component by the end of the array in order to compute the bottom position.
+    NSArray *bubbleComponents = bubbleData.bubbleComponents;
+    NSInteger index = bubbleComponents.count;
+    
+    while (index --)
+    {
+        MXKRoomBubbleComponent *component = bubbleComponents[index];
+        if ([component.event.eventId isEqualToString:eventId])
+        {
+            break;
+        }
+        else
+        {
+            // Update the bottom position
+            bottomPositionOfEvent = component.position.y + self.msgTextViewTopConstraint.constant;
+        }
+    }
+    return bottomPositionOfEvent;
+}
+
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated
 {
     [super setSelected:selected animated:animated];


### PR DESCRIPTION
When the room view controller displays is based on a timeline with an initial event.
The bubble table view content is scrolled by default to display the top of this event at the center of the screen the first time it appears.
We introduce here a new property `centerBubblesTableViewContentOnTheInitialEventBottom` to let the table view center its content on the bottom part of the event. This will be useful to jump to the last unread message and display the marker view.