### PR TITLE
Fix: Quotes (by themselves) render as white blocks

### DIFF
--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1210,7 +1210,12 @@
     str = [self postRenderAttributedString:str];
 
     // Finalize the attributed string by removing DTCoreText artifacts (Trim trailing newlines).
-    return [MXKTools removeDTCoreTextArtifacts:str];
+    str = [MXKTools removeDTCoreTextArtifacts:str];
+
+    // Finalize HTML blockquote blocks marking
+    str = [MXKTools removeMarkedBlockquotesArtifacts:str];
+
+    return str;
 }
 
 /**
@@ -1316,7 +1321,7 @@
 - (void)setDefaultCSS:(NSString*)defaultCSS
 {
     // Make sure we mark HTML blockquote blocks for later computation
-    _defaultCSS = [NSString stringWithFormat:@"%@%@", [MXKTools cssToMarkBlockquotesWithColor:_htmlBlockquoteBorderColor], defaultCSS];
+    _defaultCSS = [NSString stringWithFormat:@"%@%@", [MXKTools cssToMarkBlockquotes], defaultCSS];
 
     dtCSS = [[DTCSSStylesheet alloc] initWithStyleBlock:_defaultCSS];
 }

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -351,7 +351,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
 + (NSAttributedString*)removeMarkedBlockquotesArtifacts:(NSAttributedString*)attributedString;
 
 /**
- Enumarate all sections of the attributed string that refer to an HTML blockquote block.
+ Enumerate all sections of the attributed string that refer to an HTML blockquote block.
 
  Must be used with `cssToMarkBlockquotes` and `removeMarkedBlockquotesArtifacts`.
 

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -336,22 +336,28 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
  Return a CSS to make DTCoreText mark blockquote blocks in the `NSAttributedString` output.
 
  These blocks  output will have a `DTTextBlocksAttribute` attribute in the `NSAttributedString`
- that can be used for later computation.
+ that can be used for later computation (in `removeMarkedBlockquotesArtifacts`).
 
- @param color the color to use to mark HTML blockquote blocks.
  @return a CSS string.
  */
-+ (NSString*)cssToMarkBlockquotesWithColor:(UIColor*)color;
++ (NSString*)cssToMarkBlockquotes;
+
+/**
+ Removing DTCoreText artifacts used to mark blockquote blocks.
+
+ @param attributedString an attributed string.
+ @return the resulting string.
+ */
++ (NSAttributedString*)removeMarkedBlockquotesArtifacts:(NSAttributedString*)attributedString;
 
 /**
  Enumarate all sections of the attributed string that refer to an HTML blockquote block.
 
- Must be used with `cssToMarkBlockquotes`.
+ Must be used with `cssToMarkBlockquotes` and `removeMarkedBlockquotesArtifacts`.
 
  @param attributedString the attributed string.
- @param color the marker color used in `cssToMarkBlockquotes`.
  @param block a block called for each HTML blockquote blocks.
  */
-+ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString withColor:(UIColor*)color usingBlock:(void (^)(NSRange range, BOOL *stop))block;
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block;
 
 @end

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -1131,8 +1131,32 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                  DTTextBlock *dtTextBlock = (DTTextBlock *)array[0];
                  if ([dtTextBlock.backgroundColor isEqual:kMXKToolsBlockquoteMarkColor])
                  {
-                     // apply our own attribute
+                     // Apply our own attribute
                      [mutableAttributedString addAttribute:kMXKToolsBlockquoteMarkAttribute value:@(YES) range:range];
+
+                     // Fix a boring behaviour where DTCoreText add a " " string before a string corresponding
+                     // to an HTML blockquote. This " " string has ParagraphStyle.headIndent = 0 which breaks
+                     // the blockquote block indentation
+                     if (range.location > 0)
+                     {
+                         NSRange prevRange = NSMakeRange(range.location - 1, 1);
+
+                         NSRange effectiveRange;
+                         NSParagraphStyle *paragraphStyle = [attributedString attribute:NSParagraphStyleAttributeName
+                                                                                atIndex:prevRange.location
+                                                                         effectiveRange:&effectiveRange];
+
+                         // Check if this is the " " string
+                         if (effectiveRange.length == 1 && paragraphStyle.firstLineHeadIndent != 25)
+                         {
+                             // Fix its paragraph style
+                             NSMutableParagraphStyle *newParagraphStyle = [paragraphStyle mutableCopy];
+                             newParagraphStyle.firstLineHeadIndent = 25.0;
+                             newParagraphStyle.headIndent = 25.0;
+
+                             [mutableAttributedString addAttribute:NSParagraphStyleAttributeName value:newParagraphStyle range:prevRange];
+                         }
+                     }
                  }
              }
          }

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -27,6 +27,14 @@
 
 #import "DTCoreText.h"
 
+#pragma mark - Constants definitions
+
+// Temparary background color used to identify blockquote blocks with DTCoreText.
+#define kMXKToolsBlockquoteMarkColor [UIColor magentaColor]
+
+// Attribute in an NSAttributeString that marks a blockquote block that was in the original HTML string.
+NSString *const kMXKToolsBlockquoteMarkAttribute = @"kMXKToolsBlockquoteMarkAttribute";
+
 #pragma mark - MXKTools static private members
 // The regex used to find matrix ids.
 static NSRegularExpression *userIdRegex;
@@ -1093,14 +1101,23 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
 
 #pragma mark - HTML processing - blockquote display handling
 
-+ (NSString*)cssToMarkBlockquotesWithColor:(UIColor*)color
++ (NSString*)cssToMarkBlockquotes
 {
-    return [NSString stringWithFormat:@"blockquote {background: #%lX;}", (unsigned long)[MXKTools rgbValueWithColor:color]];
+    return [NSString stringWithFormat:@"blockquote {background: #%lX;}", (unsigned long)[MXKTools rgbValueWithColor:kMXKToolsBlockquoteMarkColor]];
 }
 
-+ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString withColor:(UIColor*)color usingBlock:(void (^)(NSRange range, BOOL *stop))block
++ (NSAttributedString*)removeMarkedBlockquotesArtifacts:(NSAttributedString*)attributedString
 {
+    NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedString];
+
     // Enumerate all sections marked thanks to `cssToMarkBlockquotes`
+    // and apply our own attribute instead.
+
+    // According to blockquotes in the string, DTCoreText can apply 2 policies:
+    //     - define a `DTTextBlocksAttribute` attribute on a <blockquote> block
+    //     - or, just define a `NSBackgroundColorAttributeName` attribute
+
+    // `DTTextBlocksAttribute` case
     [attributedString enumerateAttribute:DTTextBlocksAttribute
                                  inRange:NSMakeRange(0, attributedString.length)
                                  options:0
@@ -1112,11 +1129,45 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
              if (array.count > 0 && [array[0] isKindOfClass:DTTextBlock.class])
              {
                  DTTextBlock *dtTextBlock = (DTTextBlock *)array[0];
-                 if ([dtTextBlock.backgroundColor isEqual:color])
+                 if ([dtTextBlock.backgroundColor isEqual:kMXKToolsBlockquoteMarkColor])
                  {
-                     block(range, stop);
+                     // apply our own attribute
+                     [mutableAttributedString addAttribute:kMXKToolsBlockquoteMarkAttribute value:@(YES) range:range];
                  }
              }
+         }
+     }];
+
+    // `NSBackgroundColorAttributeName` case
+    [mutableAttributedString enumerateAttribute:NSBackgroundColorAttributeName
+                                        inRange:NSMakeRange(0, mutableAttributedString.length)
+                                        options:0
+                                     usingBlock:^(id value, NSRange range, BOOL *stop)
+     {
+
+         if ([value isKindOfClass:UIColor.class] && [(UIColor*)value isEqual:[UIColor magentaColor]])
+         {
+             // Remove the marked background
+             [mutableAttributedString removeAttribute:NSBackgroundColorAttributeName range:range];
+
+             // And apply our own attribute
+             [mutableAttributedString addAttribute:kMXKToolsBlockquoteMarkAttribute value:@(YES) range:range];
+         }
+     }];
+
+    return mutableAttributedString;
+}
+
++ (void)enumerateMarkedBlockquotesInAttributedString:(NSAttributedString*)attributedString usingBlock:(void (^)(NSRange range, BOOL *stop))block
+{
+    [attributedString enumerateAttribute:kMXKToolsBlockquoteMarkAttribute
+                                 inRange:NSMakeRange(0, attributedString.length)
+                                 options:0
+                              usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop)
+     {
+         if ([value isKindOfClass:NSNumber.class] && ((NSNumber*)value).boolValue)
+         {
+             block(range, stop);
          }
      }];
 }

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -29,7 +29,7 @@
 
 #pragma mark - Constants definitions
 
-// Temparary background color used to identify blockquote blocks with DTCoreText.
+// Temporary background color used to identify blockquote blocks with DTCoreText.
 #define kMXKToolsBlockquoteMarkColor [UIColor magentaColor]
 
 // Attribute in an NSAttributeString that marks a blockquote block that was in the original HTML string.

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -241,7 +241,6 @@ static BOOL _disableLongPressGestureOnEvent;
             {
                 typeof(self) self = weakSelf;
                 [MXKTools enumerateMarkedBlockquotesInAttributedString:self.messageTextView.attributedText
-                                                             withColor:self.bubbleData.eventFormatter.htmlBlockquoteBorderColor
                                                             usingBlock:^(NSRange range, BOOL *stop)
                  {
                      // Compute the UITextRange of the blockquote


### PR DESCRIPTION
Close vector-im/riot-ios#1877

Make sure we do not change anymore the NSAttributeString background color and manage the 2 ways how DTCoreText manages HTML blockquotes.

Live examples could be fine at https://riot.im/develop/#/room/#test_quotes:matrix.org.