### PR TITLE
Should fix "Crash after hitting bottom arrow from the top of a room, …

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2300,12 +2300,12 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
         currentEventIdAtTableBottom = nil;
         
         // Consider the visible cells (starting by those displayed at the bottom)
-        NSArray *indexPathsForVisibleRows = [_bubblesTableView indexPathsForVisibleRows];
-        NSInteger index = indexPathsForVisibleRows.count;
+        NSArray *visibleCells = [_bubblesTableView visibleCells];
+        NSInteger index = visibleCells.count;
         UITableViewCell *cell;
         while (index--)
         {
-            cell = [_bubblesTableView cellForRowAtIndexPath:indexPathsForVisibleRows[index]];
+            cell = visibleCells[index];
             
             // Check whether the cell is actually visible
             if (cell && (cell.frame.origin.y < contentBottomOffsetY))


### PR DESCRIPTION
…after playing with "jump to first unread message" function"

The crash was reproduced (with low frequency).
Remark: `[UITableView indexPathForVisibleRows]` may return some index paths for which no cell is already available. We decided to use the `visibleCells` array instead.

https://github.com/matrix-org/riot-ios-rageshakes/issues/59