### PR TITLE
Sync Filter: Refine limit value. Use 15 messages for iPhone 6 & similar screen size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Changes in MatrixKit in 0.8.5 (2018-10-)
+==========================================
+
+Improvements:
+* Upgrade MatrixSDK version (v0.11.5).
+* Sync Filter: Refine limit value. Use 15 messages for iPhone 6 & similar screen size.
+
 Changes in MatrixKit in 0.8.4 (2018-09-26)
 ==========================================
 

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1720,7 +1720,8 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         // server request.
 
         // This limit value depends on the device screen size. So, the rough rule is:
-        //    - use 10 for phones (5S/6/6S/7/8)
+        //    - use 10 for small phones (5S/SE)
+        //    - use 15 for phones (6/6S/7/8)
         //    - use 20 for phablets (.Plus/X/XR/XS/XSMax)
         //    - use 30 for iPads
         NSUInteger limit = 10;
@@ -1728,7 +1729,11 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         if (userInterfaceIdiom == UIUserInterfaceIdiomPhone)
         {
             CGFloat screenHeight = [[UIScreen mainScreen] nativeBounds].size.height;
-            if (screenHeight > 1334)    // 6/6S/7/8 screen height
+            if (screenHeight == 1334)   // 6/6S/7/8 screen height
+            {
+                limit = 15;
+            }
+            else if (screenHeight > 1334)
             {
                 limit = 20;
             }


### PR DESCRIPTION
10 was definitely not enough on Giom's iPhone.