### PR TITLE
MXRoomState: Remove displayName property

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -379,7 +379,7 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     }
     else if (mxCall.isConferenceCall)
     {
-        peerDisplayName = mxCall.room.state.displayname;
+        peerDisplayName = mxCall.room.summary.displayname;
         peerAvatarURL = mxCall.room.state.avatar;
     }
     

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -734,7 +734,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
         else
         {
             // set default title
-            self.navigationItem.title = roomDataSource.room.state.displayname;
+            self.navigationItem.title = roomDataSource.room.summary.displayname;
         }
         
         // Show input tool bar
@@ -754,7 +754,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
                 }
                 else
                 {
-                    self.navigationItem.title = roomDataSource.room.state.displayname;
+                    self.navigationItem.title = roomDataSource.room.summary.displayname;
                 }
             }
             else
@@ -856,7 +856,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
             
         } failure:^(NSError *error) {
             
-            NSLog(@"[MXKRoomVC] Failed to join room (%@)", roomDataSource.room.state.displayname);
+            NSLog(@"[MXKRoomVC] Failed to join room (%@)", roomDataSource.room.summary.displayname);
             
             joinRoomRequest = nil;
             [self stopActivityIndicator];

--- a/MatrixKit/Models/Search/MXKSearchCellData.m
+++ b/MatrixKit/Models/Search/MXKSearchCellData.m
@@ -45,7 +45,7 @@
             MXRoom *room = [searchDataSource.mxSession roomWithRoomId:searchResult.result.roomId];
             if (room)
             {
-                title = room.state.displayname;
+                title = room.summary.displayname;
             }
             else
             {

--- a/MatrixKit/Views/PushRule/MXKPushRuleCreationTableViewCell.m
+++ b/MatrixKit/Views/PushRule/MXKPushRuleCreationTableViewCell.m
@@ -167,7 +167,7 @@
         if ((row >= 0) && (row < rooms.count))
         {
             MXRoom* room = [rooms objectAtIndex:row];
-            _inputTextField.text = room.state.displayname;
+            _inputTextField.text = room.summary.displayname;
             _addButton.enabled = YES;
         }
         
@@ -189,7 +189,7 @@
     rooms = [_mxSession.rooms sortedArrayUsingComparator:^NSComparisonResult(MXRoom* firstRoom, MXRoom* secondRoom) {
         
         // Alphabetic order
-        return [firstRoom.state.displayname compare:secondRoom.state.displayname options:NSCaseInsensitiveSearch];
+        return [firstRoom.summary.displayname compare:secondRoom.summary.displayname options:NSCaseInsensitiveSearch];
     }];
 
     return rooms.count;
@@ -200,7 +200,7 @@
 - (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
 {
     MXRoom* room = [rooms objectAtIndex:row];
-    return room.state.displayname;
+    return room.summary.displayname;
 }
 
 @end

--- a/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
+++ b/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
@@ -69,7 +69,7 @@
             MXRoom *room = [_mxSession roomWithRoomId:mxPushRule.ruleId];
             if (room)
             {
-                description = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notification_settings_room_rule_title"], room.state.displayname];
+                description = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notification_settings_room_rule_title"], room.summary.displayname];
             }
             break;
         }


### PR DESCRIPTION
We have MXRoomSummary.displayName now

Follows https://github.com/matrix-org/matrix-ios-sdk/pull/529.