### PR TITLE
Bug Fix - Read marker: no "Jump to first message" on landscape mode f…

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -378,4 +378,15 @@ extern NSString *const kCmdChangeRoomTopic;
  */
 - (void)showAttachmentInCell:(UITableViewCell*)cell;
 
+/**
+ Force a refresh of the room history display.
+ 
+ You should not call this method directly.
+ You may override it in inherited 'MXKRoomViewController' class.
+ 
+ @param useBottomAnchor tells whether the updated history must keep display the same event at the bottom.
+ @return a boolean value which tells whether the table has been scrolled to the bottom.
+ */
+- (BOOL)reloadBubblesTable:(BOOL)useBottomAnchor;
+
 @end

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2157,7 +2157,6 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
 #pragma mark - bubbles table
 
-// Return a boolean value which tells whether the table has been scrolled to the bottom
 - (BOOL)reloadBubblesTable:(BOOL)useBottomAnchor
 {
     BOOL shouldScrollToBottom = shouldScrollToBottomOnTableRefresh;


### PR DESCRIPTION
…or devices with left and right panels

MXKRoomViewController: Expose the method used to reload the bubbles table.
 You should not call this method directly.
 You may override it in inherited 'MXKRoomViewController' class.

https://github.com/vector-im/riot-ios/issues/1291