### PR TITLE
Small improvements

### DIFF
--- a/MatrixKit/Animators/MXKAttachmentAnimator.h
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.h
@@ -24,8 +24,6 @@ typedef NS_ENUM(NSInteger, PhotoBrowserAnimationType) {
 
 @protocol MXKSourceAttachmentAnimatorDelegate <NSObject>
 
-@required
-
 - (UIImageView *)originalImageView;
 
 - (CGRect)convertedFrameForOriginalImageView;
@@ -33,8 +31,6 @@ typedef NS_ENUM(NSInteger, PhotoBrowserAnimationType) {
 @end
 
 @protocol MXKDestinationAttachmentAnimatorDelegate <NSObject>
-
-@required
 
 - (UIImageView *)finalImageView;
 

--- a/MatrixKit/Animators/MXKAttachmentAnimator.m
+++ b/MatrixKit/Animators/MXKAttachmentAnimator.m
@@ -18,8 +18,8 @@
 
 @interface MXKAttachmentAnimator ()
 
-@property PhotoBrowserAnimationType animationType;
-@property (weak) UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
+@property (nonatomic) PhotoBrowserAnimationType animationType;
+@property (nonatomic, weak) UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
 
 @end
 

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.h
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.h
@@ -19,7 +19,7 @@
 
 @interface MXKAttachmentInteractionController : UIPercentDrivenInteractiveTransition
 
-@property BOOL interactionInProgress;
+@property (nonatomic) BOOL interactionInProgress;
 
 - (instancetype)initWithDestinationViewController:(UIViewController <MXKDestinationAttachmentAnimatorDelegate> *)viewController sourceViewController:(UIViewController <MXKSourceAttachmentAnimatorDelegate> *)sourceViewController;
 

--- a/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -18,14 +18,14 @@
 
 @interface MXKAttachmentInteractionController ()
 
-@property (weak) UIViewController <MXKDestinationAttachmentAnimatorDelegate> *destinationViewController;
-@property (weak) UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
+@property (nonatomic, weak) UIViewController <MXKDestinationAttachmentAnimatorDelegate> *destinationViewController;
+@property (nonatomic, weak) UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
 
-@property UIImageView *transitioningImageView;
-@property id <UIViewControllerContextTransitioning> transitionContext;
+@property (nonatomic) UIImageView *transitioningImageView;
+@property (nonatomic) id <UIViewControllerContextTransitioning> transitionContext;
 
-@property CGPoint translation;
-@property CGPoint delta;
+@property (nonatomic) CGPoint translation;
+@property (nonatomic) CGPoint delta;
 
 @end
 

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -425,7 +425,8 @@
 
 // Settings keys 
 
-// call string 
+// call string
+"call_waiting" = "Waiting...";
 "call_connecting" = "Call connecting...";
 "call_ended" = "Call ended";
 "call_ring" = "Calling...";

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -88,14 +88,14 @@
 }
 
 //animations
-@property MXKAttachmentInteractionController *interactionController;
+@property (nonatomic) MXKAttachmentInteractionController *interactionController;
 
-@property UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
+@property (nonatomic) UIViewController <MXKSourceAttachmentAnimatorDelegate> *sourceViewController;
 
-@property UIImageView *originalImageView;
-@property CGRect convertedFrame;
+@property (nonatomic) UIImageView *originalImageView;
+@property (nonatomic) CGRect convertedFrame;
 
-@property BOOL customAnimationsEnabled;
+@property (nonatomic) BOOL customAnimationsEnabled;
 
 @end
 

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -566,7 +566,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             [localPreviewActivityView startAnimating];
             break;
         case MXCallStateCreateOffer:
-        case MXCallStateInviteSent:
             self.isRinging = YES;
             callStatusLabel.text = [NSBundle mxk_localizedStringForKey:@"call_ring"];
             break;
@@ -585,7 +584,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             rejectCallButton.hidden = NO;
             answerCallButton.hidden = NO;
             break;
-        case MXCallStateCreateAnswer:
         case MXCallStateConnecting:
             self.isRinging = NO;
             callStatusLabel.text = [NSBundle mxk_localizedStringForKey:@"call_connecting"];

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -559,7 +559,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     {
         case MXCallStateFledgling:
             self.isRinging = NO;
-            callStatusLabel.text = nil;
+            callStatusLabel.text = [NSBundle mxk_localizedStringForKey:@"call_waiting"];;
             break;
         case MXCallStateWaitLocalMedia:
             self.isRinging = NO;

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -148,14 +148,14 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 /**
  The eventId of the Attachment that was used to open the Attachments ViewController
  */
-@property NSString *openedAttachmentEventId;
+@property (nonatomic) NSString *openedAttachmentEventId;
 
 /**
  The eventId of the Attachment from which the Attachments ViewController was closed
  */
-@property NSString *closedAttachmentEventId;
+@property (nonatomic) NSString *closedAttachmentEventId;
 
-@property UIImageView *openedAttachmentImageView;
+@property (nonatomic) UIImageView *openedAttachmentImageView;
 
 @end
 

--- a/MatrixKit/Views/MXKTableViewCell/MXKTableViewCellWithButton.m
+++ b/MatrixKit/Views/MXKTableViewCell/MXKTableViewCellWithButton.m
@@ -18,5 +18,11 @@
 
 @implementation MXKTableViewCellWithButton
 
-@end
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    
+    self.mxkButton.titleLabel.text = nil;
+}
 
+@end

--- a/MatrixKit/Views/MXKTableViewCell/MXKTableViewCellWithLabelAndSwitch.xib
+++ b/MatrixKit/Views/MXKTableViewCell/MXKTableViewCellWithLabelAndSwitch.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aCf-VI-ocb" id="Eg5-vl-rni">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9dA-E8-w3v">
@@ -34,8 +35,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="9dA-E8-w3v" firstAttribute="centerY" secondItem="Eg5-vl-rni" secondAttribute="centerY" id="HHv-PY-RDK"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="Xx4-AP-OQs" secondAttribute="bottom" constant="3.5" id="Ikz-iJ-l4h"/>
-                    <constraint firstItem="Xx4-AP-OQs" firstAttribute="centerY" secondItem="Eg5-vl-rni" secondAttribute="centerY" id="Uky-gM-6WY"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="Xx4-AP-OQs" secondAttribute="bottom" constant="3" id="Ikz-iJ-l4h"/>
                     <constraint firstItem="Xx4-AP-OQs" firstAttribute="top" secondItem="Eg5-vl-rni" secondAttribute="topMargin" constant="3" id="Vem-3Z-NyP"/>
                     <constraint firstItem="Xx4-AP-OQs" firstAttribute="leading" secondItem="Eg5-vl-rni" secondAttribute="leading" constant="8" id="Wih-ke-1dd"/>
                     <constraint firstItem="9dA-E8-w3v" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Xx4-AP-OQs" secondAttribute="trailing" constant="8" id="hms-8a-BYd"/>


### PR DESCRIPTION
- Add a default value for `callStatusLabel`
- Fix problems(see console in Riot when you're a scrolling on the settings screen) with constraints in `MXKTableViewCellWithLabelAndSwitch`. Remove label's center constraint and change its bottom's value to 3.
- Add `prepareForReuse` to `MXKTableViewCellWithButton`. Scroll to the bottom on the settings screen in Riot and then scroll to top and you can see how text is flashing on sign out button. I fixed this
- Add missed `nonatomic` attribute for properties

Signed-off-by: Denis Morozov dmorozkn@gmail.com