### PR TITLE
Fix iOS11 disruption

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		F096A3BF1B0B3DAA00AF1357 /* MXKAccountDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F096A3BD1B0B3DAA00AF1357 /* MXKAccountDetailsViewController.m */; };
 		F09E288E1AC1FEDA00C51E44 /* MXKImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = F09E288B1AC1FEDA00C51E44 /* MXKImageView.m */; };
 		F09E288F1AC1FEDA00C51E44 /* MXKPieChartView.m in Sources */ = {isa = PBXBuildFile; fileRef = F09E288D1AC1FEDA00C51E44 /* MXKPieChartView.m */; };
+		F0A8955E1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A8955D1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.m */; };
 		F0AD3CC21B288C05002E0899 /* MXKInterleavedRecentsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = F0AD3CBF1B288C05002E0899 /* MXKInterleavedRecentsDataSource.m */; };
 		F0AD3CC71B289441002E0899 /* MXKInterleavedRecentTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F0AD3CC51B289441002E0899 /* MXKInterleavedRecentTableViewCell.m */; };
 		F0AD3CC81B289441002E0899 /* MXKInterleavedRecentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F0AD3CC61B289441002E0899 /* MXKInterleavedRecentTableViewCell.xib */; };
@@ -488,6 +489,8 @@
 		F09E288B1AC1FEDA00C51E44 /* MXKImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKImageView.m; sourceTree = "<group>"; };
 		F09E288C1AC1FEDA00C51E44 /* MXKPieChartView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKPieChartView.h; sourceTree = "<group>"; };
 		F09E288D1AC1FEDA00C51E44 /* MXKPieChartView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKPieChartView.m; sourceTree = "<group>"; };
+		F0A8955C1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+MatrixKit.h"; sourceTree = "<group>"; };
+		F0A8955D1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+MatrixKit.m"; sourceTree = "<group>"; };
 		F0AD3CBE1B288C05002E0899 /* MXKInterleavedRecentsDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKInterleavedRecentsDataSource.h; sourceTree = "<group>"; };
 		F0AD3CBF1B288C05002E0899 /* MXKInterleavedRecentsDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKInterleavedRecentsDataSource.m; sourceTree = "<group>"; };
 		F0AD3CC41B289441002E0899 /* MXKInterleavedRecentTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKInterleavedRecentTableViewCell.h; sourceTree = "<group>"; };
@@ -1063,6 +1066,8 @@
 		F07E18111ABC563900DE3766 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				F0A8955C1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.h */,
+				F0A8955D1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.m */,
 				F04F78331F17A1B60039485E /* UIAlertController+MatrixKit.h */,
 				F04F78341F17A1B60039485E /* UIAlertController+MatrixKit.m */,
 				F049FC1E1B2B878A00DD9D3C /* NSBundle+MatrixKit.h */,
@@ -1633,6 +1638,7 @@
 				F0CF98E31B0B7FDC00EAE373 /* MXKTableViewCellWithTextView.m in Sources */,
 				F0026B661C91EED1001D2C04 /* MXKWebViewViewController.m in Sources */,
 				F0B0ECC41B14B16C005EB20D /* MXKRoomTitleView.m in Sources */,
+				F0A8955E1F7A55DF00BD6C2A /* UIScrollView+MatrixKit.m in Sources */,
 				F095E50F1B25899F009606CE /* MXKContactManager.m in Sources */,
 				F09617C31DE881D800093E9D /* MXKEncryptionInfoView.m in Sources */,
 				F0CE56EB1AA8BB5E003BE77A /* MXKSampleMainTableViewController.m in Sources */,

--- a/MatrixKit/Categories/UIScrollView+MatrixKit.h
+++ b/MatrixKit/Categories/UIScrollView+MatrixKit.h
@@ -1,0 +1,30 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ Define a `UIScrollView` category at MatrixKit level to handle the adjusted content inset which is not defined before iOS 11.
+ */
+@interface UIScrollView (MatrixKit)
+
+/**
+ Get the total adjustment in a scroll view.
+ The insets derived from the content insets and the safe area of the scroll view.
+ */
+@property(nonatomic, readonly) UIEdgeInsets mxk_adjustedContentInset;
+
+@end

--- a/MatrixKit/Categories/UIScrollView+MatrixKit.m
+++ b/MatrixKit/Categories/UIScrollView+MatrixKit.m
@@ -1,0 +1,33 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "UIScrollView+MatrixKit.h"
+
+@implementation UIScrollView (MatrixKit)
+
+- (UIEdgeInsets)mxk_adjustedContentInset
+{
+    if (@available(iOS 11.0, *))
+    {
+        return self.adjustedContentInset;
+    }
+    else
+    {
+        return self.contentInset;
+    }
+}
+
+@end

--- a/MatrixKit/Controllers/MXKContactListViewController.m
+++ b/MatrixKit/Controllers/MXKContactListViewController.m
@@ -19,6 +19,7 @@
 #import "MXKSectionedContacts.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "UIScrollView+MatrixKit.h"
 
 @interface MXKContactListViewController ()
 {
@@ -149,7 +150,7 @@
     // stop any scrolling effect
     [UIView setAnimationsEnabled:NO];
     // before scrolling to the tableview top
-    self.tableView.contentOffset = CGPointMake(-self.tableView.contentInset.left, -self.tableView.contentInset.top);
+    self.tableView.contentOffset = CGPointMake(-self.tableView.mxk_adjustedContentInset.left, -self.tableView.mxk_adjustedContentInset.top);
     [UIView setAnimationsEnabled:YES];
 }
 

--- a/MatrixKit/Controllers/MXKRecentListViewController.m
+++ b/MatrixKit/Controllers/MXKRecentListViewController.m
@@ -22,6 +22,8 @@
 #import "MXKInterleavedRecentsDataSource.h"
 #import "MXKInterleavedRecentTableViewCell.h"
 
+#import "UIScrollView+MatrixKit.h"
+
 @interface MXKRecentListViewController ()
 {
     /**
@@ -509,7 +511,7 @@
 {
     if (scrollView == _recentsTableView)
     {
-        if (scrollView.contentOffset.y + scrollView.contentInset.top == 0)
+        if (scrollView.contentOffset.y + scrollView.mxk_adjustedContentInset.top == 0)
         {
             [self managePullToKick:scrollView];
         }
@@ -603,7 +605,7 @@
     if (!reconnectingView)
     {
         // detect if the user scrolls over the tableview top
-        restartConnection = (scrollView.contentOffset.y + scrollView.contentInset.top < -128);
+        restartConnection = (scrollView.contentOffset.y + scrollView.mxk_adjustedContentInset.top < -128);
         
         if (restartConnection)
         {

--- a/MatrixKit/Controllers/MXKRoomMemberListViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberListViewController.m
@@ -22,6 +22,7 @@
 #import "MXKConstants.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "UIScrollView+MatrixKit.h"
 
 @interface MXKRoomMemberListViewController ()
 {
@@ -371,7 +372,7 @@
 
 - (void)scrollToTop:(BOOL)animated
 {
-    [self.membersTableView setContentOffset:CGPointMake(-self.membersTableView.contentInset.left, -self.membersTableView.contentInset.top) animated:animated];
+    [self.membersTableView setContentOffset:CGPointMake(-self.membersTableView.mxk_adjustedContentInset.left, -self.membersTableView.mxk_adjustedContentInset.top) animated:animated];
 }
 
 #pragma mark - MXKDataSourceDelegate

--- a/MatrixKit/Controllers/MXKSearchViewController.m
+++ b/MatrixKit/Controllers/MXKSearchViewController.m
@@ -19,6 +19,7 @@
 #import "MXKSearchTableViewCell.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "UIScrollView+MatrixKit.h"
 
 @interface MXKSearchViewController ()
 {
@@ -417,10 +418,10 @@
 {
     if (_searchTableView.contentSize.height)
     {
-        CGFloat visibleHeight = _searchTableView.frame.size.height - _searchTableView.contentInset.top - _searchTableView.contentInset.bottom;
+        CGFloat visibleHeight = _searchTableView.frame.size.height - _searchTableView.mxk_adjustedContentInset.top - _searchTableView.mxk_adjustedContentInset.bottom;
         if (visibleHeight < _searchTableView.contentSize.height)
         {
-            CGFloat wantedOffsetY = _searchTableView.contentSize.height - visibleHeight - _searchTableView.contentInset.top;
+            CGFloat wantedOffsetY = _searchTableView.contentSize.height - visibleHeight - _searchTableView.mxk_adjustedContentInset.top;
             CGFloat currentOffsetY = _searchTableView.contentOffset.y;
             if (wantedOffsetY != currentOffsetY)
             {
@@ -429,7 +430,7 @@
         }
         else
         {
-            _searchTableView.contentOffset = CGPointMake(0, - _searchTableView.contentInset.top);
+            _searchTableView.contentOffset = CGPointMake(0, - _searchTableView.mxk_adjustedContentInset.top);
         }
     }
 }

--- a/MatrixKit/Controllers/MXKTableViewController.m
+++ b/MatrixKit/Controllers/MXKTableViewController.m
@@ -16,6 +16,8 @@
 
 #import "MXKTableViewController.h"
 
+#import "UIScrollView+MatrixKit.h"
+
 @interface MXKTableViewController ()
 {
     /**
@@ -553,7 +555,7 @@
     {
         // Keep centering the loading wheel
         CGPoint center = self.view.center;
-        center.y +=  self.tableView.contentOffset.y - self.tableView.contentInset.top;
+        center.y +=  self.tableView.contentOffset.y - self.tableView.mxk_adjustedContentInset.top;
         activityIndicator.center = center;
         [self.view bringSubviewToFront:activityIndicator];
         

--- a/MatrixKit/MatrixKit.h
+++ b/MatrixKit/MatrixKit.h
@@ -27,6 +27,7 @@
 #import "NSBundle+MatrixKit.h"
 #import "NSBundle+MXKLanguage.h"
 #import "UIAlertController+MatrixKit.h"
+#import "UIScrollView+MatrixKit.h"
 
 #import "MXKEventFormatter.h"
 


### PR DESCRIPTION
- MXKRoomViewController: fix header layout
- Add UIScrollView+MatrixKit category to handle the adjusted content inset which is not defined before iOS 11.