### PR TITLE
Remove keyboard type reset in MXKRoomInputToolbar... classes

### DIFF
--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithHPGrowingText.m
@@ -107,14 +107,7 @@
 - (void)setTextMessage:(NSString *)textMessage
 {
     growingTextView.text = textMessage;
-    self.rightInputToolbarButton.enabled = textMessage.length;
-    
-    if (!textMessage.length && growingTextView.isFirstResponder)
-    {
-        // Trick: Toggle default keyboard from 123 mode to ABC mode when text input is reset
-        [growingTextView resignFirstResponder];
-        [growingTextView becomeFirstResponder];
-    }
+    self.rightInputToolbarButton.enabled = textMessage.length;    
 }
 
 - (void)pasteText:(NSString *)text

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
@@ -51,13 +51,6 @@
 {
     _messageComposerTextView.text = textMessage;
     self.rightInputToolbarButton.enabled = textMessage.length;
-    
-    if (!textMessage.length && _messageComposerTextView.isFirstResponder)
-    {
-        // Trick: Toggle default keyboard from 123 mode to ABC mode when text input is reset
-        [_messageComposerTextView resignFirstResponder];
-        [_messageComposerTextView becomeFirstResponder];
-    }
 }
 
 - (void)pasteText:(NSString *)text


### PR DESCRIPTION
As mention in issue https://github.com/vector-im/riot-ios/issues/1959 keyboard is switching to alphabet after sending a message with any keyboard type. 
This was introduce in order to have same behavior as Apple Messages application, switch back to alphabet keyboard when sending a message with numbers and punctuation keyboard.
As there is currently no future proof way or clear public API to detect Apple Emoji keyboard and custom keyboard we remove this behavior for the moment.