### PR TITLE
tableView cellForRowAtIndexPath:

### DIFF
--- a/MatrixKit/Controllers/MXKAccountDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKAccountDetailsViewController.m
@@ -1065,6 +1065,12 @@ NSString* const kMXKAccountDetailsLinkedEmailCellId = @"kMXKAccountDetailsLinked
         }
         
     }
+    else
+    {
+        // Return a fake cell to prevent app from crashing.
+        cell = [[UITableViewCell alloc] init];
+    }
+    
     return cell;
 }
 

--- a/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
+++ b/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
@@ -537,6 +537,11 @@
             cell = pushRuleCell;
         }
     }
+    else
+    {
+        // Return a fake cell to prevent app from crashing.
+        cell = [[UITableViewCell alloc] init];
+    }
     
     return cell;
 }

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -820,7 +820,8 @@
         return cell;
     }
     
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 

--- a/MatrixKit/Controllers/MXKRoomSettingsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomSettingsViewController.m
@@ -198,7 +198,8 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 @end

--- a/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServersDataSource.m
+++ b/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServersDataSource.m
@@ -230,7 +230,8 @@ NSString *const kMXKDirectorServerCellIdentifier = @"kMXKDirectorServerCellIdent
         }
     }
 
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 @end

--- a/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
@@ -431,7 +431,9 @@
             return cell;
         }
     }
-    return nil;
+    
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath

--- a/MatrixKit/Models/RoomMemberList/MXKRoomMemberListDataSource.m
+++ b/MatrixKit/Models/RoomMemberList/MXKRoomMemberListDataSource.m
@@ -440,7 +440,8 @@ NSString *const kMXKRoomMemberCellIdentifier = @"kMXKRoomMemberCellIdentifier";
         }
     }
     
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 @end

--- a/MatrixKit/Models/Search/MXKSearchDataSource.m
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.m
@@ -247,7 +247,8 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
         return cell;
     }
 
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 @end


### PR DESCRIPTION
return a fake cell to prevent app from crashing.