### PR TITLE
Read marker

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		F05FB1811AD6643900DC0647 /* MXKRoomMemberTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F05FB17F1AD6643900DC0647 /* MXKRoomMemberTableViewCell.m */; };
 		F05FB1821AD6643900DC0647 /* MXKRoomMemberTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F05FB1801AD6643900DC0647 /* MXKRoomMemberTableViewCell.xib */; };
 		F066F5231B2B130A00835880 /* MatrixKitAssets.bundle in Resources */ = {isa = PBXBuildFile; fileRef = F066F5221B2B130A00835880 /* MatrixKitAssets.bundle */; };
+		F06CDD5F1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F06CDD5D1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.m */; };
+		F06CDD601EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F06CDD5E1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.xib */; };
 		F06E76811AF0FEB100980E5A /* MXKAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F06E767F1AF0FEB100980E5A /* MXKAuthenticationViewController.m */; };
 		F06E76821AF0FEB100980E5A /* MXKAuthenticationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F06E76801AF0FEB100980E5A /* MXKAuthenticationViewController.xib */; };
 		F06E76881AF0FEBC00980E5A /* MXKAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = F06E76851AF0FEBC00980E5A /* MXKAccount.m */; };
@@ -380,6 +382,9 @@
 		F05FB17F1AD6643900DC0647 /* MXKRoomMemberTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomMemberTableViewCell.m; sourceTree = "<group>"; };
 		F05FB1801AD6643900DC0647 /* MXKRoomMemberTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MXKRoomMemberTableViewCell.xib; sourceTree = "<group>"; };
 		F066F5221B2B130A00835880 /* MatrixKitAssets.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MatrixKitAssets.bundle; sourceTree = "<group>"; };
+		F06CDD5C1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomEmptyBubbleTableViewCell.h; sourceTree = "<group>"; };
+		F06CDD5D1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomEmptyBubbleTableViewCell.m; sourceTree = "<group>"; };
+		F06CDD5E1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MXKRoomEmptyBubbleTableViewCell.xib; sourceTree = "<group>"; };
 		F06E767E1AF0FEB100980E5A /* MXKAuthenticationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKAuthenticationViewController.h; sourceTree = "<group>"; };
 		F06E767F1AF0FEB100980E5A /* MXKAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKAuthenticationViewController.m; sourceTree = "<group>"; };
 		F06E76801AF0FEB100980E5A /* MXKAuthenticationViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MXKAuthenticationViewController.xib; sourceTree = "<group>"; };
@@ -786,6 +791,9 @@
 			children = (
 				328AC4841AA75E000044A6FB /* MXKRoomBubbleTableViewCell.h */,
 				328AC4851AA75E000044A6FB /* MXKRoomBubbleTableViewCell.m */,
+				F06CDD5C1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.h */,
+				F06CDD5D1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.m */,
+				F06CDD5E1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.xib */,
 				328AC4871AA75EDD0044A6FB /* MXKRoomIncomingBubbleTableViewCell.h */,
 				328AC4881AA75EDD0044A6FB /* MXKRoomIncomingBubbleTableViewCell.m */,
 				F00FA8531C0864FA00E25826 /* MXKRoomIncomingTextMsgBubbleCell.h */,
@@ -1324,6 +1332,7 @@
 				F0CF98CA1B0B63B900EAE373 /* MXKAccountDetailsViewController.xib in Resources */,
 				3235CD7C1C32DEBF0084EA40 /* MXKSearchViewController.xib in Resources */,
 				F06E76961AF0FED000980E5A /* MXKAuthInputsEmailCodeBasedView.xib in Resources */,
+				F06CDD601EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.xib in Resources */,
 				F094D15F1ACC8B9300994F67 /* MXKRoomInputToolbarViewWithSimpleTextView.xib in Resources */,
 				3235CD821C33D3EA0084EA40 /* MXKSearchTableViewCell.xib in Resources */,
 				F01449AC1B53FA7600EA7D73 /* MXKPushRuleTableViewCell.xib in Resources */,
@@ -1396,7 +1405,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		31DF541766F395AA9A742AC8 /* [CP] Copy Pods Resources */ = {
@@ -1456,7 +1465,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		FC08C2D46757964161ED45BA /* [CP] Embed Pods Frameworks */ = {
@@ -1553,6 +1562,7 @@
 				F07D74AC1AC5A29800D83B98 /* MXKEventDetailsView.m in Sources */,
 				32FBDAFB1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m in Sources */,
 				F0EA4CB11ADD6E5D007197D2 /* MXKAlert.m in Sources */,
+				F06CDD5F1EF017CB00870B75 /* MXKRoomEmptyBubbleTableViewCell.m in Sources */,
 				F01449AD1B53FA7600EA7D73 /* MXKPushRuleCreationTableViewCell.m in Sources */,
 				3235CD771C32DC8A0084EA40 /* MXKSearchDataSource.m in Sources */,
 				F0CF98DD1B0B7FDC00EAE373 /* MXKTableViewCellWithLabelAndSubLabel.m in Sources */,

--- a/MatrixKit/MatrixKit.h
+++ b/MatrixKit/MatrixKit.h
@@ -103,6 +103,8 @@
 #import "MXKRoomTitleView.h"
 #import "MXKRoomTitleViewWithTopic.h"
 
+#import "MXKRoomEmptyBubbleTableViewCell.h"
+
 #import "MXKRoomIncomingBubbleTableViewCell.h"
 #import "MXKRoomIncomingTextMsgBubbleCell.h"
 #import "MXKRoomIncomingTextMsgWithoutSenderInfoBubbleCell.h"

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1025,16 +1025,17 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         // Apply first the event filter defined in the related room data source
         MXKRoomDataSourceManager *roomDataSourceManager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:mxSession];
         MXKRoomDataSource *roomDataSource = [roomDataSourceManager roomDataSourceForRoom:event.roomId create:NO];
-        if (!roomDataSource || [roomDataSource.eventsFilterForMessages indexOfObject:event.type] == NSNotFound)
-        {
-            // Ignore
-            return;
-        }
         
-        // Check conditions to report this notification
-        if (nil == ignoredRooms || [ignoredRooms indexOfObject:event.roomId] == NSNotFound)
+        if (roomDataSource)
         {
-            onNotification(event, roomState, rule);
+            if (!roomDataSource.eventFormatter.eventTypesFilterForMessages || [roomDataSource.eventFormatter.eventTypesFilterForMessages indexOfObject:event.type] != NSNotFound)
+            {
+                // Check conditions to report this notification
+                if (nil == ignoredRooms || [ignoredRooms indexOfObject:event.roomId] == NSNotFound)
+                {
+                    onNotification(event, roomState, rule);
+                }
+            }
         }
     }];
 }

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -37,11 +37,15 @@
 @property (nonatomic) BOOL showAllEventsInRoomHistory;
 
 /**
- The type of events to display allowed to be displayed in room history.
- 
+ The types of events allowed to be displayed in room history.
  Its value depends on `showAllEventsInRoomHistory`.
  */
 @property (nonatomic, readonly) NSArray *eventsFilterForMessages;
+
+/**
+ All the event types which may be displayed in the room history.
+ */
+@property (nonatomic, readonly) NSArray *allEventTypesForMessages;
 
 /**
  Display redacted events in room history.

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -150,26 +150,8 @@ static MXKAppSettings *standardAppSettings = nil;
 {
     if (showAllEventsInRoomHistory)
     {
-        // Use a filter to retrieve all the events (except kMXEventTypeStringPresence which are not related to a specific room)
-        return @[
-                 kMXEventTypeStringRoomName,
-                 kMXEventTypeStringRoomTopic,
-                 kMXEventTypeStringRoomMember,
-                 kMXEventTypeStringRoomCreate,
-                 kMXEventTypeStringRoomEncrypted,
-                 kMXEventTypeStringRoomEncryption,
-                 kMXEventTypeStringRoomJoinRules,
-                 kMXEventTypeStringRoomPowerLevels,
-                 kMXEventTypeStringRoomAliases,
-                 kMXEventTypeStringRoomHistoryVisibility,
-                 kMXEventTypeStringRoomMessage,
-                 kMXEventTypeStringRoomMessageFeedback,
-                 kMXEventTypeStringRoomRedaction,
-                 kMXEventTypeStringRoomThirdPartyInvite,
-                 kMXEventTypeStringCallInvite,
-                 kMXEventTypeStringCallAnswer,
-                 kMXEventTypeStringCallHangup
-                 ];
+        // Consider all the event types
+        return self.allEventTypesForMessages;
     }
     else
     {
@@ -188,6 +170,30 @@ static MXKAppSettings *standardAppSettings = nil;
                  kMXEventTypeStringCallHangup
                  ];
     }
+}
+
+- (NSArray *)allEventTypesForMessages
+{
+    // List all the event types, except kMXEventTypeStringPresence which are not related to a specific room.
+    return @[
+             kMXEventTypeStringRoomName,
+             kMXEventTypeStringRoomTopic,
+             kMXEventTypeStringRoomMember,
+             kMXEventTypeStringRoomCreate,
+             kMXEventTypeStringRoomEncrypted,
+             kMXEventTypeStringRoomEncryption,
+             kMXEventTypeStringRoomJoinRules,
+             kMXEventTypeStringRoomPowerLevels,
+             kMXEventTypeStringRoomAliases,
+             kMXEventTypeStringRoomHistoryVisibility,
+             kMXEventTypeStringRoomMessage,
+             kMXEventTypeStringRoomMessageFeedback,
+             kMXEventTypeStringRoomRedaction,
+             kMXEventTypeStringRoomThirdPartyInvite,
+             kMXEventTypeStringCallInvite,
+             kMXEventTypeStringCallAnswer,
+             kMXEventTypeStringCallHangup
+             ];
 }
 
 - (BOOL)showRedactionsInRoomHistory

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -26,7 +26,7 @@
 @implementation MXKRoomBubbleCellData
 @synthesize senderId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment;
 @synthesize textMessage, attributedTextMessage;
-@synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel, useCustomReceipts, useCustomUnsentButton;
+@synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel, useCustomReceipts, useCustomUnsentButton, hasNoDisplay;
 
 #pragma mark - MXKRoomBubbleCellDataStoring
 
@@ -517,6 +517,11 @@
     }
     
     return nil;
+}
+
+- (BOOL)hasNoDisplay
+{
+    return (self.attributedTextMessage == nil && !attachment);
 }
 
 - (BOOL)isAttachmentWithThumbnail

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -69,6 +69,11 @@
 @property (nonatomic) BOOL shouldHideSenderInformation;
 
 /**
+ Tell whether this bubble has nothing to display (neither a message nor an attachment).
+ */
+@property (nonatomic) BOOL hasNoDisplay;
+
+/**
  The list of events (`MXEvent` instances) handled by this bubble.
  */
 @property (nonatomic, readonly) NSArray *events;

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -185,7 +185,7 @@ static NSAttributedString *messageSeparator = nil;
                 }
             }
             
-            for (; index < bubbleComponents.count; index++)
+            for (index++; index < bubbleComponents.count; index++)
             {
                 // Append the next text component
                 component = [bubbleComponents objectAtIndex:index];

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -29,32 +29,25 @@
         MXKEventFormatterError error;
 
         NSAttributedString *eventString = [_eventFormatter attributedStringFromEvent:event withRoomState:roomState error:&error];
-        if (eventString.length)
+        
+        // Store the potential error
+        event.mxkEventFormatterError = error;
+        
+        _textMessage = nil;
+        _attributedTextMessage = eventString;
+        
+        // Set date time
+        if (event.originServerTs != kMXUndefinedTimestamp)
         {
-            // Store the potential error
-            event.mxkEventFormatterError = error;
-
-            _textMessage = nil;
-            _attributedTextMessage = eventString;
-
-            // Set date time
-            if (event.originServerTs != kMXUndefinedTimestamp)
-            {
-                _date = [NSDate dateWithTimeIntervalSince1970:(double)event.originServerTs/1000];
-            }
-            else
-            {
-                _date = nil;
-            }
-            
-            // Keep ref on event (used in case of redaction)
-            _event = event;
+            _date = [NSDate dateWithTimeIntervalSince1970:(double)event.originServerTs/1000];
         }
         else
         {
-            // Ignore this event
-            self = nil;
+            _date = nil;
         }
+        
+        // Keep ref on event (used to handle the read marker, or a potential event redaction).
+        _event = event;
     }
     return self;
 }

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -145,12 +145,9 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 
 #pragma mark - Configuration
 /**
- The type of events to display as messages.
- */
-@property (nonatomic) NSArray *eventsFilterForMessages;
-
-/**
- The events to display texts formatter.
+ The text formatter applied on the events.
+ By default, the events are filtered according to the value stored in the shared application settings (see [MXKAppSettings standardAppSettings].eventsFilterForMessages).
+ The events whose the type doesn't belong to the this list are not displayed.
  `MXKRoomBubbleCellDataStoring` instances can use it to format text.
  */
 @property (nonatomic) MXKEventFormatter *eventFormatter;
@@ -209,9 +206,6 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 
 /**
  Tell whether only the events with a url key in their content must be handled. NO by default.
- 
- @discussion: When this option is enabled the 'eventsFilterForMessages' array is updated
- and limited to the 'kMXEventTypeStringRoomMessage' type.
  */
 @property (nonatomic) BOOL filterMessagesWithURL;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -144,6 +144,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         
         // Set default MXEvent -> NSString formatter
         self.eventFormatter = [[MXKEventFormatter alloc] initWithMatrixSession:self.mxSession];
+        // Apply here the event types filter to display only the wanted event types.
+        self.eventFormatter.eventTypesFilterForMessages = [MXKAppSettings standardAppSettings].eventsFilterForMessages;
         
         // display the read receips by default
         self.showBubbleReceipts = YES;
@@ -160,9 +162,6 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         
         _maxBackgroundCachedBubblesCount = MXKROOMDATASOURCE_CACHED_BUBBLES_COUNT_THRESHOLD;
         _paginationLimitAroundInitialEvent = MXKROOMDATASOURCE_PAGINATION_LIMIT_AROUND_INITIAL_EVENT;
-        
-        // Check here whether the app user wants to display all the events
-        self.eventsFilterForMessages = [MXKAppSettings standardAppSettings].eventsFilterForMessages;
 
         // Observe UIApplicationSignificantTimeChangeNotification to refresh bubbles if date/time are shown.
         // UIApplicationSignificantTimeChangeNotification is posted if DST is updated, carrier time is updated
@@ -429,8 +428,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         
                     }];
 
-                    // Force to set the filter at the MXRoom level
-                    self.eventsFilterForMessages = _eventsFilterForMessages;
+                    // Add the event listeners, by considering all the event types (the event filtering is applying by the event formatter).
+                    [self refreshEventListeners:[MXKAppSettings standardAppSettings].allEventTypesForMessages];
 
                     // display typing notifications is optional
                     // the inherited class can manage them by its own.
@@ -463,8 +462,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     // Less things need to configured
                     _timeline = [_room timelineOnEvent:initialEventId];
 
-                    // Force to set the filter at the MXRoom level
-                    self.eventsFilterForMessages = _eventsFilterForMessages;
+                    // Add the event listeners, by considering all the event types (the event filtering is applying by the event formatter).
+                    [self refreshEventListeners:[MXKAppSettings standardAppSettings].allEventTypesForMessages];
 
                     // Preload the state and some messages around the initial event
                     [_timeline resetPaginationAroundInitialEventWithLimit:_paginationLimitAroundInitialEvent success:^{
@@ -538,9 +537,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     _room.partialTextMessage = partialTextMessage;
 }
 
-- (void)setEventsFilterForMessages:(NSArray *)eventsFilterForMessages
+- (void)refreshEventListeners:(NSArray *)liveEventTypesFilterForMessages
 {
-    // Remove the previous live listener
+    // Remove the existing listeners
     if (liveEventsListener)
     {
         [_timeline removeListener:liveEventsListener];
@@ -552,9 +551,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     // Events for past timelines come only from pagination request
     if (_isLive)
     {
-        // And register a new one with the requested filter
-        _eventsFilterForMessages = [eventsFilterForMessages copy];
-        liveEventsListener = [_timeline listenToEventsOfTypes:_eventsFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+        // Register a new one with the requested filter
+        liveEventsListener = [_timeline listenToEventsOfTypes:liveEventTypesFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             if (MXTimelineDirectionForwards == direction)
             {
                 // Check for local echo suppression
@@ -678,7 +676,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     
     if (filterMessagesWithURL)
     {
-        self.eventsFilterForMessages = @[kMXEventTypeStringRoomMessage];
+        [self refreshEventListeners:@[kMXEventTypeStringRoomMessage]];
     }
 }
 
@@ -895,7 +893,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
     
     // Define a new listener for this pagination
-    paginationListener = [_timeline listenToEventsOfTypes:_eventsFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction2, MXRoomState *roomState) {
+    paginationListener = [_timeline listenToEventsOfTypes:[MXKAppSettings standardAppSettings].allEventTypesForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction2, MXRoomState *roomState) {
         
         if (direction2 == direction)
         {
@@ -1523,7 +1521,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     id<MXKRoomBubbleCellDataStoring> firstCellData = bubbles.firstObject;
                     
                     firstCellData.isPaginationFirstBubble = ((self.bubblesPagination == MXKRoomDataSourceBubblesPaginationPerDay) && firstCellData.date);
-                    firstCellData.shouldHideSenderInformation = NO;
+                    
+                    // Keep visible the sender information by default, except if the bubble is composed only by ignored events.
+                    firstCellData.shouldHideSenderInformation = (firstCellData.attributedTextMessage == nil);
                 }
                 else if (index < bubbles.count)
                 {
@@ -1566,8 +1566,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         }
                         
                         // Check whether the sender information is relevant for this bubble.
-                        cellData2.shouldHideSenderInformation = NO;
-                        if (cellData2.isPaginationFirstBubble == NO)
+                        // Check first if the bubble is not composed only by ignored events.
+                        cellData2.shouldHideSenderInformation = (cellData2.attributedTextMessage == nil);
+                        if (!cellData2.shouldHideSenderInformation && cellData2.isPaginationFirstBubble == NO)
                         {
                             // Check whether the neighbor bubbles have been sent by the same user.
                             cellData2.shouldHideSenderInformation = [cellData2 hasSameSenderAsBubbleCellData:cellData1];
@@ -1996,18 +1997,19 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                     bubbleData.isPaginationFirstBubble = NO;
                                 }
 
-                                // Sender information are required for this new first bubble data
-                                bubbleData.shouldHideSenderInformation = NO;
+                                // Sender information are required for this new first bubble data,
+                                // except if the bubble is composed only by ignored events.
+                                bubbleData.shouldHideSenderInformation = (bubbleData.attributedTextMessage == nil);
 
                                 // Check whether this information is relevant for the current first bubble.
-                                if (bubblesSnapshot.count)
+                                if (!bubbleData.shouldHideSenderInformation && bubblesSnapshot.count)
                                 {
                                     id<MXKRoomBubbleCellDataStoring> previousFirstBubbleData = bubblesSnapshot.firstObject;
 
                                     if (previousFirstBubbleData.isPaginationFirstBubble == NO)
                                     {
                                         // Check whether the current first bubble has been sent by the same user.
-                                        previousFirstBubbleData.shouldHideSenderInformation = [previousFirstBubbleData hasSameSenderAsBubbleCellData:bubbleData];
+                                        previousFirstBubbleData.shouldHideSenderInformation |= [previousFirstBubbleData hasSameSenderAsBubbleCellData:bubbleData];
                                     }
                                 }
 
@@ -2056,8 +2058,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                 }
 
                                 // Check whether the sender information is relevant for this new bubble.
-                                bubbleData.shouldHideSenderInformation = NO;
-                                if (bubblesSnapshot.count && (bubbleData.isPaginationFirstBubble == NO))
+                                bubbleData.shouldHideSenderInformation = (bubbleData.attributedTextMessage == nil);
+                                if (!bubbleData.shouldHideSenderInformation && bubblesSnapshot.count && (bubbleData.isPaginationFirstBubble == NO))
                                 {
                                     // Check whether the previous bubble has been sent by the same user.
                                     id<MXKRoomBubbleCellDataStoring> previousLastBubbleData = bubblesSnapshot.lastObject;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1522,8 +1522,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     
                     firstCellData.isPaginationFirstBubble = ((self.bubblesPagination == MXKRoomDataSourceBubblesPaginationPerDay) && firstCellData.date);
                     
-                    // Keep visible the sender information by default, except if the bubble is composed only by ignored events.
-                    firstCellData.shouldHideSenderInformation = (firstCellData.attributedTextMessage == nil);
+                    // Keep visible the sender information by default,
+                    // except if the bubble has no display (composed only by ignored events).
+                    firstCellData.shouldHideSenderInformation = firstCellData.hasNoDisplay;
                 }
                 else if (index < bubbles.count)
                 {
@@ -1567,7 +1568,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         
                         // Check whether the sender information is relevant for this bubble.
                         // Check first if the bubble is not composed only by ignored events.
-                        cellData2.shouldHideSenderInformation = (cellData2.attributedTextMessage == nil);
+                        cellData2.shouldHideSenderInformation = cellData2.hasNoDisplay;
                         if (!cellData2.shouldHideSenderInformation && cellData2.isPaginationFirstBubble == NO)
                         {
                             // Check whether the neighbor bubbles have been sent by the same user.
@@ -1998,8 +1999,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                 }
 
                                 // Sender information are required for this new first bubble data,
-                                // except if the bubble is composed only by ignored events.
-                                bubbleData.shouldHideSenderInformation = (bubbleData.attributedTextMessage == nil);
+                                // except if the bubble has no display (composed only by ignored events).
+                                bubbleData.shouldHideSenderInformation = bubbleData.hasNoDisplay;
 
                                 // Check whether this information is relevant for the current first bubble.
                                 if (!bubbleData.shouldHideSenderInformation && bubblesSnapshot.count)
@@ -2058,7 +2059,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                                 }
 
                                 // Check whether the sender information is relevant for this new bubble.
-                                bubbleData.shouldHideSenderInformation = (bubbleData.attributedTextMessage == nil);
+                                bubbleData.shouldHideSenderInformation = bubbleData.hasNoDisplay;
                                 if (!bubbleData.shouldHideSenderInformation && bubblesSnapshot.count && (bubbleData.isPaginationFirstBubble == NO))
                                 {
                                     // Check whether the previous bubble has been sent by the same user.

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -105,9 +105,17 @@ typedef enum : NSUInteger {
 - (void)initDateTimeFormatters;
 
 /**
+ The types of events allowed to be displayed in the room history.
+ No string will be returned by the formatter for the events whose the type doesn't belong to this array.
+ 
+ Default is nil. All messages types are displayed.
+ */
+@property (nonatomic) NSArray<NSString*> *eventTypesFilterForMessages;
+
+/**
  Checks whether the event is related to an attachment and if it is supported.
 
- @param event
+ @param event an event.
  @return YES if the provided event is related to a supported attachment type.
  */
 - (BOOL)isSupportedAttachment:(MXEvent*)event;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -639,7 +639,7 @@ static BOOL _disableLongPressGestureOnEvent;
     
     MXKRoomBubbleCellData *bubbleData = (MXKRoomBubbleCellData*)cellData;
     MXKRoomBubbleTableViewCell* cell = [self cellWithOriginalXib];
-    CGFloat rowHeight = 0;
+    CGFloat rowHeight = cell.frame.size.height;
     
     if (cell.attachmentView && bubbleData.isAttachmentWithThumbnail)
     {

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.h
@@ -1,0 +1,25 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKRoomBubbleTableViewCell.h"
+
+/**
+ `MXKRoomEmptyBubbleTableViewCell` displays an empty bubbles without user's information.
+ This kind of bubble may be used to localize an event without display in the room history.
+ */
+@interface MXKRoomEmptyBubbleTableViewCell : MXKRoomBubbleTableViewCell
+
+@end

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.m
@@ -1,0 +1,21 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKRoomEmptyBubbleTableViewCell.h"
+
+@implementation MXKRoomEmptyBubbleTableViewCell
+
+@end

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.xib
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomEmptyBubbleTableViewCell.xib
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="pad-g3-2YJ" customClass="MXKRoomEmptyBubbleTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="8"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pad-g3-2YJ" id="fCg-ju-gnG">
+                <rect key="frame" x="0.0" y="0.0" width="600" height="7"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+            </tableViewCellContentView>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
Read markers should be synchronised across clients

The read marker may be defined on an event which is not displayed in the room history.
We update here the MatrixKit in order to handle this kind of event in the MXKRoomBubbleCellData object.
Previously these events were ignored during the bubbles rendering. Now a bubble component is created even if the event has no actual display.
This component is useful to display the read marker in the room history, and to allow the user to jump on this read marker.

vector-im/riot-meta#8