### PR TITLE
Fix garbled HTML paragraph syntax during markdown conversion

### DIFF
--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1579,15 +1579,19 @@
     {
         htmlString = [htmlString substringToIndex:htmlString.length - 1];
     }
-    
-    // Strip start and end <p> tags else you get 'orrible spacing
-    if ([htmlString hasPrefix:@"<p>"])
+
+    // Strip start and end <p> tags else you get 'orrible spacing.
+    // But only do this if it's a single paragraph we're dealing with,
+    // otherwise we'll produce some garbage (`something</p><p>another`).
+    if ([htmlString hasPrefix:@"<p>"] && [htmlString hasSuffix:@"</p>"])
     {
-        htmlString = [htmlString substringFromIndex:3];
-    }
-    if ([htmlString hasSuffix:@"</p>"])
-    {
-        htmlString = [htmlString substringToIndex:htmlString.length - 4];
+        NSArray *components = [htmlString componentsSeparatedByString:@"<p>"];
+        NSUInteger paragrapsCount = components.count - 1;
+
+        if (paragrapsCount == 1) {
+            htmlString = [htmlString substringFromIndex:3];
+            htmlString = [htmlString substringToIndex:htmlString.length - 4];
+        }
     }
 
     return htmlString;


### PR DESCRIPTION
Fixes vector-im/riot-ios#1500.

It turns out that stripping the leading and ending `<p>`
tags was done in a simplistic way, which ignored the fact
that the string may contain multiple paragraphs.

For example, stripping the leading and ending `<p>` from:

	<p>line 1</p>
	<p>line 2</p>

(incorrectly) used to produce:

	line 1</p>
	<p>line 2

With this patch, we only do leading/ending `<p>` stripping
if the HTML string contains exactly 1 paragraph.

Signed-off-by: Slavi Pantaleev <s.pantaleev@gmail.com>