### PR TITLE
BF: No automatic scroll down when posting a new message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
 * Sync Filter: Get enough messages from /sync requests to display a full page without additional homeserver request.
 
 Bug fix:
+* No automatic scroll down when posting a new message (vector-im/riot-ios/issues/2040).
 * Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
 * Fix crash in [MXKContactManager refreshLocalContacts] (vector-im/riot-ios/issues/2032).
 

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -1703,9 +1703,9 @@
         // Compute the max vertical position visible according to contentOffset
         CGFloat maxPositionY = _bubblesTableView.contentOffset.y + (_bubblesTableView.frame.size.height - _bubblesTableView.mxk_adjustedContentInset.bottom);
         // Be a bit less retrictive, consider the table view at the bottom even if the most recent message is partially hidden
-        maxPositionY += 30;
+        maxPositionY += 44;
         BOOL isScrolledToBottom = (maxPositionY >= _bubblesTableView.contentSize.height);
-        
+
         // Consider the table view at the bottom if a scrolling to bottom is in progress too
         return (isScrolledToBottom || isScrollingToBottom);
     }


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/2040
Fix it by increasing the threshold value that determines that the scroll view is at the its bottom