### PR TITLE
 Sync Filter: Get enough messages from /sync requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in MatrixKit in 0.8.4 (2018-09)
 
 Improvements:
 * Upgrade MatrixSDK version (v0.11.4).
+* Sync Filter: Get enough messages from /sync requests to display a full page without additional homeserver request.
 
 Bug fix:
 * Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -292,7 +292,31 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
 
     if (self.syncWithLazyLoadOfRoomMembers)
     {
-        syncFilter = [MXFilterJSONModel syncFilterForLazyLoading];
+        // Define a message limit for /sync requests that is high enough so that
+        // a full page of room messages can be displayed without an additional
+        // server request.
+
+        // This limit value depends on the device screen size. So, the rough rule is:
+        //    - use 10 for phones (5S/6/6S/7/8)
+        //    - use 20 for phablets (.Plus/X/XR/XS/XSMax)
+        //    - use 30 for iPads
+        NSUInteger limit = 10;
+        UIUserInterfaceIdiom userInterfaceIdiom = [[UIDevice currentDevice] userInterfaceIdiom];
+        if (userInterfaceIdiom == UIUserInterfaceIdiomPhone)
+        {
+            CGFloat screenHeight = [[UIScreen mainScreen] nativeBounds].size.height;
+            if (screenHeight > 1334)    // 6/6S/7/8 screen height
+            {
+                limit = 20;
+            }
+        }
+        else if (userInterfaceIdiom == UIUserInterfaceIdiomPad)
+        {
+            limit = 30;
+        }
+
+        // Set that limit in the filter
+        syncFilter = [MXFilterJSONModel syncFilterForLazyLoadingWithMessageLimit:limit];
     }
 
     // TODO: We could extend the filter to match other settings (self.showAllEventsInRoomHistory,

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -91,7 +91,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
     /**
      The data for the cells served by `MXKRoomDataSource`.
      */
-    NSMutableArray *bubbles;
+    NSMutableArray<id<MXKRoomBubbleCellDataStoring>> *bubbles;
 
     /**
      The queue of events that need to be processed in order to compute their display.

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1173,23 +1173,26 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     // Check whether data has been aldready loaded
     if (bubbles.count)
     {
+        NSUInteger eventsCount = 0;
         for (NSInteger i = bubbles.count - 1; i >= 0; i--)
         {
+            id<MXKRoomBubbleCellDataStoring> bubbleData = bubbles[i];
+            eventsCount += bubbleData.events.count;
+            
             CGFloat bubbleHeight = [self cellHeightAtIndex:i withMaximumWidth:rect.size.width];
             // Sanity check
             if (bubbleHeight)
             {
                 bubblesTotalHeight += bubbleHeight;
-                
+
                 if (bubblesTotalHeight > rect.size.height)
                 {
                     // No need to compute more cells heights, there are enough to fill the rect
-                    NSLog(@"[MXKRoomDataSource] -> %tu already loaded bubbles are enough to fill the screen", bubbles.count - i);
+                    NSLog(@"[MXKRoomDataSource] -> %tu already loaded bubbles (%tu events) are enough to fill the screen", bubbles.count - i, eventsCount);
                     break;
                 }
                 
                 // Compute the minimal height an event takes
-                id<MXKRoomBubbleCellDataStoring> bubbleData = bubbles[i];
                 minMessageHeight = MIN(minMessageHeight, bubbleHeight / bubbleData.events.count);
             }
         }


### PR DESCRIPTION
to display a full page without additional homeserver request. This sync limit depends on the device the app is running

https://github.com/vector-im/riot-ios/issues/1931