### PR TITLE
Community: Room summary should not display notices about groups

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -656,6 +656,9 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     MXKEventFormatter *eventFormatter = [[MXKEventFormatter alloc] initWithMatrixSession:self.mxSession];
     eventFormatter.isForSubtitle = YES;
 
+    // Apply the event types filter to display only the wanted event types.
+    eventFormatter.eventTypesFilterForMessages = [MXKAppSettings standardAppSettings].eventsFilterForMessages;
+
     mxSession.roomSummaryUpdateDelegate = eventFormatter;
 
     // Observe UIApplicationSignificantTimeChangeNotification to refresh to MXRoomSummaries if date/time are shown.


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/1780

This bug revealed a more generic one where room summaries did not use any event filter. This made their display not aligned with messages displayed in room history.