### PR TITLE
Fix issues with sound

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -425,7 +425,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         }
         else
         {
-            [[MXKSoundPlayer sharedInstance] stopPlaying];
+            [[MXKSoundPlayer sharedInstance] stopPlayingWithAudioSessionDeactivation:NO];
         }
         
         _isRinging = isRinging;
@@ -548,6 +548,10 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             break;
         case MXCallStateCreateOffer:
         {
+            // When CallKit is enabled and we have an outgoing call, we need to start playing ringback sound
+            // only after AVAudioSession will be activated by the system otherwise the sound will be gone.
+            // We always receive signal about MXCallStateCreateOffer earlier than the system activates AVAudioSession
+            // so we start playing ringback sound only on AVAudioSession activation in handleAudioSessionActivationNotification
             BOOL isCallKitAvailable = [MXCallKitAdapter callKitAvailable] && [MXKAppSettings standardAppSettings].isCallKitEnabled;
             if (!isCallKitAvailable)
             {
@@ -617,10 +621,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             }
             else
             {
-                [[MXKSoundPlayer sharedInstance] stopPlaying];
-                
-                // Release the audio session to allow resuming of background music app
-                [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+                [[MXKSoundPlayer sharedInstance] stopPlayingWithAudioSessionDeactivation:YES];
             }
             
             // Except in case of call error, quit the screen right now

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -16,7 +16,10 @@
 
 #import "MXKCallViewController.h"
 
+#import <MatrixSDK/MXCallKitAdapter.h>
+
 #import "MXKAlert.h"
+#import "MXKAppSettings.h"
 #import "MXMediaManager.h"
 #import "MXKSoundPlayer.h"
 #import "MXKTools.h"
@@ -136,6 +139,16 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     
     // Refresh call information
     self.mxCall = mxCall;
+    
+    // Listen to AVAudioSession activation notification if CallKit is available and enabled
+    BOOL isCallKitAvailable = [MXCallKitAdapter callKitAvailable] && [MXKAppSettings standardAppSettings].isCallKitEnabled;
+    if (isCallKitAvailable)
+    {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleAudioSessionActivationNotification)
+                                                     name:kMXCallKitAdapterAudioSessionDidActive
+                                                   object:nil];
+    }
 }
 
 - (void)didReceiveMemoryWarning
@@ -145,6 +158,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
 
 - (void)dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXCallKitAdapterAudioSessionDidActive object:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -533,9 +547,16 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             [localPreviewActivityView startAnimating];
             break;
         case MXCallStateCreateOffer:
-            self.isRinging = YES;
+        {
+            BOOL isCallKitAvailable = [MXCallKitAdapter callKitAvailable] && [MXKAppSettings standardAppSettings].isCallKitEnabled;
+            if (!isCallKitAvailable)
+            {
+                self.isRinging = YES;
+            }
+            
             callStatusLabel.text = [NSBundle mxk_localizedStringForKey:@"call_ring"];
             break;
+        }
         case MXCallStateRinging:
             self.isRinging = YES;
             if (call.isVideoCall)
@@ -597,6 +618,9 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             else
             {
                 [[MXKSoundPlayer sharedInstance] stopPlaying];
+                
+                // Release the audio session to allow resuming of background music app
+                [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
             }
             
             // Except in case of call error, quit the screen right now
@@ -726,6 +750,15 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         return @"busy";
     
     return nil;
+}
+
+- (void)handleAudioSessionActivationNotification
+{
+    // It's only relevant for outgoing calls which aren't in connected state
+    if (self.mxCall.state >= MXCallStateCreateOffer && self.mxCall.state != MXCallStateConnected && self.mxCall.state != MXCallStateEnded)
+    {
+        self.isRinging = YES;
+    }
 }
 
 #pragma mark - UI methods

--- a/MatrixKit/Utils/MXKSoundPlayer.h
+++ b/MatrixKit/Utils/MXKSoundPlayer.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)new NS_UNAVAILABLE;
 
 - (void)playSoundAt:(NSURL *)url repeat:(BOOL)repeat vibrate:(BOOL)vibrate routeToBuiltInReceiver:(BOOL)useBuiltInReceiver;
-- (void)stopPlaying;
+- (void)stopPlayingWithAudioSessionDeactivation:(BOOL)deactivateAudioSession;
 
 - (void)vibrateWithRepeat:(BOOL)repeat;
 - (void)stopVibrating;

--- a/MatrixKit/Utils/MXKSoundPlayer.m
+++ b/MatrixKit/Utils/MXKSoundPlayer.m
@@ -74,9 +74,6 @@ static const NSTimeInterval kVibrationInterval = 1.24875;
     {
         [self.audioPlayer stop];
         self.audioPlayer = nil;
-        
-        // Release the audio session to allow resuming of background music app
-        [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
     }
     
     if (self.isVibrating)

--- a/MatrixKit/Utils/MXKSoundPlayer.m
+++ b/MatrixKit/Utils/MXKSoundPlayer.m
@@ -45,7 +45,7 @@ static const NSTimeInterval kVibrationInterval = 1.24875;
 {
     if (self.audioPlayer)
     {
-        [self stopPlaying];
+        [self stopPlayingWithAudioSessionDeactivation:NO];
     }
     
     self.audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:url error:nil];
@@ -68,12 +68,18 @@ static const NSTimeInterval kVibrationInterval = 1.24875;
     [self.audioPlayer play];
 }
 
-- (void)stopPlaying
+- (void)stopPlayingWithAudioSessionDeactivation:(BOOL)deactivateAudioSession;
 {
     if (self.audioPlayer)
     {
         [self.audioPlayer stop];
         self.audioPlayer = nil;
+        
+        if (deactivateAudioSession)
+        {
+            // Release the audio session to allow resuming of background music app
+            [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+        }
     }
     
     if (self.isVibrating)


### PR DESCRIPTION
I decided to move out `AVAudioSession` deactivation from `stopPlaying` method since we need more granular control on when we need to deactivate `AVAudioSession`. Now AVAudioSession is deactivated when it's 100% no sound to play.

As i told earlier we need to start playing ringback sound for outgoing calls only when the system has succesfully activates `AVAudioSession` otherwise the ringback sound will be gone. So i [decided](https://github.com/matrix-org/matrix-ios-sdk/pull/317) to post a global notification about this event and handle it by setting `isRinging` property to `YES` when all criterias are met.

With both PRs we won't have any issues with the sound. I have tested this code and it works well.

Maybe you have your own mind on how we can handle these situations. I'm glad to hear your suggestions.

Signed-off-by: Denis Morozov dmorozkn@gmail.com