### PR TITLE
Bug Fix - My communities screen is empty despite me being in several …

### DIFF
--- a/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
+++ b/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
@@ -215,7 +215,10 @@ NSString *const kMXKGroupCellIdentifier = @"kMXKGroupCellIdentifier";
 
 - (void)loadData
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionNewGroupInviteNotification object:self.mxSession];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidJoinGroupNotification object:self.mxSession];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidLeaveGroupNotification object:self.mxSession];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdateGroupSummaryNotification object:self.mxSession];
     
     // Reset the table
     [internalCellDataArray removeAllObjects];

--- a/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
@@ -204,6 +204,7 @@ NSString *const kMXKRecentCellIdentifier = @"kMXKRecentCellIdentifier";
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXKRoomDataSourceSyncStatusChanged object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionNewRoomNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidLeaveRoomNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDirectRoomsDidChangeNotification object:nil];
     
     // Reset the table
     [internalCellDataArray removeAllObjects];


### PR DESCRIPTION
…groups

The mxSession state change listener was removed by mistake.

vector-im/riot-ios#1792