### PR TITLE
Fix issue #933

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -523,6 +523,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
             break;
         case MXCallStateWaitLocalMedia:
             self.isRinging = NO;
+            speakerButton.selected = call.audioToSpeaker;
             [localPreviewActivityView startAnimating];
             break;
         case MXCallStateCreateOffer:
@@ -560,15 +561,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
                 // Well, hide does not work. So, shrink the view to nil
                 self.localPreviewContainerView.frame = CGRectMake(0, 0, 0, 0);
             }
-            
-            // Check whether it is an actual state change or just a refresh
-            if (event)
-            {
-                // Turn on speaker on connected video call (ONLY when the built-in receiver is currently used)
-                call.audioToSpeaker = (call.isVideoCall && self.isBuiltInReceiverAudioOuput);
-                speakerButton.selected = call.audioToSpeaker;
-            }
-            
+
             break;
         case MXCallStateInviteExpired:
             // MXCallStateInviteExpired state is sent as an notification


### PR DESCRIPTION
See [#933](https://github.com/vector-im/riot-ios/issues/933), [#359](https://github.com/matrix-org/matrix-ios-sdk/pull/359)

This check doesn't do anything since `event` is always nil for `MXCallStateConnected` state
```
case MXCallStateConnected:
if (event)
{
   ...
}
```

Signed-off-by: Denis Morozov dmorozkn@gmail.com