### PR TITLE
MXRoom: Make access to liveTimeline data async

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Bug fix:
 
 API break:
  * MXKContactManager: Remove the privateMatrixContacts method.
+ * MXKSearchCellDataStoring: Replace initWithSearchResult by async cellDataWithSearchResult.
 
 Changes in MatrixKit in 0.7.15 (2018-07-03)
 ==========================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+Changes in MatrixKit in 0.8.0 ()
+==========================================
+
+Improvements:
+ 
+Bug fix:
+
+API break:
+ * MXKContactManager: Remove the privateMatrixContacts method.
+
 Changes in MatrixKit in 0.7.15 (2018-07-03)
 ==========================================
 

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		328AC48F1AA86E110044A6FB /* MXKDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 328AC48E1AA86E110044A6FB /* MXKDataSource.m */; };
 		328AC4931AA8B05C0044A6FB /* MXKCellData.m in Sources */ = {isa = PBXBuildFile; fileRef = 328AC4921AA8B05C0044A6FB /* MXKCellData.m */; };
 		329CF77B1AA9FDE000A4753F /* MXKRoomIOSBubbleTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 329CF77A1AA9FDE000A4753F /* MXKRoomIOSBubbleTableViewCell.m */; };
+		32B046722101EB5E002A24A1 /* MXRoom+Sync.m in Sources */ = {isa = PBXBuildFile; fileRef = 32B046712101EB5E002A24A1 /* MXRoom+Sync.m */; };
 		32CEE21F1AB1A57E00F7C74D /* MXKEventFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE21E1AB1A57E00F7C74D /* MXKEventFormatter.m */; };
 		32CEE2231AB1E37600F7C74D /* MXKRecentListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2211AB1E37600F7C74D /* MXKRecentListViewController.m */; };
 		32CEE22B1AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2271AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m */; };
@@ -289,6 +290,8 @@
 		328AC4921AA8B05C0044A6FB /* MXKCellData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKCellData.m; sourceTree = "<group>"; };
 		329CF7791AA9FDE000A4753F /* MXKRoomIOSBubbleTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomIOSBubbleTableViewCell.h; sourceTree = "<group>"; };
 		329CF77A1AA9FDE000A4753F /* MXKRoomIOSBubbleTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomIOSBubbleTableViewCell.m; sourceTree = "<group>"; };
+		32B046702101EB5E002A24A1 /* MXRoom+Sync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MXRoom+Sync.h"; sourceTree = "<group>"; };
+		32B046712101EB5E002A24A1 /* MXRoom+Sync.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MXRoom+Sync.m"; sourceTree = "<group>"; };
 		32CEE21D1AB1A57E00F7C74D /* MXKEventFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKEventFormatter.h; sourceTree = "<group>"; };
 		32CEE21E1AB1A57E00F7C74D /* MXKEventFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKEventFormatter.m; sourceTree = "<group>"; };
 		32CEE2201AB1E37600F7C74D /* MXKRecentListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRecentListViewController.h; sourceTree = "<group>"; };
@@ -1165,6 +1168,8 @@
 				323F9AF51F1E53730013AFDE /* NSBundle+MXKLanguage.m */,
 				F07E18121ABC563900DE3766 /* MXEvent+MatrixKit.h */,
 				F07E18131ABC563900DE3766 /* MXEvent+MatrixKit.m */,
+				32B046702101EB5E002A24A1 /* MXRoom+Sync.h */,
+				32B046712101EB5E002A24A1 /* MXRoom+Sync.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -1735,6 +1740,7 @@
 				32185B2D1F20AFEB00752141 /* MXKLanguagePickerViewController.m in Sources */,
 				F05927AE1FD92E36009F2A68 /* MXKGroupTableViewCell.m in Sources */,
 				328AC4861AA75E000044A6FB /* MXKRoomBubbleTableViewCell.m in Sources */,
+				32B046722101EB5E002A24A1 /* MXRoom+Sync.m in Sources */,
 				F05FB1811AD6643900DC0647 /* MXKRoomMemberTableViewCell.m in Sources */,
 				F095E50E1B25899F009606CE /* MXKContactField.m in Sources */,
 				F012674A1AF8A9440067D962 /* MXK3PID.m in Sources */,

--- a/MatrixKit/Categories/MXRoom+Sync.h
+++ b/MatrixKit/Categories/MXRoom+Sync.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <MatrixSDK/MatrixSDK.h>
+
+/**
+ Temporary category to help in the transition from synchronous access to room.state
+ to asynchronous access.
+ */
+@interface MXRoom (Sync)
+
+/**
+ Get the room state if it has been already loaded else return nil.
+
+ Use this method only where you are sure the room state is already mounted.
+ */
+@property (nonatomic, readonly) MXRoomState *dangerousSyncState;
+
+@end

--- a/MatrixKit/Categories/MXRoom+Sync.m
+++ b/MatrixKit/Categories/MXRoom+Sync.m
@@ -1,0 +1,36 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXRoom+Sync.h"
+
+@implementation MXRoom (Sync)
+
+- (MXRoomState *)dangerousSyncState
+{
+    __block MXRoomState *syncState;
+
+    // If syncState is called from the right place, the following call will be
+    // synchronous and every thing will be fine
+    [self state:^(MXRoomState *roomState) {
+        syncState = roomState;
+    }];
+
+    NSAssert(syncState, @"[MXRoom+Sync] syncState failed. Are you sure the state of the room has been already loaded?");
+
+    return syncState;
+}
+
+@end

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -281,18 +281,15 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         
         // Register a listener to handle messages related to room name, members...
         MXWeakify(self);
-        [mxCall.room liveTimeline:^(MXEventTimeline *liveTimeline) {
+        [mxCall.room listenToEventsOfTypes:@[kMXEventTypeStringRoomName, kMXEventTypeStringRoomTopic, kMXEventTypeStringRoomAliases, kMXEventTypeStringRoomAvatar, kMXEventTypeStringRoomCanonicalAlias, kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             MXStrongifyAndReturnIfNil(self);
 
-            self->roomListener = [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomName, kMXEventTypeStringRoomTopic, kMXEventTypeStringRoomAliases, kMXEventTypeStringRoomAvatar, kMXEventTypeStringRoomCanonicalAlias, kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
-
-                // Consider only live events
-                if (self->mxCall && direction == MXTimelineDirectionForwards)
-                {
-                    // The room state has been changed
-                    [self callRoomStateDidChange:nil];
-                }
-            }];
+            // Consider only live events
+            if (self->mxCall && direction == MXTimelineDirectionForwards)
+            {
+                // The room state has been changed
+                [self callRoomStateDidChange:nil];
+            }
         }];
         
         // Observe room history flush (sync with limited timeline, or state event redaction)

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -785,13 +785,15 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         // Else, the room information will be used to display information about the call
         if (!mxCall.isConferenceCall)
         {
-            [mxCall.room state:^(MXRoomState *roomState) {
+            MXWeakify(self);
+            [mxCall.room members:^(MXRoomMembers *roomMembers) {
+                MXStrongifyAndReturnIfNil(self);
             
                 MXUser *theMember = nil;
-                NSArray *members = roomState.members.joinedMembers;
+                NSArray *members = roomMembers.joinedMembers;
                 for (MXUser *member in members)
                 {
-                    if (![member.userId isEqualToString:mxCall.callerId])
+                    if (![member.userId isEqualToString:self->mxCall.callerId])
                     {
                         theMember = member;
                         break;

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.h
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.h
@@ -115,6 +115,7 @@ typedef enum : NSUInteger
  */
 @property (nonatomic, readonly) MXRoomMember *mxRoomMember;
 @property (nonatomic, readonly) MXRoom *mxRoom;
+@property (nonatomic, readonly) MXEventTimeline *mxRoomLiveTimeline;
 
 /**
  Enable mention option. NO by default

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -497,19 +497,14 @@
     if (mxRoom)
     {
         // Observe room's members update
-        MXWeakify(self);
-        [mxRoom liveTimeline:^(MXEventTimeline *liveTimeline) {
-            MXStrongifyAndReturnIfNil(self);
+        NSArray *mxMembersEvents = @[kMXEventTypeStringRoomMember, kMXEventTypeStringRoomPowerLevels];
+        self->membersListener = [mxRoom listenToEventsOfTypes:mxMembersEvents onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            NSArray *mxMembersEvents = @[kMXEventTypeStringRoomMember, kMXEventTypeStringRoomPowerLevels];
-            self->membersListener = [liveTimeline listenToEventsOfTypes:mxMembersEvents onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
-
-                // consider only live event
-                if (direction == MXTimelineDirectionForwards)
-                {
-                    [self refreshRoomMember];
-                }
-            }];
+            // consider only live event
+            if (direction == MXTimelineDirectionForwards)
+            {
+                [self refreshRoomMember];
+            }
         }];
 
         // Observe kMXSessionWillLeaveRoomNotification to be notified if the user leaves the current room.

--- a/MatrixKit/Controllers/MXKRoomMemberListViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberListViewController.m
@@ -314,38 +314,44 @@
 
 - (void)refreshUIBarButtons
 {
-    BOOL showInvitationOption = _enableMemberInvitation;
-    
-    if (showInvitationOption && dataSource)
-    {
-        // Check conditions to be able to invite someone
-        MXRoom *mxRoom = [self.mainSession roomWithRoomId:dataSource.roomId];
-        NSInteger oneSelfPowerLevel = [mxRoom.state.powerLevels powerLevelOfUserWithUserID:self.mainSession.myUser.userId];
-        if (oneSelfPowerLevel < [mxRoom.state.powerLevels invite])
+    MXRoom *mxRoom = [self.mainSession roomWithRoomId:dataSource.roomId];
+
+    MXWeakify(self);
+    [mxRoom state:^(MXRoomState *roomState) {
+        MXStrongifyAndReturnIfNil(self);
+
+        BOOL showInvitationOption = self.enableMemberInvitation;
+
+        if (showInvitationOption && self->dataSource)
         {
-            showInvitationOption = NO;
+            // Check conditions to be able to invite someone
+            NSInteger oneSelfPowerLevel = [roomState.powerLevels powerLevelOfUserWithUserID:self.mainSession.myUser.userId];
+            if (oneSelfPowerLevel < [roomState.powerLevels invite])
+            {
+                showInvitationOption = NO;
+            }
         }
-    }
-    
-    if (showInvitationOption)
-    {
-        if (_enableMemberSearch)
+
+        if (showInvitationOption)
         {
-            self.navigationItem.rightBarButtonItems = @[searchBarButton, addBarButton];
+            if (self.enableMemberSearch)
+            {
+                self.navigationItem.rightBarButtonItems = @[self->searchBarButton, self->addBarButton];
+            }
+            else
+            {
+                self.navigationItem.rightBarButtonItems = @[self->addBarButton];
+            }
+        }
+        else if (self.enableMemberSearch)
+        {
+            self.navigationItem.rightBarButtonItems = @[self->searchBarButton];
         }
         else
         {
-            self.navigationItem.rightBarButtonItems = @[addBarButton];
+            self.navigationItem.rightBarButtonItems = nil;
         }
-    }
-    else if (_enableMemberSearch)
-    {
-        self.navigationItem.rightBarButtonItems = @[searchBarButton];
-    }
-    else
-    {
-        self.navigationItem.rightBarButtonItems = nil;
-    }
+    }];
 }
 
 #pragma mark -

--- a/MatrixKit/Controllers/MXKRoomSettingsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomSettingsViewController.m
@@ -150,7 +150,6 @@
             }];
         
             // Observe kMXSessionWillLeaveRoomNotification to be notified if the user leaves the current room.
-            MXWeakify(self);
             self->leaveRoomNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionWillLeaveRoomNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
 
                 // Check whether the user will leave the room related to the displayed participants
@@ -163,7 +162,6 @@
                         [self withdrawViewControllerAnimated:YES completion:nil];
                     }
                 }
-
             }];
 
             // Observe room history flush (sync with limited timeline, or state event redaction)

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -913,15 +913,16 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 
             // The room is now part of the user's room
             MXKRoomDataSourceManager *roomDataSourceManager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:self.mainSession];
-            MXKRoomDataSource *newRoomDataSource = [roomDataSourceManager roomDataSourceForRoom:room.roomId create:YES];
 
-            // And can be displayed
-            [self displayRoom:newRoomDataSource];
+            [roomDataSourceManager roomDataSourceForRoom:room.roomId create:YES onComplete:^(MXKRoomDataSource *newRoomDataSource) {
+                // And can be displayed
+                [self displayRoom:newRoomDataSource];
 
-            if (completion)
-            {
-                completion(YES);
-            }
+                if (completion)
+                {
+                    completion(YES);
+                }
+            }];
         };
 
         void (^failure)(NSError *error) = ^(NSError *error) {
@@ -985,7 +986,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
     if (event)
     {
         MXKEventFormatterError error;
-        reason = [roomDataSource.eventFormatter stringFromEvent:event withRoomState:roomDataSource.room.state error:&error];
+        reason = [roomDataSource.eventFormatter stringFromEvent:event withRoomState:roomDataSource.roomState error:&error];
         if (error != MXKEventFormatterErrorNone)
         {
             reason = nil;
@@ -2609,7 +2610,7 @@ NSString *const kCmdChangeRoomTopic = @"/topic";
 //        NSLog(@"    -> Name or avatar of %@ has been tapped", userInfo[kMXKRoomBubbleCellUserIdKey]);
         
         // Add the member display name in text input
-        MXRoomMember *selectedRoomMember = [roomDataSource.room.state.members memberWithUserId:userInfo[kMXKRoomBubbleCellUserIdKey]];
+        MXRoomMember *selectedRoomMember = [roomDataSource.roomState.members memberWithUserId:userInfo[kMXKRoomBubbleCellUserIdKey]];
         if (selectedRoomMember)
         {
             [self mention:selectedRoomMember];

--- a/MatrixKit/MatrixKit.h
+++ b/MatrixKit/MatrixKit.h
@@ -24,6 +24,7 @@
 #import "MXKAppSettings.h"
 
 #import "MXEvent+MatrixKit.h"
+#import "MXRoom+Sync.h"
 #import "NSBundle+MatrixKit.h"
 #import "NSBundle+MXKLanguage.h"
 #import "UIAlertController+MatrixKit.h"

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1251,19 +1251,19 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     {
         // Apply first the event filter defined in the related room data source
         MXKRoomDataSourceManager *roomDataSourceManager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:mxSession];
-        MXKRoomDataSource *roomDataSource = [roomDataSourceManager roomDataSourceForRoom:event.roomId create:NO];
-        
-        if (roomDataSource)
-        {
-            if (!roomDataSource.eventFormatter.eventTypesFilterForMessages || [roomDataSource.eventFormatter.eventTypesFilterForMessages indexOfObject:event.type] != NSNotFound)
+        [roomDataSourceManager roomDataSourceForRoom:event.roomId create:NO onComplete:^(MXKRoomDataSource *roomDataSource) {
+            if (roomDataSource)
             {
-                // Check conditions to report this notification
-                if (nil == ignoredRooms || [ignoredRooms indexOfObject:event.roomId] == NSNotFound)
+                if (!roomDataSource.eventFormatter.eventTypesFilterForMessages || [roomDataSource.eventFormatter.eventTypesFilterForMessages indexOfObject:event.type] != NSNotFound)
                 {
-                    onNotification(event, roomState, rule);
+                    // Check conditions to report this notification
+                    if (nil == ignoredRooms || [ignoredRooms indexOfObject:event.roomId] == NSNotFound)
+                    {
+                        onNotification(event, roomState, rule);
+                    }
                 }
             }
-        }
+        }];
     }];
 }
 

--- a/MatrixKit/Models/Contact/MXKContactManager.h
+++ b/MatrixKit/Models/Contact/MXKContactManager.h
@@ -135,13 +135,6 @@ typedef NS_ENUM(NSInteger, MXKContactManagerMXRoomSource) {
 @property (nonatomic, readonly) NSArray *directMatrixContacts;
 
 /**
- List the contacts who share at least a private room with the current user of the provided matrix session.
- 
- @param mxSession the concerned matrix session.
- */
-- (NSArray *)privateMatrixContacts:(MXSession*)mxSession;
-
-/**
  Add/remove matrix session. The matrix contact list is automatically updated (see kMXKContactManagerDidUpdateMatrixContactsNotification event).
  */
 - (void)addMatrixSession:(MXSession*)mxSession;

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -214,16 +214,17 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                 if (self.contactManagerMXRoomSource != MXKContactManagerMXRoomSourceNone)
                 {
                     MXRoom *room = notif.object;
-                    [room state:^(MXRoomState *roomState) {
-                        NSArray *roomMembers = roomState.members.members;
+                    [room members:^(MXRoomMembers *roomMembers) {
+
+                        NSArray *members = roomMembers.members;
 
                         // Consider only 1:1 chat for MXKMemberContactCreationOneToOneRoom
                         // or adding all
-                        if (((roomMembers.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
+                        if (((members.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
                         {
                             NSString* myUserId = room.mxSession.myUser.userId;
 
-                            for (MXRoomMember* member in roomMembers)
+                            for (MXRoomMember* member in members)
                             {
                                 if ([member.userId isEqualToString:myUserId])
                                 {

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -214,22 +214,24 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                 if (self.contactManagerMXRoomSource != MXKContactManagerMXRoomSourceNone)
                 {
                     MXRoom *room = notif.object;
-                    NSArray *roomMembers = room.state.members.members;
-                    
-                    // Consider only 1:1 chat for MXKMemberContactCreationOneToOneRoom
-                    // or adding all
-                    if (((roomMembers.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
-                    {
-                        NSString* myUserId = room.mxSession.myUser.userId;
-                        
-                        for (MXRoomMember* member in roomMembers)
+                    [room state:^(MXRoomState *roomState) {
+                        NSArray *roomMembers = roomState.members.members;
+
+                        // Consider only 1:1 chat for MXKMemberContactCreationOneToOneRoom
+                        // or adding all
+                        if (((roomMembers.count == 2) && (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceDirectChats)) || (self.contactManagerMXRoomSource == MXKContactManagerMXRoomSourceAll))
                         {
-                            if ([member.userId isEqualToString:myUserId])
+                            NSString* myUserId = room.mxSession.myUser.userId;
+
+                            for (MXRoomMember* member in roomMembers)
                             {
-                                [self updateMatrixContactWithID:member.userId];
+                                if ([member.userId isEqualToString:myUserId])
+                                {
+                                    [self updateMatrixContactWithID:member.userId];
+                                }
                             }
                         }
-                    }
+                    }];
                 }
             }];
         }
@@ -485,60 +487,6 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
     }
     
     return directContacts.allValues;
-}
-
-- (NSArray*)privateMatrixContacts:(MXSession *)mxSession
-{
-    NSParameterAssert([NSThread isMainThread]);
-    
-    // Sanity check
-    if (!mxSession)
-    {
-        return nil;
-    }
-    
-    NSMutableDictionary *privateContacts = [NSMutableDictionary dictionary];
-    
-    // List all the known matrix users from the private rooms
-    NSArray *rooms = mxSession.rooms;
-    for (MXRoom *room in rooms)
-    {
-        if (!room.state.isJoinRulePublic && !room.state.isConferenceUserRoom)
-        {
-            NSArray *members = room.state.members.members;
-            
-            for (MXRoomMember *member in members)
-            {
-                if ((member.membership == MXMembershipJoin || member.membership == MXMembershipInvite)
-                    && [MXCallManager isConferenceUser:member.userId] == NO)
-                {
-                    MXKContact* contact = [matrixContactByMatrixID objectForKey:member.userId];
-                    if (!contact)
-                    {
-                        MXUser *mxUser = [mxSession userWithUserId:member.userId];
-                        
-                        // Sanity check - mxUser should not be nil here
-                        if (mxUser)
-                        {
-                            contact = [[MXKContact alloc] initMatrixContactWithDisplayName:((mxUser.displayname.length > 0) ? mxUser.displayname : member.userId) andMatrixID:member.userId];
-                            [matrixContactByMatrixID setValue:contact forKey:member.userId];
-                        }
-                    }
-                    
-                    if (contact)
-                    {
-                        [privateContacts setValue:contact forKey:member.userId];
-                    }
-                }
-                
-            }
-        }
-    }
-    
-    // Remove the user himself
-    [privateContacts removeObjectForKey:mxSession.myUser.userId];
-    
-    return privateContacts.allValues;
 }
 
 - (void)setIdentityServer:(NSString *)identityServer

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -107,7 +107,7 @@
             MXKRoomBubbleComponent *roomBubbleComponent = [bubbleComponents objectAtIndex:index];
             if ([roomBubbleComponent.event.eventId isEqualToString:eventId])
             {
-                [roomBubbleComponent updateWithEvent:event andRoomState:roomDataSource.room.state];
+                [roomBubbleComponent updateWithEvent:event andRoomState:roomDataSource.roomState];
                 if (!roomBubbleComponent.textMessage.length)
                 {
                     [bubbleComponents removeObjectAtIndex:index];
@@ -370,7 +370,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
     
     // Check first whether the room enabled the flair for some groups
-    NSArray<NSString *> *roomRelatedGroups = roomDataSource.room.state.relatedGroups;
+    NSArray<NSString *> *roomRelatedGroups = roomDataSource.roomState.relatedGroups;
     if (roomRelatedGroups.count && senderId)
     {
         NSArray<NSString *> *senderPublicisedGroups;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -116,6 +116,11 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic, readonly) MXRoom *room;
 
 /**
+ The preloaded room.state.
+ */
+@property (nonatomic, readonly) MXRoomState *roomState;
+
+/**
  The timeline being managed. It can be the live timeline of the room
  or a timeline from a past event, initialEventId.
  */
@@ -217,6 +222,50 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic) BOOL filterMessagesWithURL;
 
 #pragma mark - Life cycle
+
+/**
+ Asynchronously create a data source to serve data corresponding to the passed room.
+
+ This method preloads room data, like the room state, to make it available once
+ the room data source is created.
+
+ @param roomId the id of the room to get data from.
+ @param mxSession the Matrix session to get data from.
+ @param onComplete a block providing the newly created instance.
+ */
++ (void)loadRoomDataSourceWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete;
+
+/**
+ Asynchronously create adata source to serve data corresponding to an event in the
+ past of a room.
+
+ This method preloads room data, like the room state, to make it available once
+ the room data source is created.
+
+ @param roomId the id of the room to get data from.
+ @param initialEventId the id of the event where to start the timeline.
+ @param mxSession the Matrix session to get data from.
+ @param onComplete a block providing the newly created instance.
+ */
++ (void)loadRoomDataSourceWithRoomId:(NSString*)roomId initialEventId:(NSString*)initialEventId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete;
+
+/**
+ Asynchronously create a data source to peek into a room.
+
+ The data source will close the `peekingRoom` instance on [self destroy].
+
+ This method preloads room data, like the room state, to make it available once
+ the room data source is created.
+
+ @param peekingRoom the room to peek.
+ @param initialEventId the id of the event where to start the timeline. nil means the live
+                       timeline.
+ @param onComplete a block providing the newly created instance.
+ */
++ (void)loadRoomDataSourceWithPeekingRoom:(MXPeekingRoom*)peekingRoom andInitialEventId:(NSString*)initialEventId onComplete:(void (^)(id roomDataSource))onComplete;
+
+#pragma mark - Constructors (Should not be called directly)
+
 /**
  Initialise the data source to serve data corresponding to the passed room.
  

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -47,6 +47,11 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     NSString *initialEventId;
 
     /**
+     Cache for the room state
+     */
+    MXRoomState *roomState;
+
+    /**
      Current pagination request (if any)
      */
     MXHTTPOperation *paginationRequest;
@@ -143,6 +148,51 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
 @implementation MXKRoomDataSource
 
++ (void)loadRoomDataSourceWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete
+{
+    MXKRoomDataSource *roomDataSource = [[self alloc] initWithRoomId:roomId andMatrixSession:mxSession];
+    if (roomDataSource)
+    {
+        [roomDataSource finalizeInitialization];
+
+        [roomDataSource.room state:^(MXRoomState *roomState) {
+            roomDataSource->roomState = roomState;
+
+            onComplete(roomDataSource);
+        }];
+    }
+}
+
++ (void)loadRoomDataSourceWithRoomId:(NSString*)roomId initialEventId:(NSString*)initialEventId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete
+{
+    MXKRoomDataSource *roomDataSource = [[self alloc] initWithRoomId:roomId initialEventId:initialEventId andMatrixSession:mxSession];
+    if (roomDataSource)
+    {
+        [roomDataSource finalizeInitialization];
+
+        [roomDataSource.room state:^(MXRoomState *roomState) {
+            roomDataSource->roomState = roomState;
+
+            onComplete(roomDataSource);
+        }];
+    }
+}
+
++ (void)loadRoomDataSourceWithPeekingRoom:(MXPeekingRoom*)peekingRoom andInitialEventId:(NSString*)initialEventId onComplete:(void (^)(id roomDataSource))onComplete
+{
+    MXKRoomDataSource *roomDataSource = [[self alloc] initWithPeekingRoom:peekingRoom andInitialEventId:initialEventId];
+    if (roomDataSource)
+    {
+        [roomDataSource finalizeInitialization];
+
+        [roomDataSource.room state:^(MXRoomState *roomState) {
+            roomDataSource->roomState = roomState;
+
+            onComplete(roomDataSource);
+        }];
+    }
+}
+
 - (instancetype)initWithRoomId:(NSString *)roomId andMatrixSession:(MXSession *)matrixSession
 {
     self = [super initWithMatrixSession:matrixSession];
@@ -231,6 +281,13 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         _isPeeking = YES;
     }
     return self;
+}
+
+- (MXRoomState *)roomState
+{
+    // @TODO(async-state): Just here for dev
+    NSAssert(roomState, @"Room state must be preloaded before accessing to MXKRoomDataSource.roomState");
+    return roomState;
 }
 
 - (void)onDateTimeFormatUpdate
@@ -441,15 +498,18 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                 if (_isLive)
                 {
                     // LIVE
+                    MXWeakify(self);
                     [_room liveTimeline:^(MXEventTimeline *liveTimeline) {
-                        _timeline = liveTimeline;
+                        MXStrongifyAndReturnIfNil(self);
+
+                        self->_timeline = liveTimeline;
 
                         // Only one pagination process can be done at a time by an MXRoom object.
                         // This assumption is satisfied by MatrixKit. Only MXRoomDataSource does it.
-                        [_timeline resetPagination];
+                        [self.timeline resetPagination];
 
                         // Observe room history flush (sync with limited timeline, or state event redaction)
-                        roomDidFlushDataNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomDidFlushDataNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+                        self->roomDidFlushDataNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomDidFlushDataNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
 
                             MXRoom *room = notif.object;
                             if (self.mxSession == room.mxSession && [self.roomId isEqualToString:room.roomId])
@@ -462,11 +522,11 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
                         // Add the event listeners, by considering all the event types (the event filtering is applying by the event formatter),
                         // except if only the events with a url key in their content must be handled.
-                        [self refreshEventListeners:(_filterMessagesWithURL ? @[kMXEventTypeStringRoomMessage] : [MXKAppSettings standardAppSettings].allEventTypesForMessages)];
+                        [self refreshEventListeners:(self.filterMessagesWithURL ? @[kMXEventTypeStringRoomMessage] : [MXKAppSettings standardAppSettings].allEventTypesForMessages)];
 
                         // display typing notifications is optional
                         // the inherited class can manage them by its own.
-                        if (_showTypingNotifications)
+                        if (self.showTypingNotifications)
                         {
                             // Register on typing notif
                             [self listenTypingNotifications];
@@ -476,7 +536,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         [self handleUnsentMessages];
 
                         // Update here data source state if it is not already ready
-                        state = MXKDataSourceStateReady;
+                        self->state = MXKDataSourceStateReady;
 
                         // Check user membership in this room
                         MXMembership membership = self.room.summary.membership;
@@ -552,44 +612,46 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         {
             // Flair handling: observe the update in the publicised groups by users when the flair is enabled in the room.
             [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
-            if (_room.state.relatedGroups.count)
-            {
-                [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didMXSessionUpdatePublicisedGroupsForUsers:) name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
-                
-                // Get a fresh profile for all the related groups. Trigger a table refresh when all requests are done.
-                __block NSUInteger count = _room.state.relatedGroups.count;
-                for (NSString *groupId in _room.state.relatedGroups)
+            [self.room state:^(MXRoomState *roomState) {
+                if (roomState.relatedGroups.count)
                 {
-                    MXGroup *group = [self.mxSession groupWithGroupId:groupId];
-                    if (!group)
+                    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didMXSessionUpdatePublicisedGroupsForUsers:) name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
+
+                    // Get a fresh profile for all the related groups. Trigger a table refresh when all requests are done.
+                    __block NSUInteger count = roomState.relatedGroups.count;
+                    for (NSString *groupId in roomState.relatedGroups)
                     {
-                        // Create a group instance for the groups that the current user did not join.
-                        group = [[MXGroup alloc] initWithGroupId:groupId];
-                        [externalRelatedGroups setObject:group forKey:groupId];
+                        MXGroup *group = [self.mxSession groupWithGroupId:groupId];
+                        if (!group)
+                        {
+                            // Create a group instance for the groups that the current user did not join.
+                            group = [[MXGroup alloc] initWithGroupId:groupId];
+                            [externalRelatedGroups setObject:group forKey:groupId];
+                        }
+
+                        // Refresh the group profile from server.
+                        [self.mxSession updateGroupProfile:group success:^{
+
+                            if (self.delegate && !(--count))
+                            {
+                                // All the requests have been done.
+                                [self.delegate dataSource:self didCellChange:nil];
+                            }
+
+                        } failure:^(NSError *error) {
+
+                            NSLog(@"[MXKRoomDataSource] group profile update failed %@", groupId);
+
+                            if (self.delegate && !(--count))
+                            {
+                                // All the requests have been done.
+                                [self.delegate dataSource:self didCellChange:nil];
+                            }
+
+                        }];
                     }
-                    
-                    // Refresh the group profile from server.
-                    [self.mxSession updateGroupProfile:group success:^{
-                        
-                        if (self.delegate && !(--count))
-                        {
-                            // All the requests have been done.
-                            [self.delegate dataSource:self didCellChange:nil];
-                        }
-                        
-                    } failure:^(NSError *error) {
-                        
-                        NSLog(@"[MXKRoomDataSource] group profile update failed %@", groupId);
-                        
-                        if (self.delegate && !(--count))
-                        {
-                            // All the requests have been done.
-                            [self.delegate dataSource:self didCellChange:nil];
-                        }
-                        
-                    }];
                 }
-            }
+            }];
         }
     }
 }
@@ -971,7 +1033,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 - (void)paginate:(NSUInteger)numItems direction:(MXTimelineDirection)direction onlyFromStore:(BOOL)onlyFromStore success:(void (^)(NSUInteger addedCellNumber))success failure:(void (^)(NSError *error))failure
 {
     // Check the current data source state, and the actual user membership for this room.
-    if (state != MXKDataSourceStateReady || ((self.room.summary.membership == MXMembershipUnknown || self.room.summary.membership == MXMembershipInvite) && ![self.room.state.historyVisibility isEqualToString:kMXRoomHistoryVisibilityWorldReadable]))
+    if (state != MXKDataSourceStateReady || ((self.room.summary.membership == MXMembershipUnknown || self.room.summary.membership == MXMembershipInvite) && ![self.roomState.historyVisibility isEqualToString:kMXRoomHistoryVisibilityWorldReadable]))
     {
         // Back pagination is not available here.
         if (failure)
@@ -1229,7 +1291,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1286,7 +1348,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1300,7 +1362,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1314,7 +1376,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1329,7 +1391,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1344,7 +1406,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     if (localEchoEvent)
     {
         // Make the data source digest this fake local echo message
-        [self queueEventForProcessing:localEchoEvent withRoomState:_room.state direction:MXTimelineDirectionForwards];
+        [self queueEventForProcessing:localEchoEvent withRoomState:self.roomState direction:MXTimelineDirectionForwards];
         [self processQueuedEvents:nil];
     }
 }
@@ -1557,7 +1619,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         
         if (outgoingMessage.sentState != MXEventSentStateSent)
         {
-            [self queueEventForProcessing:outgoingMessage withRoomState:_room.state direction:MXTimelineDirectionForwards];
+            [self queueEventForProcessing:outgoingMessage withRoomState:self.roomState direction:MXTimelineDirectionForwards];
             shouldProcessQueuedEvents = YES;
         }
     }
@@ -1775,7 +1837,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         // Check whether at least one listed user is a room member.
         for (NSString* userId in userIds)
         {
-            MXRoomMember * roomMember = [self.room.state.members memberWithUserId:userId];
+            MXRoomMember * roomMember = [self.roomState.members memberWithUserId:userId];
             if (roomMember)
             {
                 // Inform the delegate to refresh the bubble display
@@ -1898,7 +1960,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                 {
                     Class class = [self cellDataClassForCellIdentifier:kMXKRoomBubbleCellDataIdentifier];
 
-                    id<MXKRoomBubbleCellDataStoring> newBubbleData = [[class alloc] initWithEvent:removedEvents[0] andRoomState:self.room.state andRoomDataSource:self];
+                    id<MXKRoomBubbleCellDataStoring> newBubbleData = [[class alloc] initWithEvent:removedEvents[0] andRoomState:self.roomState andRoomDataSource:self];
 
                     if (eventIsFirstInBubble)
                     {
@@ -1936,11 +1998,11 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         MXEvent *removedEvent = removedEvents[i];
                         if (i == 1)
                         {
-                            newBubbleData = [[class alloc] initWithEvent:removedEvent andRoomState:self.room.state andRoomDataSource:self];
+                            newBubbleData = [[class alloc] initWithEvent:removedEvent andRoomState:self.roomState andRoomDataSource:self];
                         }
                         else
                         {
-                            [newBubbleData addEvent:removedEvent andRoomState:self.room.state];
+                            [newBubbleData addEvent:removedEvent andRoomState:self.roomState];
                         }
 
                         // Update bubbles mapping
@@ -2030,7 +2092,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     // read receipts have no rule
     if (![event.type isEqualToString:kMXEventTypeStringReceipt]) {
         // Check if we should bing this event
-        MXPushRule *rule = [self.mxSession.notificationCenter ruleMatchingEvent:event];
+        MXPushRule *rule = [self.mxSession.notificationCenter ruleMatchingEvent:event roomState:self.roomState];
         if (rule)
         {
             // Check whether is there an highlight tweak on it

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -286,7 +286,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 - (MXRoomState *)roomState
 {
     // @TODO(async-state): Just here for dev
-    NSAssert(roomState, @"Room state must be preloaded before accessing to MXKRoomDataSource.roomState");
+    NSAssert(roomState, @"[MXKRoomDataSource] Room state must be preloaded before accessing to MXKRoomDataSource.roomState");
     return roomState;
 }
 

--- a/MatrixKit/Models/Room/MXKRoomDataSourceManager.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSourceManager.h
@@ -86,9 +86,9 @@ typedef enum : NSUInteger {
  
  @param roomId the room id of the room.
  @param create if YES, the MXKRoomDataSourceManager will create the room data source if it does not exist yet.
- @return the room data source (instance of MXKRoomDataSource-inherited class)
+ @param onComplete blocked with the room data source (instance of MXKRoomDataSource-inherited class).
  */
-- (MXKRoomDataSource*)roomDataSourceForRoom:(NSString*)roomId create:(BOOL)create;
+- (void)roomDataSourceForRoom:(NSString*)roomId create:(BOOL)create onComplete:(void (^)(MXKRoomDataSource *roomDataSource))onComplete;
 
 /**
  Make a room data source be managed by the manager.

--- a/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
@@ -218,7 +218,7 @@ NSString *const kMXKRecentCellIdentifier = @"kMXKRecentCellIdentifier";
     for (MXRoomSummary *roomSummary in self.mxSession.roomsSummaries)
     {
         // Filter out private rooms with conference users
-        if (!roomSummary.room.state.isConferenceUserRoom)  // @TODO
+        if (!roomSummary.isConferenceUserRoom)
         {
             id<MXKRecentCellDataStoring> cellData = [[class alloc] initWithRoomSummary:roomSummary andRecentListDataSource:self];
             if (cellData)

--- a/MatrixKit/Models/Search/MXKSearchCellData.m
+++ b/MatrixKit/Models/Search/MXKSearchCellData.m
@@ -61,4 +61,9 @@
     return self;
 }
 
++ (void)cellDataWithSearchResult:(MXSearchResult *)searchResult andSearchDataSource:(MXKSearchDataSource *)searchDataSource onComplete:(void (^)(id<MXKSearchCellDataStoring>))onComplete
+{
+    onComplete([[self alloc] initWithSearchResult:searchResult andSearchDataSource:searchDataSource]);
+}
+
 @end

--- a/MatrixKit/Models/Search/MXKSearchCellDataStoring.h
+++ b/MatrixKit/Models/Search/MXKSearchCellDataStoring.h
@@ -76,8 +76,8 @@
 
  @param searchResult Bulk result returned by MatrixSDK.
  @param searchDataSource the `MXKSearchDataSource` object that will use this instance.
- @return the newly created instance.
+ @param onComplete a block providing the newly created instance.
  */
-- (instancetype)initWithSearchResult:(MXSearchResult*)searchResult andSearchDataSource:(MXKSearchDataSource*)searchDataSource;
++ (void)cellDataWithSearchResult:(MXSearchResult*)searchResult andSearchDataSource:(MXKSearchDataSource*)searchDataSource onComplete:(void (^)(id<MXKSearchCellDataStoring> cellData))onComplete;
 
 @end

--- a/MatrixKit/Models/Search/MXKSearchDataSource.h
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.h
@@ -101,7 +101,8 @@ extern NSString *const kMXKSearchCellDataIdentifier;
  This methods is in charge of filling `cellDataArray`.
  
  @param roomEventResults the homeserver response as provided by MatrixSDK.
+ @param onComplete the block called once complete.
  */
-- (void)convertHomeserverResultsIntoCells:(MXSearchRoomEventResults*)roomEventResults;
+- (void)convertHomeserverResultsIntoCells:(MXSearchRoomEventResults*)roomEventResults onComplete:(dispatch_block_t)onComplete;
 
 @end

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -24,6 +24,7 @@
 #import "MXRoomSummaryUpdater.h"
 
 #import "MXKTools.h"
+#import "MXRoom+Sync.h"
 
 #import "DTCoreText.h"
 #import "cmark.h"
@@ -314,7 +315,7 @@
             NSString *redactorId = event.redactedBecause[@"sender"];
             NSString *redactedBy = @"";
             // Consider live room state to resolve redactor name if no roomState is provided
-            MXRoomState *aRoomState = roomState ? roomState : [mxSession roomWithRoomId:event.roomId].state;
+            MXRoomState *aRoomState = roomState ? roomState : [mxSession roomWithRoomId:event.roomId].dangerousSyncState;
             redactedBy = [aRoomState.members memberName:redactorId];
             
             NSString *redactedReason = (event.redactedBecause[@"content"])[@"reason"];
@@ -1327,7 +1328,7 @@
 }
 
 #pragma mark - MXRoomSummaryUpdating
-- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withStateEvents:(NSArray<MXEvent *> *)stateEvents
+- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withStateEvents:(NSArray<MXEvent *> *)stateEvents roomState:(MXRoomState *)roomState
 {
     // We build strings containing the sender displayname (ex: "Bob: Hello!")
     // If a sender changes his displayname, we need to update the lastMessage.
@@ -1351,7 +1352,7 @@
         }
     }
 
-    return [defaultRoomSummaryUpdater session:session updateRoomSummary:summary withStateEvents:stateEvents];
+    return [defaultRoomSummaryUpdater session:session updateRoomSummary:summary withStateEvents:stateEvents roomState:roomState];
 }
 
 - (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withLastEvent:(MXEvent *)event eventState:(MXRoomState *)eventState roomState:(MXRoomState *)roomState

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1350,6 +1350,10 @@
                 break;
             }
         }
+        else if (event.eventType == MXEventTypeRoomJoinRules)
+        {
+            summary.others[@"mxkEventFormatterisJoinRulePublic"] = @(roomState.isJoinRulePublic);
+        }
     }
 
     return [defaultRoomSummaryUpdater session:session updateRoomSummary:summary withStateEvents:stateEvents roomState:roomState];

--- a/MatrixKit/Views/MXKEventDetailsView.m
+++ b/MatrixKit/Views/MXKEventDetailsView.m
@@ -125,19 +125,24 @@
                 MXRoom *mxRoom = [mxSession roomWithRoomId:mxEvent.roomId];
                 if (mxRoom)
                 {
-                    MXRoomPowerLevels *powerLevels = [mxRoom.state powerLevels];
-                    NSInteger userPowerLevel = [powerLevels powerLevelOfUserWithUserID:mxSession.myUser.userId];
-                    if (powerLevels.redact)
-                    {
-                        if (userPowerLevel >= powerLevels.redact)
+                    MXWeakify(self);
+                    [mxRoom state:^(MXRoomState *roomState) {
+                        MXStrongifyAndReturnIfNil(self);
+
+                        MXRoomPowerLevels *powerLevels = [roomState powerLevels];
+                        NSInteger userPowerLevel = [powerLevels powerLevelOfUserWithUserID:mxSession.myUser.userId];
+                        if (powerLevels.redact)
                         {
-                            _redactButton.enabled = YES;
+                            if (userPowerLevel >= powerLevels.redact)
+                            {
+                                self.redactButton.enabled = YES;
+                            }
                         }
-                    }
-                    else if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsMessage:kMXEventTypeStringRoomRedaction])
-                    {
-                        _redactButton.enabled = YES;
-                    }
+                        else if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsMessage:kMXEventTypeStringRoomRedaction])
+                        {
+                            self.redactButton.enabled = YES;
+                        }
+                    }];
                 }
             }
         }

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -26,6 +26,7 @@
 #import "MXKConstants.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "MXRoom+Sync.h"
 
 #pragma mark - Constant definitions
 NSString *const kMXKRoomBubbleCellTapOnMessageTextView = @"kMXKRoomBubbleCellTapOnMessageTextView";
@@ -651,9 +652,10 @@ static BOOL _disableLongPressGestureOnEvent;
                                     roomMembers = [[NSMutableArray alloc] initWithCapacity:receipts.count];
                                     placeholders = [[NSMutableArray alloc] initWithCapacity:receipts.count];
 
+                                    MXRoomMembers *stateRoomMembers = room.dangerousSyncState.members;
                                     for (MXReceiptData* data in receipts)
                                     {
-                                        MXRoomMember * roomMember = [room.state.members memberWithUserId:data.userId];
+                                        MXRoomMember * roomMember = [stateRoomMembers memberWithUserId:data.userId];
                                         if (roomMember)
                                         {
                                             [roomMembers addObject:roomMember];

--- a/MatrixKit/Views/RoomList/MXKRecentTableViewCell.m
+++ b/MatrixKit/Views/RoomList/MXKRecentTableViewCell.m
@@ -45,7 +45,8 @@
         }
         
         // Set in bold public room name
-        if (roomCellData.roomSummary.room.state.isJoinRulePublic)
+        if (roomCellData.roomSummary.others[@"mxkEventFormatterisJoinRulePublic"]
+            && [(NSNumber*)roomCellData.roomSummary.others[@"mxkEventFormatterisJoinRulePublic"] boolValue])
         {
             _roomTitle.font = [UIFont boldSystemFontOfSize:20];
         }

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -21,6 +21,7 @@
 #import "MXKConstants.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "MXRoom+Sync.h"
 
 @interface MXKRoomTitleView ()
 {
@@ -158,7 +159,8 @@
         if (textField == self.displayNameTextField)
         {
             // Check whether the user has enough power to rename the room
-            MXRoomPowerLevels *powerLevels = [_mxRoom.state powerLevels];
+            MXRoomPowerLevels *powerLevels = _mxRoom.dangerousSyncState.powerLevels;
+
             NSInteger userPowerLevel = [powerLevels powerLevelOfUserWithUserID:_mxRoom.mxSession.myUser.userId];
             if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomName])
             {

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -21,6 +21,7 @@
 #import "MXKConstants.h"
 
 #import "NSBundle+MatrixKit.h"
+#import "MXRoom+Sync.h"
 
 @interface MXKRoomTitleViewWithTopic ()
 {
@@ -364,7 +365,7 @@
         if (textField == self.displayNameTextField)
         {
             // Check whether the user has enough power to rename the room
-            MXRoomPowerLevels *powerLevels = [self.mxRoom.state powerLevels];
+            MXRoomPowerLevels *powerLevels = self.mxRoom.dangerousSyncState.powerLevels;
             NSInteger userPowerLevel = [powerLevels powerLevelOfUserWithUserID:self.mxRoom.mxSession.myUser.userId];
             if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomName])
             {
@@ -394,7 +395,7 @@
         else if (textField == self.topicTextField)
         {
             // Check whether the user has enough power to edit room topic
-            MXRoomPowerLevels *powerLevels = [self.mxRoom.state powerLevels];
+            MXRoomPowerLevels *powerLevels = self.mxRoom.dangerousSyncState.powerLevels;
             NSInteger userPowerLevel = [powerLevels powerLevelOfUserWithUserID:self.mxRoom.mxSession.myUser.userId];
             if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomTopic])
             {

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -128,18 +128,13 @@
             if (mxRoom)
             {
                 // Register a listener to handle messages related to room name
-                MXWeakify(self);
-                [mxRoom liveTimeline:^(MXEventTimeline *liveTimeline) {
-                    MXStrongifyAndReturnIfNil(self);
+                [mxRoom listenToEventsOfTypes:@[kMXEventTypeStringRoomTopic] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                    self->roomTopicListener = [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomTopic] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
-
-                        // Consider only live events
-                        if (direction == MXTimelineDirectionForwards)
-                        {
-                            [self refreshDisplay];
-                        }
-                    }];
+                    // Consider only live events
+                    if (direction == MXTimelineDirectionForwards)
+                    {
+                        [self refreshDisplay];
+                    }
                 }];
             }
         }


### PR DESCRIPTION
Part of vector-im/riot-ios#1931 in order to decouple MXRoom.members from MXRoom.state