### PR TITLE
MXKSoundPlayer

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		71DE22E71BCE3FF200284153 /* MXKRoomBubbleCellDataWithIncomingAppendingMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22E51BCE3FF200284153 /* MXKRoomBubbleCellDataWithIncomingAppendingMode.m */; };
 		71EBE6631C04608100E7D953 /* MXKRoomActivitiesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71EBE6621C04608100E7D953 /* MXKRoomActivitiesView.m */; };
 		79FA5AB121247287B85FA151 /* libPods-MatrixKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */; };
+		92663A6C1EF6E5B3005FB712 /* MXKSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */; };
 		ACD9DAA6B4DCFC7E33E12A97 /* libPods-MatrixKitSample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665BACA3D253B4407B1C4FD7 /* libPods-MatrixKitSample.a */; };
 		CE14CA661E80122600E329A3 /* MXKAttachmentAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = CE14CA631E80122600E329A3 /* MXKAttachmentAnimator.m */; };
 		CE14CA671E80122600E329A3 /* MXKAttachmentInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE14CA651E80122600E329A3 /* MXKAttachmentInteractionController.m */; };
@@ -291,6 +292,8 @@
 		71EBE6611C04608100E7D953 /* MXKRoomActivitiesView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomActivitiesView.h; sourceTree = "<group>"; };
 		71EBE6621C04608100E7D953 /* MXKRoomActivitiesView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomActivitiesView.m; sourceTree = "<group>"; };
 		8C751E43C4D87B309065E3C8 /* Pods-MatrixKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.release.xcconfig"; sourceTree = "<group>"; };
+		92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSoundPlayer.h; sourceTree = "<group>"; };
+		92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSoundPlayer.m; sourceTree = "<group>"; };
 		9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFDF88630F521F8C5854F64F /* Pods-MatrixKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1C97E32A7F1D6C4B99A47EF /* Pods-MatrixKitSample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSample/Pods-MatrixKitSample.debug.xcconfig"; sourceTree = "<group>"; };
@@ -841,6 +844,8 @@
 				F0F148C41AB31240005F5D4A /* MXKTools.h */,
 				F0F148C51AB31240005F5D4A /* MXKTools.m */,
 				F0F535BC1ACD748E00B603F8 /* MXKResponderRageShaking.h */,
+				92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */,
+				92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1566,6 +1571,7 @@
 				F01449AD1B53FA7600EA7D73 /* MXKPushRuleCreationTableViewCell.m in Sources */,
 				3235CD771C32DC8A0084EA40 /* MXKSearchDataSource.m in Sources */,
 				F0CF98DD1B0B7FDC00EAE373 /* MXKTableViewCellWithLabelAndSubLabel.m in Sources */,
+				92663A6C1EF6E5B3005FB712 /* MXKSoundPlayer.m in Sources */,
 				F00FA85D1C0867F900E25826 /* MXKRoomIncomingAttachmentWithoutSenderInfoBubbleCell.m in Sources */,
 				F02D21491B7109950002DE01 /* MXKConstants.m in Sources */,
 				F07E18101ABC2EDA00DE3766 /* MXKRoomDataSource.m in Sources */,

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -16,12 +16,11 @@
 
 #import "MXKCallViewController.h"
 
-#import "MXMediaManager.h"
 #import "MXKAlert.h"
-
-#import "NSBundle+MatrixKit.h"
-
+#import "MXMediaManager.h"
+#import "MXKSoundPlayer.h"
 #import "MXKTools.h"
+#import "NSBundle+MatrixKit.h"
 
 NSString *const kMXKCallViewControllerWillAppearNotification = @"kMXKCallViewControllerWillAppearNotification";
 NSString *const kMXKCallViewControllerAppearedNotification = @"kMXKCallViewControllerAppearedNotification";
@@ -31,9 +30,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
 
 @interface MXKCallViewController ()
 {
-    AVAudioPlayer *audioPlayer;
-    
-    NSTimer *vibrateTimer;
     NSTimer *hideOverlayTimer;
     NSTimer *updateStatusTimer;
     
@@ -55,9 +51,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     
     // Observe AVAudioSessionRouteChangeNotification
     id audioSessionRouteChangeNotificationObserver;
-
-    // Cache of the current audio session category
-    NSString *savedAVAudioSessionCategory;
 }
 
 @property (nonatomic, assign) Boolean isRinging;
@@ -233,7 +226,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     _delegate = nil;
     
     self.isRinging = NO;
-    audioPlayer = nil;
     
     [hideOverlayTimer invalidate];
     [updateStatusTimer invalidate];
@@ -399,52 +391,21 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     {
         if (isRinging)
         {
-            if (audioPlayer)
-            {
-                [audioPlayer stop];
-            }
-
-            // Make the ringback ringing even in silent mode
-            if (!savedAVAudioSessionCategory)
-            {
-                savedAVAudioSessionCategory = [[AVAudioSession sharedInstance] category];
-            }
-            
-            [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
-            
-            NSError* error = nil;
             NSURL *audioUrl;
             if (mxCall.isIncoming)
             {
                 audioUrl = [self audioURLWithName:@"ring"];
-                
-                // Vibrate on incoming call
-                vibrateTimer = [NSTimer scheduledTimerWithTimeInterval:1.24875 target:self selector:@selector(vibrate) userInfo:nil repeats:YES];
             }
             else
             {
                 audioUrl = [self audioURLWithName:@"ringback"];
             }
             
-            audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:audioUrl error:&error];
-            
-            if (error)
-            {
-                NSLog(@"[MXKCallVC] ringing initWithContentsOfURL failed : %@", error);
-            }
-            
-            audioPlayer.numberOfLoops = -1;
-            [audioPlayer play];
+            [[MXKSoundPlayer sharedInstance] playSoundAt:audioUrl repeat:YES vibrate:mxCall.isIncoming routeToBuiltInReciever:!mxCall.isIncoming];
         }
         else
         {
-            if (audioPlayer)
-            {
-                [audioPlayer stop];
-                audioPlayer = nil;
-            }
-            [vibrateTimer invalidate];
-            vibrateTimer = nil;
+            [[MXKSoundPlayer sharedInstance] stopPlaying];
         }
         
         _isRinging = isRinging;
@@ -621,28 +582,15 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             self.isRinging = NO;
             callStatusLabel.text = [NSBundle mxk_localizedStringForKey:@"call_ended"];
             
-            if (audioPlayer)
-            {
-                [audioPlayer stop];
-            }
-            
             NSString *soundName = [self soundNameForCallEnding];
             if (soundName)
             {
-                NSError *error = nil;
                 NSURL *audioUrl = [self audioURLWithName:soundName];
-                audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:audioUrl error:&error];
-                if (error)
-                {
-                    NSLog(@"[MXKCallVC] ringing initWithContentsOfURL failed : %@", error);
-                }
-                
-                // Listen (audioPlayerDidFinishPlaying) for the end of the playback of "callend"
-                // to release the audio session
-                audioPlayer.delegate = self;
-                
-                audioPlayer.numberOfLoops = 0;
-                [audioPlayer play];
+                [[MXKSoundPlayer sharedInstance] playSoundAt:audioUrl repeat:NO vibrate:NO routeToBuiltInReciever:YES];
+            }
+            else
+            {
+                [[MXKSoundPlayer sharedInstance] stopPlaying];
             }
             
             // Except in case of call error, quit the screen right now
@@ -687,21 +635,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         
         // And interrupt the call
         [mxCall hangup];
-    }
-}
-
-#pragma mark - AVAudioPlayerDelegate
-
-- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag
-{
-    // Release the audio session to allow resuming of background music app
-    [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
-
-    // Restore audio category
-    if (savedAVAudioSessionCategory)
-    {
-        [[AVAudioSession sharedInstance] setCategory:savedAVAudioSessionCategory error:nil];
-        savedAVAudioSessionCategory = nil;
     }
 }
 
@@ -757,11 +690,6 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         
         self.peer = theMember;
     }
-}
-
-- (void)vibrate
-{
-    AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
 }
 
 - (BOOL)isBuiltInReceiverAudioOuput

--- a/MatrixKit/Utils/MXKSoundPlayer.h
+++ b/MatrixKit/Utils/MXKSoundPlayer.h
@@ -1,0 +1,36 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXKSoundPlayer : NSObject
+
++ (instancetype)sharedInstance;
+
++ (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReciever:(BOOL)useBuiltInReciever;
+- (void)stopPlaying;
+
+- (void)vibrateWithRepeat:(BOOL)repeat;
+- (void)stopVibrating;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixKit/Utils/MXKSoundPlayer.h
+++ b/MatrixKit/Utils/MXKSoundPlayer.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReciever:(BOOL)useBuiltInReciever;
+- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReceiver:(BOOL)useBuiltInReceiver;
 - (void)stopPlaying;
 
 - (void)vibrateWithRepeat:(BOOL)repeat;

--- a/MatrixKit/Utils/MXKSoundPlayer.m
+++ b/MatrixKit/Utils/MXKSoundPlayer.m
@@ -1,0 +1,142 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKSoundPlayer.h"
+
+#import <AVFoundation/AVFAudio.h>
+#import <AudioToolbox/AudioServices.h>
+
+static const NSTimeInterval kVibrationInterval = 1.24875;
+
+@interface MXKSoundPlayer () <AVAudioPlayerDelegate>
+
+@property (nonatomic, nullable) AVAudioPlayer *audioPlayer;
+
+@property (nonatomic, getter=isVibrating) BOOL vibrating;
+
+@end
+
+@implementation MXKSoundPlayer
+
++ (instancetype)sharedInstance
+{
+    static MXKSoundPlayer *soundPlayer;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        soundPlayer = [MXKSoundPlayer alloc];
+    });
+    return soundPlayer;
+}
+
+- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReciever:(BOOL)useBuiltInReciever
+{
+    if (self.audioPlayer)
+    {
+        [self stopPlaying];
+    }
+    
+    self.audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:url error:nil];
+    
+    if (!self.audioPlayer)
+        return;
+    
+    self.audioPlayer.delegate = self;
+    self.audioPlayer.numberOfLoops = repeat ? -1 : 0;
+    [self.audioPlayer prepareToPlay];
+    
+    // Setup AVAudioSession
+    // We use SoloAmbient instead of Playback category to respect silent mode
+    NSString *audioSessionCategory = useBuiltInReciever ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategorySoloAmbient;
+    [[AVAudioSession sharedInstance] setCategory:audioSessionCategory error:nil];
+    
+    if (vibrate)
+        [self vibrateWithRepeat:repeat];
+    
+    [self.audioPlayer play];
+}
+
+- (void)stopPlaying
+{
+    if (self.audioPlayer)
+    {
+        [self.audioPlayer stop];
+        self.audioPlayer = nil;
+        
+        // Release the audio session to allow resuming of background music app
+        [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+    }
+    
+    if (self.isVibrating)
+    {
+        [self stopVibrating];
+    }
+}
+
+- (void)vibrateWithRepeat:(BOOL)repeat
+{
+    self.vibrating = YES;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kVibrationInterval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
+        
+        NSNumber *objRepeat = @(repeat);
+        AudioServicesAddSystemSoundCompletion(kSystemSoundID_Vibrate,
+                                              NULL,
+                                              kCFRunLoopCommonModes,
+                                              vibrationCompleted,
+                                              (__bridge_retained void * _Nullable)(objRepeat));
+    });
+}
+
+- (void)stopVibrating
+{
+    self.vibrating = NO;
+    AudioServicesRemoveSystemSoundCompletion(kSystemSoundID_Vibrate);
+}
+
+void vibrationCompleted(SystemSoundID ssID, void* __nullable clientData)
+{
+    NSNumber *objRepeat = (__bridge NSNumber *)clientData;
+    BOOL repeat = [objRepeat boolValue];
+    CFRelease(clientData);
+    
+    MXKSoundPlayer *soundPlayer = [MXKSoundPlayer sharedInstance];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kVibrationInterval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (repeat && soundPlayer.isVibrating)
+        {
+            [soundPlayer vibrateWithRepeat:repeat];
+        }
+        else
+        {
+            [soundPlayer stopVibrating];
+        }
+    });
+}
+
+#pragma mark - AVAudioPlayerDelegate
+
+// This method is called only when the end of the player's track is reached.
+// If you call `stop` or `pause` on player this method won't be called
+- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag
+{
+    self.audioPlayer = nil;
+    
+    // Release the audio session to allow resuming of background music app
+    [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+}
+
+@end

--- a/MatrixKit/Utils/MXKSoundPlayer.m
+++ b/MatrixKit/Utils/MXKSoundPlayer.m
@@ -41,7 +41,7 @@ static const NSTimeInterval kVibrationInterval = 1.24875;
     return soundPlayer;
 }
 
-- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReciever:(BOOL)useBuiltInReciever
+- (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReceiver:(BOOL)useBuiltInReceiver
 {
     if (self.audioPlayer)
     {
@@ -59,7 +59,7 @@ static const NSTimeInterval kVibrationInterval = 1.24875;
     
     // Setup AVAudioSession
     // We use SoloAmbient instead of Playback category to respect silent mode
-    NSString *audioSessionCategory = useBuiltInReciever ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategorySoloAmbient;
+    NSString *audioSessionCategory = useBuiltInReceiver ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategorySoloAmbient;
     [[AVAudioSession sharedInstance] setCategory:audioSessionCategory error:nil];
     
     if (vibrate)


### PR DESCRIPTION
I tried to make `MXKSoundPlayer` as simple as it could be. It suites for tasks of `MXKCallViewController` and can be improved in the future. There are problems with background music and `MXCallViewController` since `MXKCallViewController` doesn't handle all cases. With my PR there is no such problem. It also fixes [1283](https://github.com/vector-im/riot-ios/issues/1283) and the problem with sound after `MXKCallViewController` is dismissed (this problem is reproduced in the last buid from TestFlight. I mentioned about it to you earlier).

**NOTE:** It works great without CallKit but if you try to add CallKit you will notice that after the call is connected, the sound is gone. I have trying to figure out what the problem is. It's obviously that it's something connected with AVAudioSession but i can't find what is wrong.