### PR TITLE
Fix problems with MXCallViewController dismissing

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -595,7 +595,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             // Except in case of call error, quit the screen right now
             if (!errorAlert)
             {
-                [errorAlert dismissViewControllerAnimated:NO completion:nil];
+                [self dismiss];
             }
 
             break;

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -625,18 +625,18 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         errorAlert = [UIAlertController alertControllerWithTitle:title message:msg preferredStyle:UIAlertControllerStyleAlert];
         
         [errorAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
-                                                         style:UIAlertActionStyleDefault
-                                                       handler:^(UIAlertAction * action) {
-                                                           
-                                                           if (weakSelf)
-                                                           {
-                                                               typeof(self) self = weakSelf;
-                                                               self->errorAlert = nil;
-                                                               
-                                                               [self dismiss];
-                                                           }
-                                                           
-                                                       }]];
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:^(UIAlertAction * action) {
+                                                         
+                                                         typeof(self) self = weakSelf;
+                                                         if (self)
+                                                         {
+                                                             self->errorAlert = nil;
+                                                             
+                                                             [self dismiss];
+                                                         }
+                                                         
+                                                     }]];
         
         
         [self presentViewController:errorAlert animated:YES completion:nil];


### PR DESCRIPTION
Due to the last changes `MXCallViewController` wasn't dismissed in most cases. See [issue](https://github.com/vector-im/riot-ios/issues/1405). This PR fix this. Also i changed order of capturing `weakSelf` in alert action's handler since it's safer to capture `weakSelf` firstly and then check strong reference for nil.

Signed-off-by: Denis Morozov dmorozkn@gmail.com