### PR TITLE
MXKEventFormatter: Be robust on malformatted m.relates_to data content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Changes in MatrixKit in 0.8.6 (2018-10-)
+==========================================
+
+Improvements:
+* Upgrade MatrixSDK version (v0.11.6).
+
+Bug fix:
+* MXKEventFormatter: Be robust on malformatted m.relates_to data content (vector-im/riot-ios/issues/2080).
+
 Changes in MatrixKit in 0.8.5 (2018-10-05)
 ==========================================
 

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1180,7 +1180,9 @@
     NSString *html = htmlString;
 
     // Special treatment for "In reply to" message
-    if (event.content[@"m.relates_to"][@"m.in_reply_to"])
+    NSDictionary *relatesTo;
+    MXJSONModelSetDictionary(relatesTo, event.content[@"m.relates_to"]);
+    if ([relatesTo[@"m.in_reply_to"] isKindOfClass:NSDictionary.class])
     {
         html = [self renderReplyTo:html];
     }


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2080.