### PR TITLE
Bug Fix - Failed to send photos which are not stored on the local device

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -81,6 +81,11 @@ extern NSString *const kCmdChangeRoomTopic;
     NSString *savedInputToolbarPlaceholder;
     
     /**
+     Tell whether the input toolbar required to run an animation indicator.
+     */
+    BOOL isInputToolbarProcessing;
+    
+    /**
      Tell whether a device rotation is in progress
      */
     BOOL isSizeTransitionInProgress;

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -3360,10 +3360,10 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     }];
 }
 
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSURL *)imageLocalURL withMimeType:(NSString*)mimetype
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSData*)imageData withMimeType:(NSString*)mimetype
 {
     // Let the datasource send it and manage the local echo
-    [roomDataSource sendImage:imageLocalURL mimeType:mimetype success:nil failure:^(NSError *error)
+    [roomDataSource sendImage:imageData mimeType:mimetype success:nil failure:^(NSError *error)
     {
         // Nothing to do. The image is marked as unsent in the room history by the datasource
         NSLog(@"[MXKRoomViewController] sendImage with mimetype failed.");

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -308,6 +308,12 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     // Observe the server sync
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onSyncNotification) name:kMXSessionDidSyncNotification object:nil];
     
+    // Be sure to display the activity indicator during back pagination
+    if (isPaginationInProgress)
+    {
+        [self startActivityIndicator];
+    }
+    
     // Finalize view controller appearance
     [self updateViewControllerAppearanceOnRoomDataSourceState];
     
@@ -1794,7 +1800,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     }
     
     // Check internal processes before stopping the loading wheel
-    if (isPaginationInProgress)
+    if (isPaginationInProgress || isInputToolbarProcessing)
     {
         // Keep activity indicator running
         return;
@@ -3407,6 +3413,19 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     [self dismissViewControllerAnimated:flag completion:completion];
 }
 
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView updateActivityIndicator:(BOOL)isAnimating
+{
+    isInputToolbarProcessing = isAnimating;
+    
+    if (isAnimating)
+    {
+        [self startActivityIndicator];
+    }
+    else
+    {
+        [self stopActivityIndicator];
+    }
+}
 # pragma mark - Typing notification
 
 - (void)handleTypingNotification:(BOOL)typing

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -361,13 +361,13 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  While sending, a fake event will be echoed in the messages list.
  Once complete, this local echo will be replaced by the event saved by the homeserver.
  
- @param imageLocalURL the local filesystem path of the image to send.
+ @param imageData the full-sized image data of the image to send.
  @param mimetype the mime type of the image
  @param success A block object called when the operation succeeds. It returns
  the event id of the event generated on the home server
  @param failure A block object called when the operation fails.
  */
-- (void)sendImage:(NSURL *)imageLocalURL mimeType:(NSString*)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure;
+- (void)sendImage:(NSData*)imageData mimeType:(NSString*)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure;
 
 /**
  Send an video to the room.

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1149,9 +1149,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     [self sendImageData:imageData withImageSize:image.size mimeType:mimetype andThumbnail:thumbnail success:success failure:failure];
 }
 
-- (void)sendImage:(NSURL *)imageLocalURL mimeType:(NSString *)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
+- (void)sendImage:(NSData *)imageData mimeType:(NSString *)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
 {
-    NSData *imageData = [NSData dataWithContentsOfFile:imageLocalURL.path];
     UIImage *image = [UIImage imageWithData:imageData];
     
     // Shall we need to consider a thumbnail?

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1277,7 +1277,8 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     
                     if (mimetype)
                     {
-                        [self sendImage:[NSURL fileURLWithPath:localImagePath isDirectory:NO] mimeType:mimetype success:success failure:failure];
+                        NSData *imageData = [NSData dataWithContentsOfFile:localImagePath];
+                        [self sendImage:imageData mimeType:mimetype success:success failure:failure];
                     }
                     else
                     {

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -171,6 +171,14 @@ typedef enum : NSUInteger
  */
 - (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion;
 
+/**
+ Tells the delegate to start or stop an activity indicator.
+ 
+ @param toolbarView the room input toolbar view
+ @param isAnimating YES if the activity indicator should run.
+ */
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView updateActivityIndicator:(BOOL)isAnimating;
+
 @end
 
 /**

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -104,10 +104,10 @@ typedef enum : NSUInteger
  Tells the delegate that the user wants to send an image.
  
  @param toolbarView the room input toolbar view.
- @param imageLocalURL the local filesystem path of the image to send.
+ @param imageData the full-sized image data of the image.
  @param mimetype image mime type
  */
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSURL*)imageLocalURL withMimeType:(NSString*)mimetype;
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSData*)imageData withMimeType:(NSString*)mimetype;
 
 /**
  Tells the delegate that the user wants to send a video.
@@ -248,13 +248,15 @@ typedef enum : NSUInteger
 - (IBAction)onTouchUpInside:(UIButton*)button;
 
 /**
- Handle image attachment according to the compression mode. Save the image in user's photos library when the local url is nil and auto saving is enabled.
+ Handle image attachment
+ Save the image in user's photos library when 'isPhotoLibraryAsset' flag is NO and auto saving is enabled.
  
- @param selectedImage the original selected image.
- @param compressionMode the compression mode to apply on this image (see MXKRoomInputToolbarCompressionMode). This option is considered only for jpeg image.
- @param imageURL the url that references the image in the file system or in the AssetsLibrary framework (nil if the image is not stored in Photos library).
+ @param imageData the full-sized image data of the selected image.
+ @param mimetype the image MIME type (nil if unknown).
+ @param compressionMode the compression mode to apply on this image. This option is considered only for jpeg image.
+ @param isPhotoLibraryAsset tell whether the image has been selected from the user's photos library or not.
  */
-- (void)sendSelectedImage:(UIImage*)selectedImage withCompressionMode:(MXKRoomInputToolbarCompressionMode)compressionMode andLocalURL:(NSURL*)imageURL;
+- (void)sendSelectedImage:(NSData*)imageData withMimeType:(NSString *)mimetype andCompressionMode:(MXKRoomInputToolbarCompressionMode)compressionMode isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
 
 /**
  Handle video attachment.

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -318,7 +318,7 @@ NSString *const kPasteboardItemPrefix = @"pasteboard-";
     
     if (pendingImages.count)
     {
-        UIImage *firstImage = pendingImages.firstObject;
+        NSData *firstImage = pendingImages.firstObject;
         [pendingImages removeObjectAtIndex:0];
         [self sendImage:firstImage withCompressionMode:MXKRoomInputToolbarCompressionModePrompt];
     }


### PR DESCRIPTION
and must be downloaded from iCloud.

https://github.com/vector-im/riot-ios/issues/1654

- API breaks: We consider the full-sized image data instead of the local image URL (this is required to handle correctly image stored in iCloud).
MXKRoomInputToolbarView :
`(void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSURL*)imageLocalURL withMimeType:(NSString*)mimetype;`
is replaced with
`(void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendImage:(NSData*)imageData withMimeType:(NSString*)mimetype;`

`(void)sendSelectedImage:(UIImage*)selectedImage withCompressionMode:(MXKRoomInputToolbarCompressionMode)compressionMode andLocalURL:(NSURL*)imageURL`
is replaced with
`(void)sendSelectedImage:(NSData*)imageData withMimeType:(NSString *)mimetype andCompressionMode:(MXKRoomInputToolbarCompressionMode)compressionMode isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset`

MXKRoomDataSource:
`(void)sendImage:(NSURL *)imageLocalURL mimeType:(NSString*)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure`
is replaced with
`(void)sendImage:(NSData*)imageData mimeType:(NSString*)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure`

- Remove AssetsLibrary framework use (deprecated since iOS 9)