### PR TITLE
Enhance the flair handling,

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -384,22 +384,8 @@
             {
                 if ([senderPublicisedGroups indexOfObject:groupId] != NSNotFound)
                 {
-                    MXGroup *group = [self.mxSession groupWithGroupId:groupId];
-                    if (!group)
-                    {
-                        // The current user doesn't belong to this group.
-                        // Create a group instance.
-                        group = [[MXGroup alloc] initWithGroupId:groupId];
-                    }
-                    
+                    MXGroup *group = [roomDataSource groupWithGroupId:groupId];
                     [flair addObject:group];
-                    
-                    // Refresh the group profile from server.
-                    [self.mxSession updateGroupProfile:group success:nil failure:^(NSError *error) {
-                        
-                        NSLog(@"[MXKRoomBubbleCellData] refreshSenderFlair: group profile update failed %@", groupId);
-                        
-                    }];
                 }
             }
             
@@ -411,6 +397,10 @@
             {
                 self.senderFlair = nil;
             }
+        }
+        else
+        {
+            self.senderFlair = nil;
         }
         
         // Observe any change on publicised groups for the message sender

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -96,6 +96,11 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
      The queue of events that need to be processed in order to compute their display.
      */
     NSMutableArray *eventsToProcess;
+    
+    /**
+     The dictionary of the related groups that the current user did not join.
+     */
+    NSMutableDictionary<NSString*, MXGroup*> *externalRelatedGroups;
 }
 
 /**
@@ -141,7 +146,6 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  The current text message partially typed in text input (use nil to reset it).
  */
 @property (nonatomic) NSString *partialTextMessage;
-
 
 #pragma mark - Configuration
 /**
@@ -479,5 +483,16 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  @param collapsed YES to collapse. NO to expand.
  */
 - (void)collapseRoomBubble:(id<MXKRoomBubbleCellDataStoring>)bubbleData collapsed:(BOOL)collapsed;
+
+#pragma mark - Groups
+
+/**
+ Get a MXGroup instance for a group.
+ This method is used by the bubble to retrieve a related groups of the room.
+ 
+ @param groupId The identifier to the group.
+ @return the MXGroup instance.
+ */
+- (MXGroup *)groupWithGroupId:(NSString*)groupId;
 
 @end


### PR DESCRIPTION
by managing the related groups of a room at the RoomDataSource level instead of at the bubble level

vector-im/riot-meta#118