### PR TITLE
MXKCallViewController: Fix crash in callRoomStateDidChange

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Improvements:
 * Upgrade MatrixSDK version (v0.11.6).
 
 Bug fix:
+* MXKCallViewController: Fix crash in callRoomStateDidChange (vector-im/riot-ios#2079).
 * MXKEventFormatter: Be robust on malformatted m.relates_to data content (vector-im/riot-ios/issues/2080).
 
 Changes in MatrixKit in 0.8.5 (2018-10-05)

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -778,7 +778,10 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     if (mxCall.isIncoming)
     {
         self.peer = [mxCall.room.mxSession getOrCreateUser:mxCall.callerId];
-        onComplete();
+        if (onComplete)
+        {
+            onComplete();
+        }
     }
     else
     {
@@ -802,13 +805,19 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
                 }
 
                 self.peer = theMember;
-                onComplete();
+                if (onComplete)
+                {
+                    onComplete();
+                }
             }];
         }
         else
         {
             self.peer = nil;
-            onComplete();
+            if (onComplete)
+            {
+                onComplete();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2079

Regression made with LL in commit b6010fa2.