### PR TITLE
Fix crash in [MXKContactManager refreshLocalContacts] 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Changes in MatrixKit in 0.8.4 (2018-09)
+==========================================
+
+Improvements:
+* Upgrade MatrixSDK version (v0.11.4).
+
+Bug fix:
+* Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
+
 Changes in MatrixKit in 0.8.3 (2018-08-27)
 ==========================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
 
 Bug fix:
 * Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
+* Fix crash in [MXKContactManager refreshLocalContacts] (vector-im/riot-ios/issues/2032).
 
 Changes in MatrixKit in 0.8.3 (2018-08-27)
 ==========================================

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -278,10 +278,11 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         mxCall = call;
         
         [self addMatrixSession:mxCall.room.mxSession];
-        
-        // Register a listener to handle messages related to room name, members...
+
         MXWeakify(self);
-        [mxCall.room listenToEventsOfTypes:@[kMXEventTypeStringRoomName, kMXEventTypeStringRoomTopic, kMXEventTypeStringRoomAliases, kMXEventTypeStringRoomAvatar, kMXEventTypeStringRoomCanonicalAlias, kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+        // Register a listener to handle messages related to room name, members...
+        roomListener = [mxCall.room listenToEventsOfTypes:@[kMXEventTypeStringRoomName, kMXEventTypeStringRoomTopic, kMXEventTypeStringRoomAliases, kMXEventTypeStringRoomAvatar, kMXEventTypeStringRoomCanonicalAlias, kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             MXStrongifyAndReturnIfNil(self);
 
             // Consider only live events
@@ -294,9 +295,10 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
         
         // Observe room history flush (sync with limited timeline, or state event redaction)
         roomDidFlushDataNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomDidFlushDataNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+            MXStrongifyAndReturnIfNil(self);
             
             MXRoom *room = notif.object;
-            if (mxCall && self.mainSession == room.mxSession && [mxCall.room.roomId isEqualToString:room.roomId])
+            if (self->mxCall && self.mainSession == room.mxSession && [self->mxCall.room.roomId isEqualToString:room.roomId])
             {
                 // The existing room history has been flushed during server sync.
                 // Take into account the updated room state

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -642,13 +642,16 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                             {
                                 // ignore unchanged contacts since the previous sync
                                 CFDateRef lastModifDate = ABRecordCopyValue(contactRecord, kABPersonModificationDateProperty);
-                                if (kCFCompareGreaterThan != CFDateCompare (lastModifDate, (__bridge CFDateRef)self->lastSyncDate, nil))
-
+                                if (lastModifDate)
                                 {
+                                    if (kCFCompareGreaterThan != CFDateCompare(lastModifDate, (__bridge CFDateRef)self->lastSyncDate, nil))
+
+                                    {
+                                        CFRelease(lastModifDate);
+                                        continue;
+                                    }
                                     CFRelease(lastModifDate);
-                                    continue;
                                 }
-                                CFRelease(lastModifDate);
                             }
 
                             didContactBookChange = YES;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -775,7 +775,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 
     // Register a listener to handle redaction which can affect live and past timelines
-    [_room listenToEventsOfTypes:@[kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *redactionEvent, MXTimelineDirection direction, MXRoomState *roomState) {
+    redactionListener = [_room listenToEventsOfTypes:@[kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *redactionEvent, MXTimelineDirection direction, MXRoomState *roomState) {
 
         // Consider only live redaction events
         if (direction == MXTimelineDirectionForwards)

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -25,8 +25,6 @@
 
 @interface MXKRoomTitleView ()
 {
-    id roomListener;
-    
     // Observer kMXRoomSummaryDidChangeNotification to keep updated the room name.
     id mxRoomSummaryDidChangeObserver;
 }

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -128,7 +128,7 @@
             if (mxRoom)
             {
                 // Register a listener to handle messages related to room name
-                [mxRoom listenToEventsOfTypes:@[kMXEventTypeStringRoomTopic] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                self->roomTopicListener = [mxRoom listenToEventsOfTypes:@[kMXEventTypeStringRoomTopic] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                     // Consider only live events
                     if (direction == MXTimelineDirectionForwards)


### PR DESCRIPTION
vector-im/riot-ios/issues/2032

by adding a sanity check.