### PR TITLE
 HTML Rendering: Fix the display of side borders of HTML blockquotes

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -83,6 +83,11 @@
 @property (nonatomic) CGSize contentSize;
 
 /**
+ Set of flags indicating fixes that need to be applied at display time.
+ */
+@property (nonatomic, readonly) MXKRoomBubbleComponentDisplayFix displayFix;
+
+/**
  Attachment upload
  */
 @property (nonatomic) NSString *uploadId;

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -567,6 +567,20 @@
     return hasAttributedTextMessage;
 }
 
+- (MXKRoomBubbleComponentDisplayFix)displayFix
+{
+    MXKRoomBubbleComponentDisplayFix displayFix = MXKRoomBubbleComponentDisplayFixNone;
+
+    @synchronized(bubbleComponents)
+    {
+        for (MXKRoomBubbleComponent *component in self.bubbleComponents)
+        {
+            displayFix |= component.displayFix;
+        }
+    }
+    return displayFix;
+}
+
 - (BOOL)shouldHideSenderName
 {
     BOOL res = NO;

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -19,6 +19,23 @@
 #import "MXKEventFormatter.h"
 
 /**
+ Flags to indicate if a fix is required at the display time.
+ */
+typedef enum : NSUInteger {
+
+    /**
+     No fix required.
+     */
+    MXKRoomBubbleComponentDisplayFixNone = 0,
+
+    /**
+     Borders for HTML blockquotes need to be fixed.
+     */
+    MXKRoomBubbleComponentDisplayFixHtmlBlockquote = 0x1
+
+} MXKRoomBubbleComponentDisplayFix;
+
+/**
  `MXKRoomBubbleComponent` class compose data related to one `MXEvent` instance.
  */
 @interface MXKRoomBubbleComponent : NSObject
@@ -52,6 +69,11 @@
 // They must be handled by the object which creates the MXKRoomBubbleComponent instance.
 //@property (nonatomic) CGFloat height;
 @property (nonatomic) CGPoint position;
+
+/**
+ Set of flags indicating fixes that need to be applied at display time.
+ */
+@property (nonatomic) MXKRoomBubbleComponentDisplayFix displayFix;
 
 /**
  Create a new `MXKRoomBubbleComponent` object based on a `MXEvent` instance.

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -48,6 +48,15 @@
         
         // Keep ref on event (used to handle the read marker, or a potential event redaction).
         _event = event;
+
+        _displayFix = MXKRoomBubbleComponentDisplayFixNone;
+        if ([event.content[@"format"] isEqualToString:kMXRoomMessageFormatHTML])
+        {
+            if ([((NSString*)event.content[@"formatted_body"]) containsString:@"<blockquote"])
+            {
+                _displayFix |= MXKRoomBubbleComponentDisplayFixHtmlBlockquote;
+            }
+        }
     }
     return self;
 }

--- a/MatrixKit/Utils/MXKEventFormatter.h
+++ b/MatrixKit/Utils/MXKEventFormatter.h
@@ -311,6 +311,12 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIColor *errorTextColor;
 
 /**
+ Color used to display the side border of HTML blockquotes.
+ Default is a grey.
+ */
+@property (nonatomic) UIColor *htmlBlockquoteBorderColor;
+
+/**
  Default text font used to display text content of event.
  Default is SFUIText-Regular 14.
  */

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -83,6 +83,7 @@
         _encryptingTextColor = [UIColor lightGrayColor];
         _sendingTextColor = [UIColor lightGrayColor];
         _errorTextColor = [UIColor redColor];
+        _htmlBlockquoteBorderColor = [MXKTools colorWithRGBValue:0xDDDDDD];
         
         _defaultTextFont = [UIFont systemFontOfSize:14];
         _prefixTextFont = [UIFont systemFontOfSize:14];
@@ -1269,7 +1270,9 @@
 
 - (void)setDefaultCSS:(NSString*)defaultCSS
 {
-    _defaultCSS = defaultCSS;
+    // Make sure we mark HTML blockquote blocks for later computation
+    _defaultCSS = [NSString stringWithFormat:@"%@%@", [MXKTools cssToMarkBlockquotes], defaultCSS];
+
     dtCSS = [[DTCSSStylesheet alloc] initWithStyleBlock:_defaultCSS];
 }
 

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1271,7 +1271,7 @@
 - (void)setDefaultCSS:(NSString*)defaultCSS
 {
     // Make sure we mark HTML blockquote blocks for later computation
-    _defaultCSS = [NSString stringWithFormat:@"%@%@", [MXKTools cssToMarkBlockquotes], defaultCSS];
+    _defaultCSS = [NSString stringWithFormat:@"%@%@", [MXKTools cssToMarkBlockquotesWithColor:_htmlBlockquoteBorderColor], defaultCSS];
 
     dtCSS = [[DTCSSStylesheet alloc] initWithStyleBlock:_defaultCSS];
 }

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -338,9 +338,10 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
  These blocks  output will have a `DTTextBlocksAttribute` attribute in the `NSAttributedString`
  that can be used for later computation.
 
+ @param color the color to use to mark HTML blockquote blocks.
  @return a CSS string.
  */
-+ (NSString*)cssToMarkBlockquotes;
++ (NSString*)cssToMarkBlockquotesWithColor:(UIColor*)color;
 
 /**
  Enumarate all sections of the attributed string that refer to an HTML blockquote block.
@@ -348,8 +349,9 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
  Must be used with `cssToMarkBlockquotes`.
 
  @param attributedString the attributed string.
+ @param color the marker color used in `cssToMarkBlockquotes`.
  @param block a block called for each HTML blockquote blocks.
  */
-+ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block;
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString withColor:(UIColor*)color usingBlock:(void (^)(NSRange range, BOOL *stop))block;
 
 @end

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -330,4 +330,26 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
  */
 + (NSAttributedString*)createLinksInAttributedString:(NSAttributedString*)attributedString forEnabledMatrixIds:(NSInteger)enabledMatrixIdsBitMask;
 
+#pragma mark - HTML processing - blockquote display handling
+
+/**
+ Return a CSS to make DTCoreText mark blockquote blocks in the `NSAttributedString` output.
+
+ These blocks  output will have a `DTTextBlocksAttribute` attribute in the `NSAttributedString`
+ that can be used for later computation.
+
+ @return a CSS string.
+ */
++ (NSString*)cssToMarkBlockquotes;
+
+/**
+ Enumarate all sections of the attributed string that refer to an HTML blockquote block.
+
+ Must be used with `cssToMarkBlockquotes`.
+
+ @param attributedString the attributed string.
+ @param block a block called for each HTML blockquote blocks.
+ */
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block;
+
 @end

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -27,10 +27,6 @@
 
 #import "DTCoreText.h"
 
-#pragma mark - Contants
-
-#define MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK  0xFFFEFF
-
 #pragma mark - MXKTools static private members
 // The regex used to find matrix ids.
 static NSRegularExpression *userIdRegex;
@@ -1096,12 +1092,12 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
 
 #pragma mark - HTML processing - blockquote display handling
 
-+ (NSString*)cssToMarkBlockquotes
++ (NSString*)cssToMarkBlockquotesWithColor:(UIColor*)color
 {
-    return [NSString stringWithFormat:@"blockquote {background: #%X;}", MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK];
+    return [NSString stringWithFormat:@"blockquote {background: #%lX;}", (unsigned long)[MXKTools rgbValueWithColor:color]];
 }
 
-+ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString withColor:(UIColor*)color usingBlock:(void (^)(NSRange range, BOOL *stop))block
 {
     // Enumerate all sections marked thanks to `cssToMarkBlockquotes`
     [attributedString enumerateAttribute:DTTextBlocksAttribute
@@ -1110,7 +1106,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                               usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop)
      {
          DTTextBlock *dtTextBlock = (DTTextBlock *)((NSArray *)value)[0];
-         if ([MXKTools rgbValueWithColor:dtTextBlock.backgroundColor] == MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK)
+         if ([dtTextBlock.backgroundColor isEqual:color])
          {
              block(range, stop);
          }

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -27,6 +27,10 @@
 
 #import "DTCoreText.h"
 
+#pragma mark - Contants
+
+#define MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK  0xFFFEFF
+
 #pragma mark - MXKTools static private members
 // The regex used to find matrix ids.
 static NSRegularExpression *userIdRegex;
@@ -1088,6 +1092,29 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
             [*mutableAttributedString addAttribute:NSLinkAttributeName value:link range:match.range];
         }
     }];
+}
+
+#pragma mark - HTML processing - blockquote display handling
+
++ (NSString*)cssToMarkBlockquotes
+{
+    return [NSString stringWithFormat:@"blockquote {background: #%X;}", MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK];
+}
+
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block
+{
+    // Enumerate all sections marked thanks to `cssToMarkBlockquotes`
+    [attributedString enumerateAttribute:DTTextBlocksAttribute
+                                 inRange:NSMakeRange(0, attributedString.length)
+                                 options:0
+                              usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop)
+     {
+         DTTextBlock *dtTextBlock = (DTTextBlock *)((NSArray *)value)[0];
+         if ([MXKTools rgbValueWithColor:dtTextBlock.backgroundColor] == MXKTOOLS_HTML_BLOCKQUOTE_COLOR_MARK)
+         {
+             block(range, stop);
+         }
+     }];
 }
 
 @end

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -1105,10 +1105,17 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                                  options:0
                               usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop)
      {
-         DTTextBlock *dtTextBlock = (DTTextBlock *)((NSArray *)value)[0];
-         if ([dtTextBlock.backgroundColor isEqual:color])
+         if ([value isKindOfClass:NSArray.class])
          {
-             block(range, stop);
+             NSArray *array = (NSArray*)value;
+             if (array.count > 0 && [array[0] isKindOfClass:DTTextBlock.class])
+             {
+                 DTTextBlock *dtTextBlock = (DTTextBlock *)array[0];
+                 if ([dtTextBlock.backgroundColor isEqual:color])
+                 {
+                     block(range, stop);
+                 }
+             }
          }
      }];
 }

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -240,7 +240,9 @@ static BOOL _disableLongPressGestureOnEvent;
             if (weakSelf)
             {
                 typeof(self) self = weakSelf;
-                [MXKTools enumerateMarkedBlockquotesInAttributedString:self.messageTextView.attributedText usingBlock:^(NSRange range, BOOL *stop)
+                [MXKTools enumerateMarkedBlockquotesInAttributedString:self.messageTextView.attributedText
+                                                             withColor:self.bubbleData.eventFormatter.htmlBlockquoteBorderColor
+                                                            usingBlock:^(NSRange range, BOOL *stop)
                  {
                      // Compute the UITextRange of the blockquote
                      UITextPosition *beginning = self.messageTextView.beginningOfDocument;


### PR DESCRIPTION
vector-im/riot-ios#1857

This is a bit fragile but I have not found a better workaround.