### PR TITLE
Translation: Make language fallback work for MatrixKit strings

### DIFF
--- a/MatrixKit/Categories/NSBundle+MXKLanguage.h
+++ b/MatrixKit/Categories/NSBundle+MXKLanguage.h
@@ -44,4 +44,11 @@
  */
 + (void)mxk_setFallbackLanguage:(NSString*)language;
 
+/**
+ The fallback language set by mxk_setFallbackLanguage.
+
+ @return the ISO language code of the current fallback language.
+ */
++ (NSString *)mxk_fallbackLanguage;
+
 @end

--- a/MatrixKit/Categories/NSBundle+MXKLanguage.m
+++ b/MatrixKit/Categories/NSBundle+MXKLanguage.m
@@ -21,9 +21,7 @@
 static const char _bundle = 0;
 static const char _fallbackBundle = 0;
 static const char _language = 0;
-
-@interface MXKLanguageBundle : NSBundle
-@end
+static const char _fallbackLanguage = 0;
 
 @implementation MXKLanguageBundle
 
@@ -76,6 +74,15 @@ static const char _language = 0;
     objc_setAssociatedObject([NSBundle mainBundle],
                              &_fallbackBundle, language ? [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:language ofType:@"lproj"]] : nil,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    objc_setAssociatedObject([NSBundle mainBundle],
+                             &_fallbackLanguage, language,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
++ (NSString *)mxk_fallbackLanguage
+{
+    return objc_getAssociatedObject([NSBundle mainBundle], &_fallbackLanguage);
 }
 
 #pragma mark - Private methods

--- a/MatrixKit/Categories/NSBundle+MatrixKit.m
+++ b/MatrixKit/Categories/NSBundle+MatrixKit.m
@@ -15,6 +15,7 @@
  */
 
 #import "NSBundle+MatrixKit.h"
+#import "NSBundle+MXKLanguage.h"
 #import "MXKViewController.h"
 
 @implementation NSBundle (MatrixKit)
@@ -33,6 +34,12 @@ static NSString *customLocalizedStringTableName = nil;
     }
 
     return [NSBundle bundleWithURL:assetsBundleURL];
+}
+
++ (NSBundle*)mxk_fallbackBundle
+{
+    // Return the sub bundle of the fallback language
+    return [NSBundle bundleWithPath:[[NSBundle mxk_assetsBundle] pathForResource:[MXKLanguageBundle mxk_fallbackLanguage] ofType:@"lproj"]];
 }
 
 // use a cache to avoid loading images from file system.
@@ -86,7 +93,30 @@ static MXLRUCache *imagesResourceCache = nil;
 
     if (!localizedString || (localizedString.length == 1 && [localizedString isEqualToString:@"_"]))
     {
-        localizedString = NSLocalizedStringFromTableInBundle(key, @"MatrixKit", [NSBundle mxk_assetsBundle], nil);
+        // Check if we need to manage a fallback language
+        // as we do in NSBundle+MXKLanguage
+        NSString *language = [NSBundle mxk_language];
+        if (!language)
+        {
+            language = [NSBundle mainBundle].preferredLocalizations.firstObject;
+        }
+        NSString *fallbackLanguage = [NSBundle mxk_fallbackLanguage];
+
+        BOOL manageFallbackLanguage = fallbackLanguage && ![language isEqualToString:fallbackLanguage];
+
+        localizedString = NSLocalizedStringWithDefaultValue(key, @"MatrixKit",
+                                                            [NSBundle mxk_assetsBundle],
+                                                            manageFallbackLanguage ? @"_" : nil,
+                                                            nil);
+
+        if (manageFallbackLanguage
+            && (!localizedString || (localizedString.length == 1 && [localizedString isEqualToString:@"_"])))
+        {
+            // The translation is not available, use the fallback language
+            localizedString = NSLocalizedStringFromTableInBundle(key, @"MatrixKit",
+                                                                 [NSBundle mxk_fallbackBundle],
+                                                                 nil);
+        }
     }
     
     return localizedString;


### PR DESCRIPTION
Apply the same hack in NSBundle+MXKLanguage to manage fallback