### PR TITLE
BF: Riot on iOS11 sends images as HEIC format, which nothing else can display

### DIFF
--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -494,6 +494,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     }
 
     // Send data without compression if the image type is not jpeg
+    // Force compression for a heic image so that we generate jpeg from it
     if (mimetype
         && [mimetype isEqualToString:@"image/jpeg"] == NO
         && [mimetype isEqualToString:@"image/heic"] == NO

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -494,7 +494,10 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     }
 
     // Send data without compression if the image type is not jpeg
-    if (mimetype && [mimetype isEqualToString:@"image/jpeg"] == NO && [self.delegate respondsToSelector:@selector(roomInputToolbarView:sendImage:withMimeType:)])
+    if (mimetype
+        && [mimetype isEqualToString:@"image/jpeg"] == NO
+        && [mimetype isEqualToString:@"image/heic"] == NO
+        && [self.delegate respondsToSelector:@selector(roomInputToolbarView:sendImage:withMimeType:)])
     {
         // Check whether the url references the image in the AssetsLibrary framework
         if ([imageURL.scheme isEqualToString:@"assets-library"])


### PR DESCRIPTION
vector-im/riot-ios#1521

Force compression for HEIC images so that the kit creates JPEG images for them.