### PR TITLE
MXKTools - availableCompressionSizesForImage: The original image data…

### DIFF
--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -146,11 +146,12 @@ typedef struct
 + (UIImage*)forceImageOrientationUp:(UIImage*)imageSrc;
 
 /**
- Return struct MXKImageCompressionSizes representing the available compresseion sizes for the image
+ Return struct MXKImageCompressionSizes representing the available compression sizes for the image
  
  @param image the image to get available sizes for
+ @param originalFileSize the size in bytes of the original image file or the image data (0 if this value is unknown).
  */
-+ (MXKImageCompressionSizes)availableCompressionSizesForImage:(UIImage*)image;
++ (MXKImageCompressionSizes)availableCompressionSizesForImage:(UIImage*)image originalFileSize:(NSUInteger)originalFileSize;
 
 /**
  Compute image size to fit in specific box size (in aspect fit mode)

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -296,14 +296,14 @@
     return retImage;
 }
 
-+ (MXKImageCompressionSizes)availableCompressionSizesForImage:(UIImage*)image
++ (MXKImageCompressionSizes)availableCompressionSizesForImage:(UIImage*)image originalFileSize:(NSUInteger)originalFileSize
 {
     MXKImageCompressionSizes compressionSizes;
     memset(&compressionSizes, 0, sizeof(MXKImageCompressionSizes));
     
     // Store the original
     compressionSizes.original.imageSize = image.size;
-    compressionSizes.original.fileSize = UIImageJPEGRepresentation(image, 0.9).length;
+    compressionSizes.original.fileSize = originalFileSize ? originalFileSize : UIImageJPEGRepresentation(image, 0.9).length;
     
     NSLog(@"[MXKRoomInputToolbarView] availableCompressionSizesForImage: %f %f - File size: %tu", compressionSizes.original.imageSize.width, compressionSizes.original.imageSize.height, compressionSizes.original.fileSize);
     

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -399,7 +399,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         NSData *data = [NSData dataWithContentsOfURL:contentEditingInput.fullSizeImageURL];
         UIImage *image = [UIImage imageWithData:data];
 
-        MXKImageCompressionSizes compressionSizes = [MXKTools availableCompressionSizesForImage:image];
+        MXKImageCompressionSizes compressionSizes = [MXKTools availableCompressionSizesForImage:image originalFileSize:data.length];
 
         sizes.small = compressionSizes.small.fileSize;
         sizes.medium = compressionSizes.medium.fileSize;
@@ -589,7 +589,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     }
 
     // Get availabe sizes for this image
-    MXKImageCompressionSizes compressionSizes = [MXKTools availableCompressionSizesForImage:image];
+    MXKImageCompressionSizes compressionSizes = [MXKTools availableCompressionSizesForImage:image originalFileSize:0];
 
     // Apply the compression mode
     if (compressionMode == MXKRoomInputToolbarCompressionModePrompt


### PR DESCRIPTION
… size should be provided

to avoid useless computations which impact application performance in case of big image.

Required to fix "share silently fails on big pics - eg panoramas"
https://github.com/vector-im/riot-ios/issues/1627