### PR TITLE
[MXKRoomDataSource] Fix a multithreading issue that caused a crash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in MatrixKit in 0.7.16 ()
 
 Improvements:
  * MXKRoomDataSource: Add send reply with text message (vector-im/riot-ios#1911).
+ * MXKRoomDataSource: Fix a multithreading issue that caused a crash (PR #456).
 
 
 Changes in MatrixKit in 0.7.15 (2018-07-03)

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -354,9 +354,16 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         eventsToProcessSnapshot = nil;
         bubblesSnapshot = nil;
         
-        [bubbles removeAllObjects];
-        [eventIdToBubbleMap removeAllObjects];
-
+        @synchronized(bubbles)
+        {
+            [bubbles removeAllObjects];
+        }
+        
+        @synchronized(eventIdToBubbleMap)
+        {
+            [eventIdToBubbleMap removeAllObjects];
+        }
+        
         _room = nil;
     }
     


### PR DESCRIPTION
[MXKRoomDataSource] Fix a multithreading issue that caused a crash when `bubbles` property was mutated while being enumerated.

Fix issue https://github.com/vector-im/riot-ios/issues/1953