### PR TITLE
Lazy-loading: Fix search display

### DIFF
--- a/MatrixKit/Models/Search/MXKSearchDataSource.m
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.m
@@ -139,6 +139,10 @@ NSString *const kMXKSearchCellDataIdentifier = @"kMXKSearchCellDataIdentifier";
             {
                 ((id<MXKSearchCellDataStoring>)cellData).shouldShowRoomDisplayName = self.shouldShowRoomDisplayName;
 
+                // Use profile information as data to display
+                MXSearchUserProfile *userProfile = result.context.profileInfo[result.result.sender];
+                cellData.senderDisplayName = userProfile.displayName;
+
                 [self->cellDataArray insertObject:cellData atIndex:0];
             }
         }];


### PR DESCRIPTION
Use profile info sent in the search response.

Part of https://github.com/vector-im/riot-ios/issues/1931