### PR TITLE
MXKRoomBubbleCellData: add a `readReceipts` member to cache read receipts data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Improvements:
  * MXKWebViewVC: enableDebug: support multiple parameters in console.* logs methods.
  * Add MXKBarButtonItem, UIBarButtonItem subclass with convenient action block.
  * MXKRoomDataSource: Make processingQueue public so that overidding class can use it.
+ * MXKRoomBubbleCellData: add a readReceipts member to cache read receipts data.
  
 Bug fix:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in MatrixKit in 0.7.15 ()
 Improvements:
  * MXKWebViewVC: enableDebug: support multiple parameters in console.* logs methods.
  * Add MXKBarButtonItem, UIBarButtonItem subclass with convenient action block.
+ * MXKRoomDataSource: Make processingQueue public so that overidding class can use it.
  
 Bug fix:
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -64,6 +64,12 @@
 @property (nonatomic, readonly) NSArray<MXKRoomBubbleComponent*> *bubbleComponents;
 
 /**
+ Read receipts per event.
+ */
+@property(nonatomic) NSMutableDictionary<NSString* /* eventId */,
+                                         NSArray<MXReceiptData *> *> *readReceipts;
+
+/**
  Event formatter
  */
 @property (nonatomic) MXKEventFormatter *eventFormatter;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -492,6 +493,15 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  By default, they are added to the end of the timeline.
  */
 - (void)handleUnsentMessages;
+
+#pragma mark - Asynchronous events processing
+/**
+ The dispatch queue to process room messages.
+ 
+ This processing can consume time. Handling it on a separated thread avoids to block the main thread.
+ All MXKRoomDataSource instances share the same dispatch queue.
+ */
++ (dispatch_queue_t)processingQueue;
 
 #pragma mark - Bubble collapsing
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1965,11 +1965,6 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
 
 #pragma mark - Asynchronous events processing
-/**
- The dispatch queue to process room messages.
- This processing can consume time. Handling it on a separated thread avoids to block the main thread.
- All MXKRoomDataSource instances share the same dispatch queue.
- */
  + (dispatch_queue_t)processingQueue
 {
     static dispatch_queue_t processingQueue;

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -639,30 +639,26 @@ static BOOL _disableLongPressGestureOnEvent;
                         {
                             NSMutableArray* roomMembers = nil;
                             NSMutableArray* placeholders = nil;
-                            NSArray* receipts = nil;
-                            
-                            MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
-                            
-                            // Get the events receipts by ignoring the current user receipt.
-                            if (room)
-                            {
-                                receipts = [room getEventReceipts:component.event.eventId sorted:YES];
-                            }
+                            NSArray<MXReceiptData*> *receipts = bubbleData.readReceipts[component.event.eventId];
                             
                             // Check whether some receipts are found
                             if (receipts.count)
                             {
-                                // Retrieve the corresponding room members
-                                roomMembers = [[NSMutableArray alloc] initWithCapacity:receipts.count];
-                                placeholders = [[NSMutableArray alloc] initWithCapacity:receipts.count];
-                                
-                                for (MXReceiptData* data in receipts)
+                                MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
+                                if (room)
                                 {
-                                    MXRoomMember * roomMember = [room.state memberWithUserId:data.userId];
-                                    if (roomMember)
+                                    // Retrieve the corresponding room members
+                                    roomMembers = [[NSMutableArray alloc] initWithCapacity:receipts.count];
+                                    placeholders = [[NSMutableArray alloc] initWithCapacity:receipts.count];
+
+                                    for (MXReceiptData* data in receipts)
                                     {
-                                        [roomMembers addObject:roomMember];
-                                        [placeholders addObject:self.picturePlaceholder];
+                                        MXRoomMember * roomMember = [room.state memberWithUserId:data.userId];
+                                        if (roomMember)
+                                        {
+                                            [roomMembers addObject:roomMember];
+                                            [placeholders addObject:self.picturePlaceholder];
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/1899
