### PR TITLE
Lazy loading server side

### DIFF
--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -783,11 +783,11 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         if (!mxCall.isConferenceCall)
         {
             MXWeakify(self);
-            [mxCall.room members:^(MXRoomMembers *roomMembers) {
+            [mxCall.room state:^(MXRoomState *roomState) {
                 MXStrongifyAndReturnIfNil(self);
             
                 MXUser *theMember = nil;
-                NSArray *members = roomMembers.joinedMembers;
+                NSArray *members = roomState.members.joinedMembers;
                 for (MXUser *member in members)
                 {
                     if (![member.userId isEqualToString:self->mxCall.callerId])

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1311,9 +1311,12 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         NSLog(@"[MXKAccount] Initial server sync is applicable only when store data is ready to complete session initialisation");
         return;
     }
+
+    // Use /sync filter corresponding to current settings
+    MXFilterJSONModel *syncFilter = [MXKAppSettings standardAppSettings].syncFilter;
     
     // Launch mxSession
-    [mxSession start:^{
+    [mxSession startWithSyncFilter:syncFilter onServerSyncDone:^{
         
         NSLog(@"[MXKAccount] %@: The session is ready. Matrix SDK session has been started in %0.fms.", mxCredentials.userId, [[NSDate date] timeIntervalSinceDate:openSessionStartDate] * 1000);
         

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -210,11 +210,13 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                 
                 MXStrongifyAndReturnIfNil(self);
                 
-                // create contact for room members
+                // create contact for known room members
                 if (self.contactManagerMXRoomSource != MXKContactManagerMXRoomSourceNone)
                 {
                     MXRoom *room = notif.object;
-                    [room members:^(MXRoomMembers *roomMembers) {
+                    [room state:^(MXRoomState *roomState) {
+
+                        MXRoomMembers *roomMembers = roomState.members;
 
                         NSArray *members = roomMembers.members;
 

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -26,6 +26,18 @@
  */
 @interface MXKAppSettings : NSObject
 
+#pragma mark - /sync filter
+
+/**
+ Lazy load room members when /syncing with the homeserver.
+ */
+@property (nonatomic) BOOL syncWithLazyLoadOfRoomMembers;
+
+/**
+ The filter object to use in /sync requests according to current settings.
+ */
+@property (nonatomic, readonly) MXFilterJSONModel *syncFilter;
+
 #pragma mark - Room display
 
 /**

--- a/MatrixKit/Utils/MXKEventFormatter.m
+++ b/MatrixKit/Utils/MXKEventFormatter.m
@@ -1411,6 +1411,11 @@
     return updated;
 }
 
+- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState
+{
+    return [defaultRoomSummaryUpdater session:session updateRoomSummary:summary withServerRoomSummary:serverRoomSummary roomState:roomState];
+}
+
 
 #pragma mark - Conversion private methods
 

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -107,7 +107,7 @@
     // Make sure we can access synchronously to self.mxRoom and mxRoom data
     // to avoid race conditions
     MXWeakify(self);
-    [self.mxRoom.mxSession preloadRoomsData:@[self.mxRoom.roomId, mxRoom.roomId] onComplete:^{
+    [mxRoom.mxSession preloadRoomsData:self.mxRoom ? @[self.mxRoom.roomId, mxRoom.roomId] : @[mxRoom.roomId] onComplete:^{
         MXStrongifyAndReturnIfNil(self);
 
         // Check whether the room is actually changed


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/1931

Fix some async bits and add MXKAppSettings.syncWithLazyLoadOfRoomMembers to use LL server side.