### PR TITLE
Bug Fix - Chat screen: the sender avatar is missing.

### DIFF
--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -924,6 +924,12 @@ static NSMutableDictionary *childClasses;
                 
                 for (MXKRoomBubbleComponent *component in bubbleComponents)
                 {
+                    // Ignore components without display.
+                    if (!component.attributedTextMessage)
+                    {
+                        continue;
+                    }
+                        
                     if (tapPoint.y < component.position.y)
                     {
                         break;
@@ -1053,6 +1059,12 @@ static NSMutableDictionary *childClasses;
                 CGPoint longPressPoint = [longPressGestureRecognizer locationInView:view];
                 for (MXKRoomBubbleComponent *component in bubbleComponents)
                 {
+                    // Ignore components without display.
+                    if (!component.attributedTextMessage)
+                    {
+                        continue;
+                    }
+                    
                     if (longPressPoint.y < component.position.y)
                     {
                         break;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingBubbleTableViewCell.m
@@ -91,6 +91,12 @@
             UIButton *unsentButton = (UIButton *)sender;
             for (MXKRoomBubbleComponent *component in bubbleComponents)
             {
+                // Ignore components without display.
+                if (!component.attributedTextMessage)
+                {
+                    continue;
+                }
+                
                 if (unsentButton.frame.origin.y == component.position.y)
                 {
                     selectedEvent = component.event;


### PR DESCRIPTION
This regression was introduced when we decided to keep a component for each event, even for those without display.

We fix tap on bubble handling too.

https://github.com/vector-im/riot-ios/issues/1361