### PR TITLE
Missing Push Notifications: Store MXKAccount data (like user credentials) 

### DIFF
--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -507,23 +507,14 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
     }
     else
     {
-        // Migration of accountData from [NSUserDefaults standardUserDefaults] to a file
+        // Migration of accountData from sharedUserDefaults to a file
         NSUserDefaults *sharedDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;
 
         NSData *accountData = [sharedDefaults objectForKey:kMXKAccountsKey];
         if (!accountData)
         {
-            // Migration of accountData from [NSUserDefaults standardUserDefaults] to sharedDefaults (shared between apps and extensions)
-            NSData *oldAccountData = [[NSUserDefaults standardUserDefaults] objectForKey:kMXKAccountsKey];
-            if (oldAccountData)
-            {
-                [sharedDefaults setObject:oldAccountData forKey:kMXKAccountsKey];
-                [sharedDefaults synchronize];;
-
-                NSLog(@"[MXKAccountManager] loadAccounts: performed data migration #1");
-            }
-
-            accountData = [sharedDefaults objectForKey:kMXKAccountsKey];
+            // Migration of accountData from [NSUserDefaults standardUserDefaults], the first location storage
+            accountData = [[NSUserDefaults standardUserDefaults] objectForKey:kMXKAccountsKey];
         }
 
         if (accountData)
@@ -531,7 +522,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
             mxAccounts = [NSMutableArray arrayWithArray:[NSKeyedUnarchiver unarchiveObjectWithData:accountData]];
             [self saveAccounts];
 
-            NSLog(@"[MXKAccountManager] loadAccounts: performed data migration #2");
+            NSLog(@"[MXKAccountManager] loadAccounts: performed data migration");
 
             // Now that data has been migrated, erase old location of accountData
             [[NSUserDefaults standardUserDefaults] removeObjectForKey:kMXKAccountsKey];

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -190,6 +190,11 @@
 + (MXKAppSettings *)standardAppSettings;
 
 /**
+ Return the folder to use for caching MatrixKit data.
+ */
++ (NSString*)cacheFolder;
+
+/**
  Restore the default values.
  */
 - (void)reset;

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -59,6 +59,40 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
     return standardAppSettings;
 }
 
++ (NSString *)cacheFolder
+{
+    NSString *cacheFolder;
+
+    // Check for a potential application group id
+    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
+    if (applicationGroupIdentifier)
+    {
+        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
+        cacheFolder = [sharedContainerURL path];
+    }
+    else
+    {
+        NSArray *cacheDirList = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        cacheFolder  = [cacheDirList objectAtIndex:0];
+    }
+
+    // Use a dedicated cache folder for MatrixKit
+    cacheFolder = [cacheFolder stringByAppendingPathComponent:@"MatrixKit"];
+
+    // Make sure the folder exists so that it can be used
+    if (cacheFolder && ![[NSFileManager defaultManager] fileExistsAtPath:cacheFolder])
+    {
+        NSError *error;
+        [[NSFileManager defaultManager] createDirectoryAtPath:cacheFolder withIntermediateDirectories:YES attributes:nil error:&error];
+        if (error)
+        {
+            NSLog(@"[MXKAppSettings] cacheFolder: Error: Cannot create MatrixKit folder at %@. Error: %@", cacheFolder, error);
+        }
+    }
+
+    return cacheFolder;
+}
+
 #pragma  mark -
 
 -(instancetype)init


### PR DESCRIPTION
into a file instead of NSUserDefaults.

This data should be then more accessible for background processing like handling push notifications.

https://github.com/vector-im/riot-ios/issues/1696