### PR TITLE
Render sticker events in the timeline

### DIFF
--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2040,6 +2040,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
         if (attachmentsViewer)
         {
             // Check whether some older attachments have been added.
+            // Note: the stickers are excluded from the attachments list returned by the room datasource.
             BOOL isDone = NO;
             NSArray *attachmentsWithThumbnail = self.roomDataSource.attachmentsWithThumbnail;
             if (attachmentsWithThumbnail.count)
@@ -3552,8 +3553,10 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
             
             if (bubbleData.isAttachmentWithThumbnail)
             {
-                if (selectedAttachment.eventSentState == MXEventSentStateSent)
+                // The attachments viewer is opened only on a valid attachment. It does not display the stickers.
+                if (selectedAttachment.eventSentState == MXEventSentStateSent && selectedAttachment.type != MXKAttachmentTypeSticker)
                 {
+                    // Note: the stickers are presently excluded from the attachments list returned by the room dataSource.
                     NSArray *attachmentsWithThumbnail = self.roomDataSource.attachmentsWithThumbnail;
                     
                     // Present an attachment viewer

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -133,6 +133,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 
 /**
  The list of the attachments with thumbnail in the current available bubbles (MXKAttachment instances).
+ Note: the stickers are excluded from the returned list.
  */
 @property (nonatomic, readonly) NSArray *attachmentsWithThumbnail;
 
@@ -209,7 +210,8 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic) NSUInteger paginationLimitAroundInitialEvent;
 
 /**
- Tell whether only the events with a url key in their content must be handled. NO by default.
+ Tell whether only the message events with an url key in their content must be handled. NO by default.
+ Note: The stickers are not retained by this filter.
  */
 @property (nonatomic) BOOL filterMessagesWithURL;
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -600,7 +600,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     {
         for (id<MXKRoomBubbleCellDataStoring> bubbleData in bubbles)
         {
-            if (bubbleData.isAttachmentWithThumbnail)
+            if (bubbleData.isAttachmentWithThumbnail && bubbleData.attachment.type != MXKAttachmentTypeSticker)
             {
                 [attachments addObject:bubbleData.attachment];
             }
@@ -994,7 +994,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
     
     // Define a new listener for this pagination
-    paginationListener = [_timeline listenToEventsOfTypes:[MXKAppSettings standardAppSettings].allEventTypesForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction2, MXRoomState *roomState) {
+    paginationListener = [_timeline listenToEventsOfTypes:(_filterMessagesWithURL ? @[kMXEventTypeStringRoomMessage] : [MXKAppSettings standardAppSettings].allEventTypesForMessages) onEvent:^(MXEvent *event, MXTimelineDirection direction2, MXRoomState *roomState) {
         
         if (direction2 == direction)
         {


### PR DESCRIPTION
- Remove the stickers from the attachments viewer and the files tab

https://github.com/vector-im/riot-ios/issues/1819