### PR TITLE
BF: MXKRoomDataSource: roomState was not updated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Improvements:
 * Upgrade MatrixSDK version (v0.11.5).
 * Sync Filter: Refine limit value. Use 15 messages for iPhone 6 & similar screen size.
 
+Bug fix:
+* MXKRoomDataSource: roomState was not updated (vector-im/riot-ios/issues/2058).
+
 Changes in MatrixKit in 0.8.4 (2018-09-26)
 ==========================================
 


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2058