### PR TITLE
Bug Fix - Read marker: hit "Jump to first unread marker" leads to mes…

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1342,14 +1342,11 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     id<MXKRoomBubbleCellDataStoring> bubbleData = [self cellDataOfEventWithEventId:eventId];
     if (bubbleData)
     {
-        
         // Then look into the events in this cell
         for (MXEvent *event in bubbleData.events)
         {
-            
             if ([event.eventId isEqualToString:eventId])
             {
-                
                 theEvent = event;
                 break;
             }


### PR DESCRIPTION
…sage above the last unread

Update the read marker only if the current event is available, and the new event is posterior to it.

https://github.com/vector-im/riot-ios/issues/1293