### PR TITLE
BF: iPhone X: room messages overlap the room activity view

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -348,7 +348,13 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
+
+    if (@available(iOS 11.0, *))
+    {
+        // Remove the rounded bottom unsafe area of the iPhone X
+        _bubblesTableViewBottomConstraint.constant += self.view.safeAreaInsets.bottom;
+    }
+
     if (_saveProgressTextInput && roomDataSource)
     {
         // Retrieve the potential message partially typed during last room display.
@@ -472,7 +478,13 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     // Update constraints
     _roomInputToolbarContainerBottomConstraint.constant = inputToolbarViewBottomConst;
     _bubblesTableViewBottomConstraint.constant = inputToolbarViewBottomConst + _roomInputToolbarContainerHeightConstraint.constant + _roomActivitiesContainerHeightConstraint.constant;
-    
+
+    if (@available(iOS 11.0, *))
+    {
+        // Remove the rounded bottom unsafe area of the iPhone X
+        _bubblesTableViewBottomConstraint.constant += self.view.safeAreaInsets.bottom;
+    }
+
     // Invalidate the current layout to take into account the new constraints in the next update cycle.
     [self.view setNeedsLayout];
     


### PR DESCRIPTION
(https://github.com/vector-im/riot-ios/issues/1754)