### PR TITLE
Add UIBarButtonItem subclass with convenient action block

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		79FA5AB121247287B85FA151 /* libPods-MatrixKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */; };
 		92663A6C1EF6E5B3005FB712 /* MXKSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */; };
 		ACD9DAA6B4DCFC7E33E12A97 /* libPods-MatrixKitSample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665BACA3D253B4407B1C4FD7 /* libPods-MatrixKitSample.a */; };
+		B11D3C7E20C032BD00938BCB /* MXKBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B11D3C7D20C032BD00938BCB /* MXKBarButtonItem.m */; };
 		B12C470C20BECAF8004FBF96 /* MXKErrorViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470920BECAF7004FBF96 /* MXKErrorViewModel.m */; };
 		B12C470D20BECAF8004FBF96 /* MXKErrorAlertPresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470A20BECAF7004FBF96 /* MXKErrorAlertPresentation.m */; };
 		B12C471020BED312004FBF96 /* MXKErrorPresentableBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470F20BED312004FBF96 /* MXKErrorPresentableBuilder.m */; };
@@ -320,6 +321,8 @@
 		92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSoundPlayer.h; sourceTree = "<group>"; };
 		92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSoundPlayer.m; sourceTree = "<group>"; };
 		9F0ED791C0728768E176BE57 /* libPods-MatrixKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B11D3C7C20C032BD00938BCB /* MXKBarButtonItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKBarButtonItem.h; sourceTree = "<group>"; };
+		B11D3C7D20C032BD00938BCB /* MXKBarButtonItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKBarButtonItem.m; sourceTree = "<group>"; };
 		B12C470620BECAF7004FBF96 /* MXKErrorPresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKErrorPresentation.h; sourceTree = "<group>"; };
 		B12C470720BECAF7004FBF96 /* MXKErrorViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKErrorViewModel.h; sourceTree = "<group>"; };
 		B12C470820BECAF7004FBF96 /* MXKErrorAlertPresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKErrorAlertPresentation.h; sourceTree = "<group>"; };
@@ -797,6 +800,7 @@
 		3219CBBD1AA6FB1C0027D7E2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B11D3C7B20C0329B00938BCB /* BarButtonItem */,
 				F0B14DD51FF65BC200F11630 /* MXKTableViewHeaderFooterView */,
 				F079333C1F38A6A600F04D4C /* MXKView.h */,
 				F079333D1F38A6A600F04D4C /* MXKView.m */,
@@ -975,6 +979,15 @@
 				8C751E43C4D87B309065E3C8 /* Pods-MatrixKitTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		B11D3C7B20C0329B00938BCB /* BarButtonItem */ = {
+			isa = PBXGroup;
+			children = (
+				B11D3C7C20C032BD00938BCB /* MXKBarButtonItem.h */,
+				B11D3C7D20C032BD00938BCB /* MXKBarButtonItem.m */,
+			);
+			path = BarButtonItem;
 			sourceTree = "<group>";
 		};
 		B12C470520BECAF7004FBF96 /* ErrorPresentation */ = {
@@ -1667,6 +1680,7 @@
 				F049FC201B2B878A00DD9D3C /* NSBundle+MatrixKit.m in Sources */,
 				F0868E121B1CAD58004CBE80 /* MXKPublicRoomTableViewCell.m in Sources */,
 				F09617BD1DE8478C00093E9D /* MXKDeviceView.m in Sources */,
+				B11D3C7E20C032BD00938BCB /* MXKBarButtonItem.m in Sources */,
 				32CEE2301AB1EE0900F7C74D /* MXKRecentTableViewCell.m in Sources */,
 				F00FA8771C08A51B00E25826 /* MXKRoomOutgoingTextMsgBubbleCell.m in Sources */,
 				32CEE2231AB1E37600F7C74D /* MXKRecentListViewController.m in Sources */,

--- a/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.h
+++ b/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.h
@@ -19,6 +19,10 @@
 @import Foundation;
 @import UIKit;
 
+#pragma mark - Types
+
+typedef void (^MXKBarButtonItemAction)();
+
 #pragma mark - Interface
 
 /**
@@ -28,7 +32,7 @@
 
 #pragma mark - Instance Methods
 
-- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action;
-- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action;
+- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(MXKBarButtonItemAction)action;
+- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(MXKBarButtonItemAction)action;
 
 @end

--- a/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.h
+++ b/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#pragma mark - Imports
+
+@import Foundation;
+@import UIKit;
+
+#pragma mark - Interface
+
+/**
+ `MXKBarButtonItem` is a subclass of UIBarButtonItem allowing to use convenient action block instead of action selector.
+ */
+@interface MXKBarButtonItem : UIBarButtonItem
+
+#pragma mark - Instance Methods
+
+- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action;
+- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action;
+
+@end

--- a/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.m
+++ b/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.m
@@ -24,7 +24,7 @@
 
 #pragma mark - Private Properties
 
-@property (nonatomic, copy) dispatch_block_t actionBlock;
+@property (nonatomic, copy) MXKBarButtonItemAction actionBlock;
 
 @end
 
@@ -34,7 +34,7 @@
 
 #pragma mark - Public methods
 
-- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action
+- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(MXKBarButtonItemAction)action
 {
     self = [self initWithImage:image style:style target:self action:@selector(executeAction:)];
     if (self)
@@ -44,7 +44,7 @@
     return self;
 }
 
-- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action
+- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(MXKBarButtonItemAction)action
 {
     self = [self initWithTitle:title style:style target:self action:@selector(executeAction:)];
     if (self)

--- a/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.m
+++ b/MatrixKit/Views/BarButtonItem/MXKBarButtonItem.m
@@ -1,0 +1,67 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#pragma mark - Imports
+
+#import "MXKBarButtonItem.h"
+
+#pragma mark - Private Interface
+
+@interface MXKBarButtonItem ()
+
+#pragma mark - Private Properties
+
+@property (nonatomic, copy) dispatch_block_t actionBlock;
+
+@end
+
+#pragma mark - Implementation
+
+@implementation MXKBarButtonItem
+
+#pragma mark - Public methods
+
+- (instancetype)initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action
+{
+    self = [self initWithImage:image style:style target:self action:@selector(executeAction:)];
+    if (self)
+    {
+        self.actionBlock = action;
+    }
+    return self;
+}
+
+- (instancetype)initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style action:(dispatch_block_t)action
+{
+    self = [self initWithTitle:title style:style target:self action:@selector(executeAction:)];
+    if (self)
+    {
+        self.actionBlock = action;
+    }
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (void)executeAction:(id)sender
+{
+    if (self.actionBlock)
+    {
+        self.actionBlock();
+    }
+}
+
+@end


### PR DESCRIPTION
Add a MXKBarButtonItem, UIBarButtonItem subclass with convenient action block. Avoid to use selector.