### PR TITLE
MXKRoomDataSource: Fix crash when opening a room with unsent message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Improvements:
 Bug fix:
 * Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
 * Fix crash in [MXKContactManager refreshLocalContacts] (vector-im/riot-ios/issues/2032).
+* Fix crash when opening a room with unsent message (vector-im/riot-ios/issues/2041).
 
 Changes in MatrixKit in 0.8.3 (2018-08-27)
 ==========================================

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -159,36 +159,23 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 + (void)loadRoomDataSourceWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete
 {
     MXKRoomDataSource *roomDataSource = [[self alloc] initWithRoomId:roomId andMatrixSession:mxSession];
-    if (roomDataSource)
-    {
-        [roomDataSource finalizeInitialization];
-
-        [roomDataSource.room state:^(MXRoomState *roomState) {
-            roomDataSource->roomState = roomState;
-
-            onComplete(roomDataSource);
-        }];
-    }
+    [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
 }
 
 + (void)loadRoomDataSourceWithRoomId:(NSString*)roomId initialEventId:(NSString*)initialEventId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete
 {
     MXKRoomDataSource *roomDataSource = [[self alloc] initWithRoomId:roomId initialEventId:initialEventId andMatrixSession:mxSession];
-    if (roomDataSource)
-    {
-        [roomDataSource finalizeInitialization];
-
-        [roomDataSource.room state:^(MXRoomState *roomState) {
-            roomDataSource->roomState = roomState;
-
-            onComplete(roomDataSource);
-        }];
-    }
+    [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
 }
 
 + (void)loadRoomDataSourceWithPeekingRoom:(MXPeekingRoom*)peekingRoom andInitialEventId:(NSString*)initialEventId onComplete:(void (^)(id roomDataSource))onComplete
 {
     MXKRoomDataSource *roomDataSource = [[self alloc] initWithPeekingRoom:peekingRoom andInitialEventId:initialEventId];
+    [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
+}
+
++ (void)finalizeRoomDataSource:(MXKRoomDataSource*)roomDataSource onComplete:(void (^)(id roomDataSource))onComplete
+{
     if (roomDataSource)
     {
         [roomDataSource finalizeInitialization];

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -520,6 +520,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                         MXStrongifyAndReturnIfNil(self);
 
                         self->_timeline = liveTimeline;
+                        self->roomState = liveTimeline.state;
 
                         // Only one pagination process can be done at a time by an MXRoom object.
                         // This assumption is satisfied by MatrixKit. Only MXRoomDataSource does it.


### PR DESCRIPTION
vector-im/riot-ios/issues/2041
