### PR TITLE
Groups: Display flair for users in room history.

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -25,7 +25,7 @@
 #import "MXMediaManager.h"
 
 @implementation MXKRoomBubbleCellData
-@synthesize senderId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment;
+@synthesize senderId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment, senderFlair;
 @synthesize textMessage, attributedTextMessage;
 @synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel, useCustomReceipts, useCustomUnsentButton, hasNoDisplay;
 @synthesize tag;
@@ -86,6 +86,9 @@
 
 - (void)dealloc
 {
+    // Reset any observer on publicised groups by user.
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
+    
     roomDataSource = nil;
     bubbleComponents = nil;
 }
@@ -346,6 +349,73 @@
     
     // flush the current attributed string to force refresh
     self.attributedTextMessage = nil;
+}
+
+- (void)setShouldHideSenderInformation:(BOOL)inShouldHideSenderInformation
+{
+    shouldHideSenderInformation = inShouldHideSenderInformation;
+    
+    if (!shouldHideSenderInformation)
+    {
+        // Refresh the flair
+        [self refreshSenderFlair];
+    }
+}
+
+- (void)refreshSenderFlair
+{
+    // Reset by default any observer on publicised groups by user.
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
+    
+    // Check first whether the room enabled the flair for some groups
+    NSArray<NSString *> *roomRelatedGroups = roomDataSource.room.state.relatedGroups;
+    if (roomRelatedGroups.count && senderId)
+    {
+        NSArray<NSString *> *senderPublicisedGroups;
+        
+        senderPublicisedGroups = [self.mxSession publicisedGroupsForUser:senderId];
+        
+        if (senderPublicisedGroups.count)
+        {
+            // Cross the 2 arrays to keep only the common group ids
+            NSMutableArray *flair = [NSMutableArray arrayWithCapacity:roomRelatedGroups.count];
+            
+            for (NSString *groupId in roomRelatedGroups)
+            {
+                if ([senderPublicisedGroups indexOfObject:groupId] != NSNotFound)
+                {
+                    MXGroup *group = [self.mxSession groupWithGroupId:groupId];
+                    if (!group)
+                    {
+                        // The current user doesn't belong to this group.
+                        // Create a group instance.
+                        group = [[MXGroup alloc] initWithGroupId:groupId];
+                    }
+                    
+                    [flair addObject:group];
+                    
+                    // Refresh the group profile from server.
+                    [self.mxSession updateGroupProfile:group success:nil failure:^(NSError *error) {
+                        
+                        NSLog(@"[MXKRoomBubbleCellData] refreshSenderFlair: group profile update failed %@", groupId);
+                        
+                    }];
+                }
+            }
+            
+            if (flair.count)
+            {
+                self.senderFlair = flair;
+            }
+            else
+            {
+                self.senderFlair = nil;
+            }
+        }
+        
+        // Observe any change on publicised groups for the message sender
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didMXSessionUpdatePublicisedGroupsForUsers:) name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
+    }
 }
 
 #pragma mark -
@@ -771,6 +841,20 @@
     }
 
     return index;
+}
+
+- (void)didMXSessionUpdatePublicisedGroupsForUsers:(NSNotification *)notif
+{
+    // Retrieved the list of the concerned users
+    NSArray<NSString*> *userIds = notif.userInfo[kMXSessionNotificationUserIdsArrayKey];
+    if (userIds.count && self.senderId)
+    {
+        // Check whether the current sender is concerned.
+        if ([userIds indexOfObject:self.senderId] != NSNotFound)
+        {
+            [self refreshSenderFlair];
+        }
+    }
 }
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -59,6 +59,11 @@
 @property (nonatomic) UIImage *senderAvatarPlaceholder;
 
 /**
+ The current sender flair (list of the publicised groups in the sender profile which matches the room flair settings)
+ */
+@property (nonatomic) NSArray<MXGroup*> *senderFlair;
+
+/**
  Tell whether a new pagination starts with this bubble.
  */
 @property (nonatomic) BOOL isPaginationFirstBubble;
@@ -225,6 +230,11 @@ Update the event because its sent state changed or it is has been redacted.
  @param patternFont optional text font (the pattern font is unchanged if nil).
  */
 - (void)highlightPatternInTextMessage:(NSString*)pattern withForegroundColor:(UIColor*)patternColor andFont:(UIFont*)patternFont;
+
+/**
+ Refresh the sender flair information
+ */
+- (void)refreshSenderFlair;
 
 #pragma mark - Bubble collapsing
 

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -200,6 +200,15 @@ typedef struct
 + (UIImage*)resizeImage:(UIImage *)image toSize:(CGSize)size;
 
 /**
+ Resize image with rounded corners to a provided size.
+ 
+ @param image the image to modify.
+ @param size the new size.
+ @return resized image.
+ */
++ (UIImage*)resizeImageWithRoundedCorners:(UIImage *)image toSize:(CGSize)size;
+
+/**
  Paint an image with a color.
  
  @discussion

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -462,7 +462,14 @@ static NSRegularExpression *httpLinksRegex;
         {
             // Create the thumbnail
             CGSize imageSize = CGSizeMake(width, height);
-            UIGraphicsBeginImageContext(imageSize);
+            
+            // Convert first the provided size in pixels
+#if TARGET_OS_IPHONE
+            CGFloat scale = [[UIScreen mainScreen] scale];
+#elif TARGET_OS_OSX
+            CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+#endif
+            UIGraphicsBeginImageContextWithOptions(imageSize, NO, scale);
             
             //            // set to the top quality
             //            CGContextRef context = UIGraphicsGetCurrentContext();
@@ -489,10 +496,46 @@ static NSRegularExpression *httpLinksRegex;
     // Check whether resize is required
     if (size.width && size.height)
     {
-        UIGraphicsBeginImageContext(size);
+        // Convert first the provided size in pixels
+#if TARGET_OS_IPHONE
+        CGFloat scale = [[UIScreen mainScreen] scale];
+#elif TARGET_OS_OSX
+        CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+#endif
+        UIGraphicsBeginImageContextWithOptions(size, NO, scale);
         
         CGContextRef context = UIGraphicsGetCurrentContext();
         CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+        
+        [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
+        resizedImage = UIGraphicsGetImageFromCurrentImageContext();
+        
+        UIGraphicsEndImageContext();
+    }
+    
+    return resizedImage;
+}
+
++ (UIImage*)resizeImageWithRoundedCorners:(UIImage *)image toSize:(CGSize)size
+{
+    UIImage *resizedImage = image;
+    
+    // Check whether resize is required
+    if (size.width && size.height)
+    {
+        // Convert first the provided size in pixels
+#if TARGET_OS_IPHONE
+        CGFloat scale = [[UIScreen mainScreen] scale];
+#elif TARGET_OS_OSX
+        CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+#endif
+        UIGraphicsBeginImageContextWithOptions(size, NO, scale);
+        
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+        
+        // Add a clip to round corners
+        [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, size.width, size.height) cornerRadius:size.width/2] addClip];
         
         [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
         resizedImage = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
MXKRoomDataSource: Force a refresh on flair settings change.
MXKRoomBubbleCellData: keep update the flair of the sender.
MXKRoomBubbleTableViewCell: Display the sender flair if any

TODO: display the full flair list when the user clicks on the displayed flair.

vector-im/riot-meta#118