### PR TITLE
Improve Error Notifications

### DIFF
--- a/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
+++ b/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -148,7 +149,8 @@
             [self stopActivityIndicator];
             
             // Notify MatrixKit user
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:note.userInfo[kMXNotificationCenterErrorKey]];
+            NSString *myUserId = self.mxAccount.mxCredentials.userId;
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:note.userInfo[kMXNotificationCenterErrorKey] userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
         }];
     }
     

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -190,7 +191,8 @@
                                [self removePendingActionMask];
                                NSLog(@"[MXKRoomMemberDetailsVC] Invite %@ failed", _mxRoomMember.userId);
                                // Notify MatrixKit user
-                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                               NSString *myUserId = self.mainSession.myUser.userId;
+                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                
                            }];
                 break;
@@ -208,7 +210,8 @@
                     [self removePendingActionMask];
                     NSLog(@"[MXKRoomMemberDetailsVC] Leave room %@ failed", mxRoom.state.roomId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = self.mainSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
                 break;
@@ -232,7 +235,8 @@
                              [self removePendingActionMask];
                              NSLog(@"[MXKRoomMemberDetailsVC] Kick %@ failed", _mxRoomMember.userId);
                              // Notify MatrixKit user
-                             [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                             NSString *myUserId = self.mainSession.myUser.userId;
+                             [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                              
                          }];
                 break;
@@ -251,7 +255,8 @@
                             [self removePendingActionMask];
                             NSLog(@"[MXKRoomMemberDetailsVC] Ban %@ failed", _mxRoomMember.userId);
                             // Notify MatrixKit user
-                            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                            NSString *myUserId = self.mainSession.myUser.userId;
+                            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                             
                         }];
                 break;
@@ -269,7 +274,8 @@
                               [self removePendingActionMask];
                               NSLog(@"[MXKRoomMemberDetailsVC] Unban %@ failed", _mxRoomMember.userId);
                               // Notify MatrixKit user
-                              [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                              NSString *myUserId = self.mainSession.myUser.userId;
+                              [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                               
                           }];
                 break;
@@ -307,7 +313,8 @@
                                                                                                  NSLog(@"[MXKRoomMemberDetailsVC] Ignore %@ failed", self.mxRoomMember.userId);
                                                                                                  
                                                                                                  // Notify MatrixKit user
-                                                                                                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                                                 NSString *myUserId = self.mainSession.myUser.userId;
+                                                                                                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                                                  
                                                                                              }];
                                                                    }
@@ -347,7 +354,8 @@
                                                 NSLog(@"[MXKRoomMemberDetailsVC] Unignore %@ failed", strongSelf.mxRoomMember.userId);
 
                                                 // Notify MatrixKit user
-                                                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                NSString *myUserId = self.mainSession.myUser.userId;
+                                                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
 
                                             }];
                 break;
@@ -431,7 +439,8 @@
                                                  NSLog(@"[MXKRoomMemberDetailsVC] Create room failed");
                                                  [self removePendingActionMask];
                                                  // Notify MatrixKit user
-                                                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                 NSString *myUserId = self.mainSession.myUser.userId;
+                                                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                  
                                              }];
                     }
@@ -922,7 +931,8 @@
                 NSLog(@"[MXKRoomMemberDetailsVC] Set user power (%@) failed", strongSelf.mxRoomMember.userId);
 
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = self.mainSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
             }];
         }

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -931,7 +931,7 @@
                 NSLog(@"[MXKRoomMemberDetailsVC] Set user power (%@) failed", strongSelf.mxRoomMember.userId);
 
                 // Notify MatrixKit user
-                NSString *myUserId = self.mainSession.myUser.userId;
+                NSString *myUserId = strongSelf.mainSession.myUser.userId;
                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
             }];

--- a/MatrixKit/Controllers/MXKRoomMemberListViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberListViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -564,7 +565,8 @@
                                                                        
                                                                        NSLog(@"[MXKRoomVC] Invite %@ failed", userId);
                                                                        // Notify MatrixKit user
-                                                                       [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                       NSString *myUserId = self.mainSession.myUser.userId;
+                                                                       [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                        
                                                                    }];
                                                                }

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -1340,7 +1340,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                 
                 NSLog(@"[MXKRoomVC] Set displayName failed");
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
             }];
         }
@@ -1373,7 +1374,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                 
                 NSLog(@"[MXKRoomVC] Join roomAlias (%@) failed", roomAlias);
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
             }];
         }
@@ -1430,7 +1432,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
                 NSLog(@"[MXKRoomVC] Part room_alias (%@ / %@) failed", roomIdOrAlias, roomId);
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
             }];
         }
@@ -1461,7 +1464,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
                 NSLog(@"[MXKRoomVC] Set topic failed");
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
 
             }];
         }
@@ -1498,7 +1502,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
                     NSLog(@"[MXKRoomVC] Invite user (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
 
                 }];
             }
@@ -1532,7 +1537,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     
                     NSLog(@"[MXKRoomVC] Kick user (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
             }
@@ -1566,7 +1572,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     
                     NSLog(@"[MXKRoomVC] Ban user (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
             }
@@ -1587,7 +1594,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     
                     NSLog(@"[MXKRoomVC] Unban user (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
             }
@@ -1622,7 +1630,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                     
                     NSLog(@"[MXKRoomVC] Set user power (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
             }
@@ -1643,7 +1652,8 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
                     NSLog(@"[MXKRoomVC] Reset user power (%@) failed", userId);
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = roomDataSource.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
 
                 }];
             }

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -1287,7 +1288,8 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         {
             // Notify MatrixKit user only once
             notifyOpenSessionFailure = NO;
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+            NSString *myUserId = mxSession.myUser.userId;
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
         }
         
         // Check if it is a network connectivity issue

--- a/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
+++ b/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -596,7 +597,8 @@ NSString *const kMXKGroupCellIdentifier = @"kMXKGroupCellIdentifier";
             NSLog(@"[MXKSessionGroupsDataSource] Failed to leave group (%@)", cellData.group.groupId);
             
             // Notify MatrixKit user
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+            NSString *myUserId = self.mxSession.myUser.userId;
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
             
         }];
     }

--- a/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKRecentsDataSource.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -634,7 +635,8 @@
             NSLog(@"[MXKRecentsDataSource] Failed to leave room (%@) failed", room.state.roomId);
             
             // Notify MatrixKit user
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+            NSString *myUserId = room.mxSession.myUser.userId;
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
             
         }];
     }

--- a/MatrixKit/Utils/MXKConstants.h
+++ b/MatrixKit/Utils/MXKConstants.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -25,5 +26,14 @@ FOUNDATION_EXPORT NSString *const MatrixKitVersion;
  Posted when an error is observed at Matrix Kit level.
  This notification may be used to inform user by showing the error as an alert.
  The notification object is the NSError instance.
+ 
+ The passed userInfo dictionary may contain:
+ - `kMXKErrorUserIdKey` the matrix identifier of the account concerned by this error.
  */
 FOUNDATION_EXPORT NSString *const kMXKErrorNotification;
+
+/**
+ The key in notification userInfo dictionary representating the account userId.
+ */
+FOUNDATION_EXPORT NSString *const kMXKErrorUserIdKey;
+

--- a/MatrixKit/Utils/MXKConstants.m
+++ b/MatrixKit/Utils/MXKConstants.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -19,3 +20,5 @@
 NSString *const MatrixKitVersion = @"0.7.9";
 
 NSString *const kMXKErrorNotification = @"kMXKErrorNotification";
+
+NSString *const kMXKErrorUserIdKey = @"kMXKErrorUserIdKey";

--- a/MatrixKit/Views/DeviceView/MXKDeviceView.m
+++ b/MatrixKit/Views/DeviceView/MXKDeviceView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -310,12 +311,13 @@ static NSAttributedString *verticalWhitespace = nil;
                                                                
                                                            } failure:^(NSError *error) {
                                                                
-                                                               // Notify MatrixKit user
-                                                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
-                                                               
                                                                if (weakSelf)
                                                                {
                                                                    typeof(self) self = weakSelf;
+                                                                   
+                                                                   // Notify MatrixKit user
+                                                                   NSString *myUserId = self->mxSession.myUser.userId;
+                                                                   [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                    
                                                                    self->mxCurrentOperation = nil;
                                                                    
@@ -428,13 +430,14 @@ static NSAttributedString *verticalWhitespace = nil;
                                                                        }
                                                                        
                                                                    } failure:^(NSError *error) {
-                                                                       
-                                                                       // Notify MatrixKit user
-                                                                       [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
-                                                                       
+                                                    
                                                                        if (weakSelf)
                                                                        {
                                                                            typeof(self) self = weakSelf;
+                                                                           
+                                                                           // Notify MatrixKit user
+                                                                           NSString *myUserId = self->mxSession.myUser.userId;
+                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                            
                                                                            self->mxCurrentOperation = nil;
                                                                            
@@ -466,7 +469,8 @@ static NSAttributedString *verticalWhitespace = nil;
         [self.activityIndicator stopAnimating];
         
         // Notify MatrixKit user
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+        NSString *myUserId = mxSession.myUser.userId;
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
     }];
 }
 

--- a/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -185,7 +186,8 @@ static NSAttributedString *verticalWhitespace = nil;
                     NSLog(@"[MXKEncryptionInfoView] Crypto failed to download device info for user: %@", mxEvent.sender);
                     
                     // Notify MatrixKit user
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                    NSString *myUserId = mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                     
                 }];
             }

--- a/MatrixKit/Views/MXKEventDetailsView.m
+++ b/MatrixKit/Views/MXKEventDetailsView.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -178,7 +179,8 @@
                 NSLog(@"[MXKEventDetailsView] Redact event (%@) failed", mxEvent.eventId);
                 
                 // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                NSString *myUserId = mxRoom.mxSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 
                 [_activityIndicator stopAnimating];
                 

--- a/MatrixKit/Views/MXKRoomCreationView.m
+++ b/MatrixKit/Views/MXKRoomCreationView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -559,7 +560,8 @@
                                     NSLog(@"[MXKRoomCreationView] Create room (%@ %@ (%@)) failed", _roomNameTextField.text, self.alias, (_roomVisibilityControl.selectedSegmentIndex == 0) ? @"Public":@"Private");
                                     
                                     // Notify MatrixKit user
-                                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                    NSString *myUserId = selectedSession.myUser.userId;
+                                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                     
                                 }];
         }

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -219,25 +220,32 @@
             __weak typeof(self) weakSelf = self;
             [_mxRoom setName:roomName success:^{
                 
-                __strong __typeof(weakSelf)strongSelf = weakSelf;
-                if ([strongSelf.delegate respondsToSelector:@selector(roomTitleView:isSaving:)])
+                if (weakSelf)
                 {
-                    [strongSelf.delegate roomTitleView:strongSelf isSaving:NO];
+                    typeof(weakSelf)strongSelf = weakSelf;
+                    if ([strongSelf.delegate respondsToSelector:@selector(roomTitleView:isSaving:)])
+                    {
+                        [strongSelf.delegate roomTitleView:strongSelf isSaving:NO];
+                    }
                 }
                 
             } failure:^(NSError *error) {
                 
-                __strong __typeof(weakSelf)strongSelf = weakSelf;
-                if ([strongSelf.delegate respondsToSelector:@selector(roomTitleView:isSaving:)])
+                if (weakSelf)
                 {
-                    [strongSelf.delegate roomTitleView:strongSelf isSaving:NO];
+                    typeof(weakSelf)strongSelf = weakSelf;
+                    if ([strongSelf.delegate respondsToSelector:@selector(roomTitleView:isSaving:)])
+                    {
+                        [strongSelf.delegate roomTitleView:strongSelf isSaving:NO];
+                    }
+                    
+                    // Revert change
+                    textField.text = strongSelf.mxRoom.summary.displayname;
+                    NSLog(@"[MXKRoomTitleView] Rename room failed");
+                    // Notify MatrixKit user
+                    NSString *myUserId = strongSelf.mxRoom.mxSession.myUser.userId;
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 }
-                
-                // Revert change
-                textField.text = strongSelf.mxRoom.summary.displayname;
-                NSLog(@"[MXKRoomTitleView] Rename room failed");
-                // Notify MatrixKit user
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
                 
             }];
         }


### PR DESCRIPTION
Add the account identifier in userInfo dictionary to let the listener know which account is concerned by the error.

https://github.com/vector-im/riot-ios/issues/1839