### PR TITLE
Groups: self-management of membership of groups

### DIFF
--- a/MatrixKit/Controllers/MXKGroupListViewController.m
+++ b/MatrixKit/Controllers/MXKGroupListViewController.m
@@ -161,6 +161,9 @@
     
     // Do a full reload
     [self refreshGroupsTable];
+    
+    // Refresh all groups summary
+    [self.dataSource refreshGroupsSummary:nil];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -480,7 +483,11 @@
 - (void)onSyncNotification
 {
     latestServerSync = [NSDate date];
-    [self removeReconnectingView];
+    
+    // Refresh all groups summary
+    [self.dataSource refreshGroupsSummary:^{
+        [self removeReconnectingView];
+    }];
 }
 
 - (BOOL)canReconnect

--- a/MatrixKit/Models/Group/MXKGroupCellData.m
+++ b/MatrixKit/Models/Group/MXKGroupCellData.m
@@ -37,7 +37,7 @@
     group = theGroup;
     
     // Keep ref on displayed last event
-    groupDisplayname = sortingDisplayname = group.summary.profile.name;
+    groupDisplayname = sortingDisplayname = group.profile.name;
     
     if (!groupDisplayname.length)
     {

--- a/MatrixKit/Models/Group/MXKSessionGroupsDataSource.h
+++ b/MatrixKit/Models/Group/MXKSessionGroupsDataSource.h
@@ -51,6 +51,15 @@ extern NSString *const kMXKGroupCellIdentifier;
 #pragma mark - Life cycle
 
 /**
+ Refresh all the groups summary.
+ The group data are not synced with the server, use this method to refresh them according to your needs.
+ 
+ @param completion the block to execute when a request has been done for each group (whatever the result of the requests).
+ You may specify nil for this parameter.
+ */
+- (void)refreshGroupsSummary:(void (^)(void))completion;
+
+/**
  Filter the current groups list according to the provided patterns.
  When patterns are not empty, the search result is stored in `filteredGroupsCellDataArray`,
  this array provides then data for the cells served by `MXKSessionGroupsDataSource`.

--- a/MatrixKit/Views/Group/MXKGroupTableViewCell.m
+++ b/MatrixKit/Views/Group/MXKGroupTableViewCell.m
@@ -28,17 +28,17 @@
     groupCellData = (id<MXKGroupCellDataStoring>)cellData;
     if (groupCellData)
     {
-        // Report computed values as is
+        // Render the current group values.
         _groupName.text = groupCellData.groupDisplayname;
-        _groupDescription.text = groupCellData.group.summary.profile.shortDescription;
+        _groupDescription.text = groupCellData.group.profile.shortDescription;
         
         if (_memberCount)
         {
-            if (groupCellData.group.users.totalUserCountEstimate > 1)
+            if (groupCellData.group.summary.usersSection.totalUserCountEstimate > 1)
             {
-                _memberCount.text = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"num_members_other"], @(groupCellData.group.users.totalUserCountEstimate)];
+                _memberCount.text = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"num_members_other"], @(groupCellData.group.summary.usersSection.totalUserCountEstimate)];
             }
-            else if (groupCellData.group.users.totalUserCountEstimate == 1)
+            else if (groupCellData.group.summary.usersSection.totalUserCountEstimate == 1)
             {
                 _memberCount.text = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"num_members_one"], @1];
             }


### PR DESCRIPTION
- MXKSessionGroupDataSource: support the group summary refresh

vector-im/riot-meta#114