### PR TITLE
MXMediaManager/MXMediaLoader: Do not allow non-mxc content URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,44 +1,58 @@
+Changes in MatrixKit in 0.8.x (2018-xx-xx)
+==========================================
+
+Improvements:
+ * Replace the deprecated MXMediaManager and MXMediaLoader interfaces use (see matrix-ios-sdk/pull/593).
+ 
+Deprecated API:
+ * MXKAttachment: the properties "actualURL" and "thumbnailURL" are deprecated because only Matrix Content URI should be considered now.
+ * MXKAttachment: the property "cacheThumbnailPath" is deprecated, use "thumbnailCachePath" instead.
+ * MXKAttachment: [initWithEvent:andMatrixSession:] is deprecated, use [initWithEvent:andMediaManager:] instead.
+ * MXKImageView: [setImageURL:withType:andImageOrientation:previewImage:] is deprecated, use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] or [setImageURI:withType:andImageOrientation:toFitViewSize:withMethod:previewImage:mediaManager] instead.
+ * MXKReceiptSendersContainer: the property "restClient" is deprecated.
+ * MXKReceiptSendersContainer: [initWithFrame:andRestClient:] is deprecated, use [initWithFrame:andMediaManager:] instead.
+
 Changes in MatrixKit in 0.8.6 (2018-10-31)
 ==========================================
 
 Improvements:
-* Upgrade MatrixSDK version (v0.11.6).
+ * Upgrade MatrixSDK version (v0.11.6).
 
 Bug fix:
-* MXKCallViewController: Fix crash in callRoomStateDidChange (vector-im/riot-ios#2079).
-* MXKEventFormatter: Be robust on malformatted m.relates_to data content (vector-im/riot-ios/issues/2080).
+ * MXKCallViewController: Fix crash in callRoomStateDidChange (vector-im/riot-ios#2079).
+ * MXKEventFormatter: Be robust on malformatted m.relates_to data content (vector-im/riot-ios/issues/2080).
 
 Changes in MatrixKit in 0.8.5 (2018-10-05)
 ==========================================
 
 Improvements:
-* Upgrade MatrixSDK version (v0.11.5).
-* Sync Filter: Refine limit value. Use 15 messages for iPhone 6 & similar screen size.
+ * Upgrade MatrixSDK version (v0.11.5).
+ * Sync Filter: Refine limit value. Use 15 messages for iPhone 6 & similar screen size.
 
 Bug fix:
-* MXKRoomDataSource: roomState was not updated (vector-im/riot-ios/issues/2058).
+ * MXKRoomDataSource: roomState was not updated (vector-im/riot-ios/issues/2058).
 
 Changes in MatrixKit in 0.8.4 (2018-09-26)
 ==========================================
 
 Improvements:
-* Upgrade MatrixSDK version (v0.11.4).
-* Lazy loading: Enable it by default (if the homeserver supports it).
-* Sync Filter: Get enough messages from /sync requests to display a full page without additional homeserver request.
-* MXKRoomViewController: Improve the display of the reason when the user is kicked.
-* MXKEventFormatter: Internationalise the room name computation for rooms with no name.
+ * Upgrade MatrixSDK version (v0.11.4).
+ * Lazy loading: Enable it by default (if the homeserver supports it).
+ * Sync Filter: Get enough messages from /sync requests to display a full page without additional homeserver request.
+ * MXKRoomViewController: Improve the display of the reason when the user is kicked.
+ * MXKEventFormatter: Internationalise the room name computation for rooms with no name.
 
 Bug fix:
-* No automatic scroll down when posting a new message (vector-im/riot-ios/issues/2040).
-* Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
-* Fix crash in [MXKContactManager refreshLocalContacts] (vector-im/riot-ios/issues/2032).
-* Fix crash when opening a room with unsent message (vector-im/riot-ios/issues/2041).
+ * No automatic scroll down when posting a new message (vector-im/riot-ios/issues/2040).
+ * Fix crash in [MXKCallViewController callRoomStateDidChange:] (vector-im/riot-ios/issues/2031).
+ * Fix crash in [MXKContactManager refreshLocalContacts] (vector-im/riot-ios/issues/2032).
+ * Fix crash when opening a room with unsent message (vector-im/riot-ios/issues/2041).
 
 Changes in MatrixKit in 0.8.3 (2018-08-27)
 ==========================================
 
 Improvements:
-* Upgrade MatrixSDK version (v0.11.3).
+ * Upgrade MatrixSDK version (v0.11.3).
 
 Changes in MatrixKit in 0.8.2 (2018-08-24)
 ==========================================

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -774,19 +774,13 @@
             else if (indexPath.item == currentVisibleItemIndex)
             {
                 // Load high res image
-                cell.mxkImageView.mediaFolder = attachment.eventRoomId;
                 cell.mxkImageView.stretchable = YES;
-                cell.mxkImageView.enableInMemoryCache = NO;
-                
                 [cell.mxkImageView setAttachment:attachment];
             }
             else
             {
                 // Use the thumbnail here - Full res images should only be downloaded explicitly when requested (see [self refreshCurrentVisibleItemIndex])
-                cell.mxkImageView.mediaFolder = attachment.eventRoomId;
                 cell.mxkImageView.stretchable = YES;
-                cell.mxkImageView.enableInMemoryCache = YES;
-                
                 [cell.mxkImageView setAttachmentThumb:attachment];
             }
         }

--- a/MatrixKit/Controllers/MXKAttachmentsViewController.m
+++ b/MatrixKit/Controllers/MXKAttachmentsViewController.m
@@ -517,7 +517,6 @@
         if (item < attachments.count)
         {
             MXKAttachment *attachment = attachments[item];
-            NSString *attachmentURL = attachment.actualURL;
             NSString *mimeType = attachment.contentInfo[@"mimetype"];
             
             // Tell the delegate which attachment has been shown using its eventId
@@ -527,11 +526,10 @@
             }
             
             // Check attachment type
-            if (attachment.type == MXKAttachmentTypeImage && attachmentURL.length && ![mimeType isEqualToString:@"image/gif"])
+            if (attachment.type == MXKAttachmentTypeImage && attachment.contentURL && ![mimeType isEqualToString:@"image/gif"])
             {
                 // Retrieve the related cell
                 UICollectionViewCell *cell = [_attachmentsCollection cellForItemAtIndexPath:[NSIndexPath indexPathForItem:currentVisibleItemIndex inSection:0]];
-                
                 if ([cell isKindOfClass:[MXKMediaCollectionViewCell class]])
                 {
                     MXKMediaCollectionViewCell *mediaCollectionViewCell = (MXKMediaCollectionViewCell*)cell;
@@ -540,18 +538,7 @@
                     mediaCollectionViewCell.mxkImageView.stretchable = YES;
                     mediaCollectionViewCell.mxkImageView.enableInMemoryCache = NO;
                     
-                    // Use the current image as preview
-                    UIImage *preview = mediaCollectionViewCell.mxkImageView.image;
-                    if (!preview)
-                    {
-                        // Check whether the thumbnail has just been downloaded and cached
-                        NSString *previewCacheFilePath = [MXMediaManager cachePathForMediaWithURL:attachment.thumbnailURL
-                                                                                           andType:mimeType
-                                                                                          inFolder:attachment.eventRoomId];
-                        preview = [MXMediaManager loadPictureFromFilePath:previewCacheFilePath];
-                    }
-                    
-                    [mediaCollectionViewCell.mxkImageView setImageURL:attachmentURL withType:mimeType andImageOrientation:UIImageOrientationUp previewImage:preview];
+                    [mediaCollectionViewCell.mxkImageView setAttachment:attachment];
                 }
             }
         }
@@ -649,14 +636,13 @@
     if (item < attachments.count)
     {
         MXKAttachment *attachment = attachments[item];
-        NSString *attachmentURL = attachment.actualURL;
         NSString *mimeType = attachment.contentInfo[@"mimetype"];
         
         // Use the cached thumbnail (if any) as preview
         UIImage* preview = [attachment getCachedThumbnail];
         
         // Check attachment type
-        if ((attachment.type == MXKAttachmentTypeImage || attachment.type == MXKAttachmentTypeSticker) && attachmentURL.length)
+        if ((attachment.type == MXKAttachmentTypeImage || attachment.type == MXKAttachmentTypeSticker) && attachment.contentURL)
         {
             if ([mimeType isEqualToString:@"image/gif"])
             {
@@ -726,23 +712,29 @@
                 [cell.customView addSubview:pieChartView];
                 
                 // Add download progress observer
-                cell.notificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXMediaDownloadProgressNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+                NSString *downloadId = attachment.downloadId;
+                cell.notificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXMediaLoaderStateDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
                     
-                    if ([notif.object isEqualToString:attachmentURL])
+                    MXMediaLoader *loader = (MXMediaLoader*)notif.object;
+                    if ([loader.downloadId isEqualToString:downloadId])
                     {
-                        if (notif.userInfo)
-                        {
-                            NSNumber* progressNumber = [notif.userInfo valueForKey:kMXMediaLoaderProgressValueKey];
-                            
-                            if (progressNumber)
+                        // update the image
+                        switch (loader.state) {
+                            case MXMediaLoaderStateDownloadInProgress:
                             {
-                                pieChartView.progress = progressNumber.floatValue;
+                                NSNumber* progressNumber = [loader.statisticsDict valueForKey:kMXMediaLoaderProgressValueKey];
+                                if (progressNumber)
+                                {
+                                    pieChartView.progress = progressNumber.floatValue;
+                                }
+                                break;
                             }
+                            default:
+                                break;
                         }
                     }
                     
                 }];
-                
                 
                 void (^onDownloaded)(NSData *) = ^(NSData *data){
                     if (cell.notificationObserver)
@@ -798,14 +790,13 @@
                 [cell.mxkImageView setAttachmentThumb:attachment];
             }
         }
-        else if (attachment.type == MXKAttachmentTypeVideo && attachmentURL.length)
+        else if (attachment.type == MXKAttachmentTypeVideo && attachment.contentURL)
         {
             cell.mxkImageView.mediaFolder = attachment.eventRoomId;
             cell.mxkImageView.stretchable = NO;
             cell.mxkImageView.enableInMemoryCache = YES;
             // Display video thumbnail, the video is played only when user selects this cell
             [cell.mxkImageView setAttachmentThumb:attachment];
-            //[cell.mxkImageView setImageURL:attachment.thumbnailURL withType:mimeType andImageOrientation:attachment.thumbnailOrientation previewImage:nil];
             
             cell.centerIcon.image = [NSBundle mxk_imageFromMXKAssetsBundleWithName:@"play"];
             cell.centerIcon.hidden = NO;
@@ -849,9 +840,8 @@
     if (item < attachments.count)
     {
         MXKAttachment *attachment = attachments[item];
-        NSString *attachmentURL = attachment.actualURL;
         
-        if (attachment.type == MXKAttachmentTypeVideo && attachmentURL.length)
+        if (attachment.type == MXKAttachmentTypeVideo && attachment.contentURL)
         {
             MXKMediaCollectionViewCell *selectedCell = (MXKMediaCollectionViewCell*)[collectionView cellForItemAtIndexPath:indexPath];
             
@@ -986,18 +976,25 @@
                     [selectedCell.customView addSubview:pieChartView];
                     
                     // Add download progress observer
-                    selectedCell.notificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXMediaDownloadProgressNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+                    NSString *downloadId = attachment.downloadId;
+                    selectedCell.notificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXMediaLoaderStateDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
                         
-                        if ([notif.object isEqualToString:attachmentURL])
+                        MXMediaLoader *loader = (MXMediaLoader*)notif.object;
+                        if ([loader.downloadId isEqualToString:downloadId])
                         {
-                            if (notif.userInfo)
-                            {
-                                NSNumber* progressNumber = [notif.userInfo valueForKey:kMXMediaLoaderProgressValueKey];
-                                
-                                if (progressNumber)
+                            // update progress
+                            switch (loader.state) {
+                                case MXMediaLoaderStateDownloadInProgress:
                                 {
-                                    pieChartView.progress = progressNumber.floatValue;
+                                    NSNumber* progressNumber = [loader.statisticsDict valueForKey:kMXMediaLoaderProgressValueKey];
+                                    if (progressNumber)
+                                    {
+                                        pieChartView.progress = progressNumber.floatValue;
+                                    }
+                                    break;
                                 }
+                                default:
+                                    break;
                             }
                         }
                         
@@ -1270,13 +1267,13 @@
                                                                
                                                                self->documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:fileURL];
                                                                [self->documentInteractionController setDelegate:self];
-                                                               currentSharedAttachment = attachment;
+                                                               self->currentSharedAttachment = attachment;
                                                                
                                                                if (![self->documentInteractionController presentOptionsMenuFromRect:self.view.frame inView:self.view animated:YES])
                                                                {
                                                                    self->documentInteractionController = nil;
                                                                    [attachment onShareEnded];
-                                                                   currentSharedAttachment = nil;
+                                                                   self->currentSharedAttachment = nil;
                                                                }
                                                                
                                                            } failure:^(NSError *error) {
@@ -1291,7 +1288,7 @@
                                                            
                                                        }]];
         
-        if ([MXMediaManager existingDownloaderWithOutputFilePath:attachment.cacheFilePath])
+        if ([MXMediaManager existingDownloaderWithIdentifier:attachment.downloadId])
         {
             [currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel_download"]
                                                              style:UIAlertActionStyleDefault
@@ -1301,7 +1298,7 @@
                                                                self->currentAlert = nil;
                                                                
                                                                // Get again the loader
-                                                               MXMediaLoader *loader = [MXMediaManager existingDownloaderWithOutputFilePath:attachment.cacheFilePath];
+                                                               MXMediaLoader *loader = [MXMediaManager existingDownloaderWithIdentifier:attachment.downloadId];
                                                                if (loader)
                                                                {
                                                                    [loader cancel];

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -394,10 +395,15 @@ NSString *const kMXKCallViewControllerBackToAppNotification = @"kMXKCallViewCont
     if (peerAvatarURL)
     {
         // Suppose avatar url is a matrix content uri, we use SDK to get the well adapted thumbnail from server
-        NSString *avatarThumbURL = [self.mainSession.matrixRestClient urlOfContentThumbnail:peerAvatarURL toFitViewSize:callerImageView.frame.size withMethod:MXThumbnailingMethodCrop];
         callerImageView.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
         callerImageView.enableInMemoryCache = YES;
-        [callerImageView setImageURL:avatarThumbURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:self.picturePlaceholder];
+        [callerImageView setImageURI:peerAvatarURL
+                            withType:nil
+                 andImageOrientation:UIImageOrientationUp
+                       toFitViewSize:callerImageView.frame.size
+                          withMethod:MXThumbnailingMethodCrop
+                        previewImage:self.picturePlaceholder
+                        mediaManager:self.mainSession.mediaManager];
     }
     else
     {

--- a/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKRoomMemberDetailsViewController.m
@@ -611,16 +611,15 @@
     [self.memberThumbnail.layer setCornerRadius:self.memberThumbnail.frame.size.width / 2];
     [self.memberThumbnail setClipsToBounds:YES];
     
-    NSString *thumbnailURL = nil;
-    if (_mxRoomMember.avatarUrl)
-    {
-        // Suppose this url is a matrix content uri, we use SDK to get the well adapted thumbnail from server
-        thumbnailURL = [self.mainSession.matrixRestClient urlOfContentThumbnail:_mxRoomMember.avatarUrl toFitViewSize:self.memberThumbnail.frame.size withMethod:MXThumbnailingMethodCrop];
-    }
-    
     self.memberThumbnail.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
     self.memberThumbnail.enableInMemoryCache = YES;
-    [self.memberThumbnail setImageURL:thumbnailURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:self.picturePlaceholder];
+    [self.memberThumbnail setImageURI:_mxRoomMember.avatarUrl
+                             withType:nil
+                  andImageOrientation:UIImageOrientationUp
+                        toFitViewSize:self.memberThumbnail.frame.size
+                           withMethod:MXThumbnailingMethodCrop
+                         previewImage:self.picturePlaceholder
+                           mediaManager:self.mainSession.mediaManager];
     
     self.roomMemberMatrixInfo.text = _mxRoomMember.userId;
     

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2624,8 +2624,8 @@
         MXKRoomBubbleTableViewCell *roomBubbleTableViewCell = (MXKRoomBubbleTableViewCell *)cell;
         
         // Check if there is a download in progress, then offer to cancel it
-        NSString *cacheFilePath = roomBubbleTableViewCell.bubbleData.attachment.cacheFilePath;
-        if ([MXMediaManager existingDownloaderWithOutputFilePath:cacheFilePath])
+        NSString *downloadId = roomBubbleTableViewCell.bubbleData.attachment.downloadId;
+        if ([MXMediaManager existingDownloaderWithIdentifier:downloadId])
         {
             if (currentAlert)
             {
@@ -2652,7 +2652,7 @@
                                                                self->currentAlert = nil;
                                                                
                                                                // Get again the loader
-                                                               MXMediaLoader *loader = [MXMediaManager existingDownloaderWithOutputFilePath:cacheFilePath];
+                                                               MXMediaLoader *loader = [MXMediaManager existingDownloaderWithIdentifier:downloadId];
                                                                if (loader)
                                                                {
                                                                    [loader cancel];
@@ -2671,7 +2671,7 @@
         {
             // Offer to cancel the upload in progress
             // Upload id is stored in attachment url (nasty trick)
-            NSString *uploadId = roomBubbleTableViewCell.bubbleData.attachment.actualURL;
+            NSString *uploadId = roomBubbleTableViewCell.bubbleData.attachment.contentURL;
             if ([MXMediaManager existingUploaderWithId:uploadId])
             {
                 if (currentAlert)
@@ -2714,7 +2714,7 @@
                                                                        
                                                                        // Remove the outgoing message and its related cached file.
                                                                        [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.cacheFilePath error:nil];
-                                                                       [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.cacheThumbnailPath error:nil];
+                                                                       [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.thumbnailCachePath error:nil];
                                                                        [self.roomDataSource removeEventWithEventId:roomBubbleTableViewCell.bubbleData.attachment.eventId];
                                                                    }
                                                                    
@@ -2950,7 +2950,7 @@
                     selectedEvent.sentState == MXEventSentStateUploading)
                 {
                     // Upload id is stored in attachment url (nasty trick)
-                    NSString *uploadId = roomBubbleTableViewCell.bubbleData.attachment.actualURL;
+                    NSString *uploadId = roomBubbleTableViewCell.bubbleData.attachment.contentURL;
                     if ([MXMediaManager existingUploaderWithId:uploadId])
                     {
                         [currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel_upload"]
@@ -2976,7 +2976,7 @@
                                                                                
                                                                                // Remove the outgoing message and its related cached file.
                                                                                [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.cacheFilePath error:nil];
-                                                                               [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.cacheThumbnailPath error:nil];
+                                                                               [[NSFileManager defaultManager] removeItemAtPath:roomBubbleTableViewCell.bubbleData.attachment.thumbnailCachePath error:nil];
                                                                                [self.roomDataSource removeEventWithEventId:selectedEvent.eventId];
                                                                            }
                                                                            
@@ -2991,8 +2991,8 @@
                 // Check whether download is in progress
                 if (selectedEvent.isMediaAttachment)
                 {
-                    NSString *cacheFilePath = roomBubbleTableViewCell.bubbleData.attachment.cacheFilePath;
-                    if ([MXMediaManager existingDownloaderWithOutputFilePath:cacheFilePath])
+                    NSString *downloadId = roomBubbleTableViewCell.bubbleData.attachment.downloadId;
+                    if ([MXMediaManager existingDownloaderWithIdentifier:downloadId])
                     {
                         [currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel_download"]
                                                                          style:UIAlertActionStyleDefault
@@ -3002,7 +3002,7 @@
                                                                            self->currentAlert = nil;
                                                                            
                                                                            // Get again the loader
-                                                                           MXMediaLoader *loader = [MXMediaManager existingDownloaderWithOutputFilePath:cacheFilePath];
+                                                                           MXMediaLoader *loader = [MXMediaManager existingDownloaderWithIdentifier:downloadId];
                                                                            if (loader)
                                                                            {
                                                                                [loader cancel];

--- a/MatrixKit/Models/Contact/MXKContactField.h
+++ b/MatrixKit/Models/Contact/MXKContactField.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -28,7 +29,7 @@
  */
 @property (nonatomic, readwrite) NSString *matrixID;
 /**
- The matrix avatar url, nil by default.
+ The matrix avatar url (Matrix Content URI), nil by default.
  */
 @property (nonatomic) NSString* matrixAvatarURL;
 /**

--- a/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServerCellData.m
+++ b/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServerCellData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -22,6 +23,7 @@
 @synthesize desc, icon;
 @synthesize homeserver, includeAllNetworks;
 @synthesize thirdPartyProtocolInstance, thirdPartyProtocol;
+@synthesize mediaManager;
 
 - (id)initWithHomeserver:(NSString *)theHomeserver includeAllNetworks:(BOOL)theIncludeAllNetworks
 {

--- a/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServerCellDataStoring.h
+++ b/MatrixKit/Models/PublicRoomList/DirectoryServerList/MXKDirectoryServerCellDataStoring.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -21,7 +22,7 @@
 
 /**
  `MXKDirectoryServerCellDataStoring` defines a protocol a class must conform in order to
- store room member cell data managed by `MXKDirectoryServersDataSource`.
+ store directory cell data managed by `MXKDirectoryServersDataSource`.
  */
 @protocol MXKDirectoryServerCellDataStoring <NSObject>
 
@@ -36,6 +37,11 @@
  The icon of the server.
  */
 @property (nonatomic) UIImage *icon;
+
+/**
+ The optional media manager used to download the icon of the server.
+ */
+@property (nonatomic) MXMediaManager *mediaManager;
 
 /**
  In case the cell data represents a homeserver, its description.

--- a/MatrixKit/Models/Room/MXKAttachment.h
+++ b/MatrixKit/Models/Room/MXKAttachment.h
@@ -63,7 +63,7 @@ typedef enum : NSUInteger {
  */
 @property (nonatomic, readonly, nullable) NSString *mxcThumbnailURI;
 @property (nonatomic, readonly, nullable) NSString *thumbnailMimeType;
-@property (nonatomic, readonly) NSString *thumbnailURL __attribute__((deprecated("Use [mxcThumbnailURI] instead")));
+@property (nonatomic, readonly) NSString *thumbnailURL __attribute__((deprecated("Use mxcThumbnailURI instead")));
 
 /**
  The download identifier of the attachment content (related to contentURL).
@@ -87,7 +87,7 @@ typedef enum : NSUInteger {
 /**
  The actual attachment url
  */
-@property (nonatomic, readonly) NSString *actualURL __attribute__((deprecated("Use [contentURL] instead")));
+@property (nonatomic, readonly) NSString *actualURL __attribute__((deprecated("Use contentURL instead")));
 
 /**
  The thumbnail orientation (relevant in case of image).
@@ -103,7 +103,7 @@ typedef enum : NSUInteger {
  The cache file path of the attachment thumbnail (may be nil).
  */
 @property (nonatomic, readonly) NSString *thumbnailCachePath;
-@property (nonatomic, readonly) NSString *cacheThumbnailPath __attribute__((deprecated("Use [thumbnailCachePath] instead")));
+@property (nonatomic, readonly) NSString *cacheThumbnailPath __attribute__((deprecated("Use thumbnailCachePath instead")));
 
 /**
  The preview of the attachment (nil by default).

--- a/MatrixKit/Models/Room/MXKAttachment.h
+++ b/MatrixKit/Models/Room/MXKAttachment.h
@@ -63,7 +63,6 @@ typedef enum : NSUInteger {
  */
 @property (nonatomic, readonly, nullable) NSString *mxcThumbnailURI;
 @property (nonatomic, readonly, nullable) NSString *thumbnailMimeType;
-@property (nonatomic, readonly) NSString *thumbnailURL __attribute__((deprecated("Use mxcThumbnailURI instead")));
 
 /**
  The download identifier of the attachment content (related to contentURL).
@@ -85,11 +84,6 @@ typedef enum : NSUInteger {
 @property (nonatomic, readonly) NSString *originalFileName;
 
 /**
- The actual attachment url
- */
-@property (nonatomic, readonly) NSString *actualURL __attribute__((deprecated("Use contentURL instead")));
-
-/**
  The thumbnail orientation (relevant in case of image).
  */
 @property (nonatomic, readonly) UIImageOrientation thumbnailOrientation;
@@ -103,7 +97,6 @@ typedef enum : NSUInteger {
  The cache file path of the attachment thumbnail (may be nil).
  */
 @property (nonatomic, readonly) NSString *thumbnailCachePath;
-@property (nonatomic, readonly) NSString *cacheThumbnailPath __attribute__((deprecated("Use thumbnailCachePath instead")));
 
 /**
  The preview of the attachment (nil by default).
@@ -129,16 +122,6 @@ typedef enum : NSUInteger {
  */
 - (instancetype)initWithEvent:(MXEvent*)event andMediaManager:(MXMediaManager*)mediaManager;
 
-/**
- Create a `MXKAttachment` instance for the passed event.
- The created instance copies the current data of the event (content, event id, sent state...).
- It will ignore any future changes of these data.
- 
- @param mxEvent the matrix event.
- @param mxSession the matrix session.
- @return `MXKAttachment` instance.
- */
-- (instancetype)initWithEvent:(MXEvent*)mxEvent andMatrixSession:(MXSession*)mxSession __attribute__((deprecated("Use [initWithEvent:andMediaManager:] instead")));
 - (void)destroy;
 
 /**

--- a/MatrixKit/Models/Room/MXKAttachment.h
+++ b/MatrixKit/Models/Room/MXKAttachment.h
@@ -40,6 +40,11 @@ typedef enum : NSUInteger {
 @interface MXKAttachment : NSObject
 
 /**
+ The media manager instance used to download the attachment data.
+ */
+@property (nonatomic, readonly) MXMediaManager *mediaManager;
+
+/**
  The attachment type.
  */
 @property (nonatomic, readonly) MXKAttachmentType type;
@@ -53,11 +58,25 @@ typedef enum : NSUInteger {
 @property (nonatomic, readonly) NSString *contentURL;
 @property (nonatomic, readonly) NSDictionary *contentInfo;
 
-// The URL of a 'standard size' thumbnail
-@property (nonatomic, readonly) NSString *thumbnailURL;
-@property (nonatomic, readonly) NSString *thumbnailMimeType;
+/**
+ The URL of a 'standard size' thumbnail.
+ */
+@property (nonatomic, readonly, nullable) NSString *mxcThumbnailURI;
+@property (nonatomic, readonly, nullable) NSString *thumbnailMimeType;
+@property (nonatomic, readonly) NSString *thumbnailURL __attribute__((deprecated("Use [mxcThumbnailURI] instead")));
 
-// The attached video thumbnail information
+/**
+ The download identifier of the attachment content (related to contentURL).
+ */
+@property (nonatomic, readonly, nullable) NSString *downloadId;
+/**
+ The download identifier of the attachment thumbnail.
+ */
+@property (nonatomic, readonly, nullable) NSString *thumbnailDownloadId;
+
+/**
+ The attached video thumbnail information.
+ */
 @property (nonatomic, readonly) NSDictionary *thumbnailInfo;
 
 /**
@@ -68,7 +87,7 @@ typedef enum : NSUInteger {
 /**
  The actual attachment url
  */
-@property (nonatomic, readonly) NSString *actualURL;
+@property (nonatomic, readonly) NSString *actualURL __attribute__((deprecated("Use [contentURL] instead")));
 
 /**
  The thumbnail orientation (relevant in case of image).
@@ -83,7 +102,8 @@ typedef enum : NSUInteger {
 /**
  The cache file path of the attachment thumbnail (may be nil).
  */
-@property (nonatomic, readonly) NSString *cacheThumbnailPath;
+@property (nonatomic, readonly) NSString *thumbnailCachePath;
+@property (nonatomic, readonly) NSString *cacheThumbnailPath __attribute__((deprecated("Use [thumbnailCachePath] instead")));
 
 /**
  The preview of the attachment (nil by default).
@@ -103,11 +123,22 @@ typedef enum : NSUInteger {
  The created instance copies the current data of the event (content, event id, sent state...).
  It will ignore any future changes of these data.
  
+ @param event a matrix event.
+ @param mediaManager the media manager instance used to download the attachment data.
+ @return `MXKAttachment` instance.
+ */
+- (instancetype)initWithEvent:(MXEvent*)event andMediaManager:(MXMediaManager*)mediaManager;
+
+/**
+ Create a `MXKAttachment` instance for the passed event.
+ The created instance copies the current data of the event (content, event id, sent state...).
+ It will ignore any future changes of these data.
+ 
  @param mxEvent the matrix event.
  @param mxSession the matrix session.
  @return `MXKAttachment` instance.
  */
-- (instancetype)initWithEvent:(MXEvent*)mxEvent andMatrixSession:(MXSession*)mxSession;
+- (instancetype)initWithEvent:(MXEvent*)mxEvent andMatrixSession:(MXSession*)mxSession __attribute__((deprecated("Use [initWithEvent:andMediaManager:] instead")));
 - (void)destroy;
 
 /**

--- a/MatrixKit/Models/Room/MXKAttachment.m
+++ b/MatrixKit/Models/Room/MXKAttachment.m
@@ -64,7 +64,7 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
 @end
 
 @interface MXKAttachment ()
-@property (nonatomic) MXSession *sess __attribute__((deprecated("Use [contentURL] instead")));
+@property (nonatomic) MXSession *sess __attribute__((deprecated("No longer defined")));
 @end
 
 @implementation MXKAttachment
@@ -160,6 +160,7 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
     return self;
 }
 
+// TODO: MEDIA: Remove this deprecated method
 - (instancetype)initWithEvent:(MXEvent *)mxEvent andMatrixSession:(MXSession*)mxSession
 {
     self = [super init];

--- a/MatrixKit/Models/Room/MXKAttachment.m
+++ b/MatrixKit/Models/Room/MXKAttachment.m
@@ -415,6 +415,11 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
         {
             [self getImage:onSuccess failure:onFailure];
         }
+        else if (onFailure)
+        {
+            onFailure(nil);
+        }
+        
         return;
     }
     

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -60,7 +60,7 @@
             if ([roomDataSource.eventFormatter isSupportedAttachment:event])
             {
                 // Note: event.eventType is equal here to MXEventTypeRoomMessage or MXEventTypeSticker
-                attachment = [[MXKAttachment alloc] initWithEvent:event andMatrixSession:roomDataSource.mxSession];
+                attachment = [[MXKAttachment alloc] initWithEvent:event andMediaManager:roomDataSource.mxSession.mediaManager];
                 if (attachment && attachment.type == MXKAttachmentTypeImage)
                 {
                     // Check the current thumbnail orientation. Rotate the current content size (if need)
@@ -136,7 +136,7 @@
                     }
                     else if (![attachment.eventId isEqualToString:event.eventId] || ![attachment.contentURL isEqualToString:eventContentURL])
                     {
-                        MXKAttachment *updatedAttachment = [[MXKAttachment alloc] initWithEvent:event andMatrixSession:roomDataSource.mxSession];
+                        MXKAttachment *updatedAttachment = [[MXKAttachment alloc] initWithEvent:event andMediaManager:roomDataSource.mxSession.mediaManager];
                         
                         // Sanity check on attachment type
                         if (updatedAttachment && attachment.type == updatedAttachment.type)
@@ -182,7 +182,7 @@
                 else if ([roomDataSource.eventFormatter isSupportedAttachment:event])
                 {
                     // The event is updated to an event with attachement
-                    attachment = [[MXKAttachment alloc] initWithEvent:event andMatrixSession:roomDataSource.mxSession];
+                    attachment = [[MXKAttachment alloc] initWithEvent:event andMediaManager:roomDataSource.mxSession.mediaManager];
                     if (attachment && attachment.type == MXKAttachmentTypeImage)
                     {
                         // Check the current thumbnail orientation. Rotate the current content size (if need)

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -153,9 +153,9 @@
                             {
                                 [[NSFileManager defaultManager] removeItemAtPath:attachment.cacheFilePath error:nil];
                             }
-                            if (![updatedAttachment.cacheThumbnailPath isEqualToString:attachment.cacheThumbnailPath])
+                            if (![updatedAttachment.thumbnailCachePath isEqualToString:attachment.thumbnailCachePath])
                             {
-                                [[NSFileManager defaultManager] removeItemAtPath:attachment.cacheThumbnailPath error:nil];
+                                [[NSFileManager defaultManager] removeItemAtPath:attachment.thumbnailCachePath error:nil];
                             }
                             
                             // Update the current attachmnet description

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1505,7 +1505,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     mimetype = event.content[@"info"][@"mimetype"];
                 }
                 
-                NSString *localImagePath = [MXMediaManager cachePathForMediaWithURL:contentURL andType:mimetype inFolder:_roomId];
+                NSString *localImagePath = [MXMediaManager cachePathForMatrixContentURI:contentURL andType:mimetype inFolder:_roomId];
                 UIImage* image = [MXMediaManager loadPictureFromFilePath:localImagePath];
                 if (image)
                 {
@@ -1571,7 +1571,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
                     // Remove the local echo
                     [self removeEventWithEventId:eventId];
                     
-                    NSString *localFilePath = [MXMediaManager cachePathForMediaWithURL:contentURL andType:mimetype inFolder:_roomId];
+                    NSString *localFilePath = [MXMediaManager cachePathForMatrixContentURI:contentURL andType:mimetype inFolder:_roomId];
                     
                     [self sendFile:[NSURL fileURLWithPath:localFilePath isDirectory:NO] mimeType:mimetype success:success failure:failure];
                 }

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -270,7 +270,7 @@
     // Handle here the case where no avatar is defined (Check SDK options before using identicon).
     if (!senderAvatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
     {
-        senderAvatarUrl = [mxSession.matrixRestClient urlOfIdenticon:event.sender];
+        senderAvatarUrl = [mxSession.mediaManager urlOfIdenticon:event.sender];
     }
     
     return senderAvatarUrl;

--- a/MatrixKit/Views/Account/MXKAccountTableViewCell.m
+++ b/MatrixKit/Views/Account/MXKAccountTableViewCell.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -38,16 +39,15 @@
     
     if (mxAccount.mxSession)
     {
-        // User thumbnail
-        NSString *thumbnailURL = nil;
-        if (mxAccount.userAvatarUrl)
-        {
-            // Suppose this url is a matrix content uri, we use SDK to get the well adapted thumbnail from server
-            thumbnailURL = [mxAccount.mxSession.matrixRestClient urlOfContentThumbnail:mxAccount.userAvatarUrl toFitViewSize:_accountPicture.frame.size withMethod:MXThumbnailingMethodCrop];
-        }
         _accountPicture.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
         _accountPicture.enableInMemoryCache = YES;
-        [_accountPicture setImageURL:thumbnailURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:self.picturePlaceholder];
+        [_accountPicture setImageURI:mxAccount.userAvatarUrl
+                            withType:nil
+                 andImageOrientation:UIImageOrientationUp
+                       toFitViewSize:_accountPicture.frame.size
+                          withMethod:MXThumbnailingMethodCrop
+                        previewImage:self.picturePlaceholder
+                        mediaManager:mxAccount.mxSession.mediaManager];
         
         presenceColor = [MXKAccount presenceColor:mxAccount.userPresence];
     }

--- a/MatrixKit/Views/MXKCollectionViewCell/MXKMediaCollectionViewCell.m
+++ b/MatrixKit/Views/MXKCollectionViewCell/MXKMediaCollectionViewCell.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,7 +31,11 @@
     self.mxkImageView.stretchable = NO;
     // Cancel potential image download
     self.mxkImageView.enableInMemoryCache = NO;
-    [self.mxkImageView setImageURL:nil withType:nil andImageOrientation:UIImageOrientationUp previewImage:nil];
+    [self.mxkImageView setImageURI:nil
+                          withType:nil
+               andImageOrientation:UIImageOrientationUp
+                      previewImage:nil
+                      mediaManager:nil];
     
     self.customView.hidden = YES;
     self.centerIcon.hidden = YES;

--- a/MatrixKit/Views/MXKImageView.h
+++ b/MatrixKit/Views/MXKImageView.h
@@ -83,7 +83,7 @@ andImageOrientation:(UIImageOrientation)orientation
  @param orientation the actual orientation of the encoded image (used UIImageOrientationUp by default).
  @param previewImage image displayed until the actual image is available.
  */
-- (void)setImageURL:(NSString *)imageURL withType:(NSString *)mimeType andImageOrientation:(UIImageOrientation)orientation previewImage:(UIImage*)previewImage __attribute__((deprecated("Use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] instead")));
+- (void)setImageURL:(NSString *)imageURL withType:(NSString *)mimeType andImageOrientation:(UIImageOrientation)orientation previewImage:(UIImage*)previewImage __attribute__((deprecated("Use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] or [setImageURI:withType:andImageOrientation:toFitViewSize:withMethod:previewImage:mediaManager] instead")));
 
 /**
  * Load an image attachment into the image viewer and display the full res image.

--- a/MatrixKit/Views/MXKImageView.h
+++ b/MatrixKit/Views/MXKImageView.h
@@ -73,19 +73,6 @@ andImageOrientation:(UIImageOrientation)orientation
        mediaManager:(MXMediaManager*)mediaManager;
 
 /**
- Load an image by its url.
- 
- The image extension is extracted from the provided mime type (if any). If no type is available, we look for a potential extension
- in the url. By default 'image/jpeg' is considered.
- 
- @param imageURL the remote image url
- @param mimeType the media mime type, it is used to define the file extension (may be nil).
- @param orientation the actual orientation of the encoded image (used UIImageOrientationUp by default).
- @param previewImage image displayed until the actual image is available.
- */
-- (void)setImageURL:(NSString *)imageURL withType:(NSString *)mimeType andImageOrientation:(UIImageOrientation)orientation previewImage:(UIImage*)previewImage __attribute__((deprecated("Use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] or [setImageURI:withType:andImageOrientation:toFitViewSize:withMethod:previewImage:mediaManager] instead")));
-
-/**
  * Load an image attachment into the image viewer and display the full res image.
  * This method must be used to display encrypted attachments
  * @param attachment The attachment

--- a/MatrixKit/Views/MXKImageView.h
+++ b/MatrixKit/Views/MXKImageView.h
@@ -17,11 +17,11 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <MatrixSDK/MatrixSDK.h>
 
 #import "MXKView.h"
 
 @class MXKAttachment;
-@class MXMediaManager;
 
 /**
  Customize UIView in order to display image defined with remote url. Zooming inside the image (Stretching) is supported.
@@ -46,6 +46,29 @@ typedef void (^blockMXKImageView_onClick)(MXKImageView *imageView, NSString* tit
 - (void)setImageURI:(NSString *)mxContentURI
            withType:(NSString *)mimeType
 andImageOrientation:(UIImageOrientation)orientation
+       previewImage:(UIImage*)previewImage
+       mediaManager:(MXMediaManager*)mediaManager;
+
+/**
+ Load an image by its Matrix Content URI to fit a specific view size.
+ 
+ CAUTION: this method is available only for the unencrypted content.
+ 
+ The image is loaded from the media cache (if any). If the image is not available yet,
+ it is downloaded from the Matrix media repository only if a media manager instance is provided.
+ The image extension is extracted from the provided mime type (if any). By default 'image/jpeg' is considered.
+ 
+ @param mxContentURI the Matrix Content URI
+ @param mimeType the media mime type, it is used to define the file extension (may be nil).
+ @param orientation the actual orientation of the encoded image (used UIImageOrientationUp by default).
+ @param previewImage image displayed until the actual image is available.
+ @param mediaManager the media manager instance used to download the image if it is not already in cache.
+ */
+- (void)setImageURI:(NSString *)mxContentURI
+           withType:(NSString *)mimeType
+andImageOrientation:(UIImageOrientation)orientation
+      toFitViewSize:(CGSize)viewSize
+         withMethod:(MXThumbnailingMethod)thumbnailingMethod
        previewImage:(UIImage*)previewImage
        mediaManager:(MXMediaManager*)mediaManager;
 

--- a/MatrixKit/Views/MXKImageView.h
+++ b/MatrixKit/Views/MXKImageView.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@
 #import "MXKView.h"
 
 @class MXKAttachment;
+@class MXMediaManager;
 
 /**
  Customize UIView in order to display image defined with remote url. Zooming inside the image (Stretching) is supported.
@@ -27,6 +29,25 @@
 @interface MXKImageView : MXKView <UIScrollViewDelegate>
 
 typedef void (^blockMXKImageView_onClick)(MXKImageView *imageView, NSString* title);
+
+/**
+ Load an image by its Matrix Content URI.
+ The image is loaded from the media cache (if any). If the image is not available yet,
+ it is downloaded from the Matrix media repository only if a media manager instance is provided.
+ 
+ The image extension is extracted from the provided mime type (if any). By default 'image/jpeg' is considered.
+ 
+ @param mxContentURI the Matrix Content URI
+ @param mimeType the media mime type, it is used to define the file extension (may be nil).
+ @param orientation the actual orientation of the encoded image (used UIImageOrientationUp by default).
+ @param previewImage image displayed until the actual image is available.
+ @param mediaManager the media manager instance used to download the image if it is not already in cache.
+ */
+- (void)setImageURI:(NSString *)mxContentURI
+           withType:(NSString *)mimeType
+andImageOrientation:(UIImageOrientation)orientation
+       previewImage:(UIImage*)previewImage
+       mediaManager:(MXMediaManager*)mediaManager;
 
 /**
  Load an image by its url.
@@ -39,7 +60,7 @@ typedef void (^blockMXKImageView_onClick)(MXKImageView *imageView, NSString* tit
  @param orientation the actual orientation of the encoded image (used UIImageOrientationUp by default).
  @param previewImage image displayed until the actual image is available.
  */
-- (void)setImageURL:(NSString *)imageURL withType:(NSString *)mimeType andImageOrientation:(UIImageOrientation)orientation previewImage:(UIImage*)previewImage;
+- (void)setImageURL:(NSString *)imageURL withType:(NSString *)mimeType andImageOrientation:(UIImageOrientation)orientation previewImage:(UIImage*)previewImage __attribute__((deprecated("Use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] instead")));
 
 /**
  * Load an image attachment into the image viewer and display the full res image.

--- a/MatrixKit/Views/MXKImageView.m
+++ b/MatrixKit/Views/MXKImageView.m
@@ -748,6 +748,7 @@ andImageOrientation:(UIImageOrientation)orientation
     // Set default orientation
     imageOrientation = UIImageOrientationUp;
     
+    mediaFolder = attachment.eventRoomId;
     mxcURI = attachment.contentURL;
     mimeType = attachment.contentInfo[@"mimetype"];
     if (!mimeType.length)
@@ -798,8 +799,15 @@ andImageOrientation:(UIImageOrientation)orientation
     // Store image orientation
     imageOrientation = attachment.thumbnailOrientation;
     
+    mediaFolder = attachment.eventRoomId;
+    
     // Remove the existing image (if any) by using the potential preview.
     self.image = attachment.previewImage;
+    
+    if (!_hideActivityIndicator)
+    {
+        [self startActivityIndicator];
+    }
     
     MXWeakify(self);
     [attachment getThumbnail:^(UIImage *img) {
@@ -812,7 +820,11 @@ andImageOrientation:(UIImageOrientation)orientation
         {
             self.image = img;
         }
-    } failure:nil];
+        [self stopActivityIndicator];
+    } failure:^(NSError *error) {
+        MXStrongifyAndReturnIfNil(self);
+        [self stopActivityIndicator];
+    }];
 }
 
 // TODO: MEDIA: Remove this method when deprecated methods will be removed

--- a/MatrixKit/Views/MXKReceiptSendersContainer.h
+++ b/MatrixKit/Views/MXKReceiptSendersContainer.h
@@ -41,11 +41,6 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
 @interface MXKReceiptSendersContainer : MXKView
 
 /**
- The REST client used to resize matrix user's avatar.
- */
-@property (nonatomic) MXRestClient* restClient __attribute__((deprecated("No longer defined")));
-
-/**
  The maximum number of avatars displayed in the container. 3 by default.
  */
 @property (nonatomic) NSInteger maxDisplayedAvatars;
@@ -85,17 +80,6 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
  @return The newly-initialized MXKReceiptSendersContainer instance
  */
 - (instancetype)initWithFrame:(CGRect)frame andMediaManager:(MXMediaManager*)mediaManager;
-
-/**
- Initializes an `MXKReceiptSendersContainer` object with a frame and a REST client.
- 
- This is the designated initializer.
- 
- @param frame the container frame. Note that avatar will be displayed in full height in this container.
- @param restclient the REST client used to resize matrix user's avatar.
- @return The newly-initialized MXKReceiptSendersContainer instance
- */
-- (instancetype)initWithFrame:(CGRect)frame andRestClient:(MXRestClient*)restclient __attribute__((deprecated("Use [initWithFrame:andMediaManager:] instead")));
 
 /**
  Refresh the container content by using the provided room members.

--- a/MatrixKit/Views/MXKReceiptSendersContainer.h
+++ b/MatrixKit/Views/MXKReceiptSendersContainer.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
 /**
  The REST client used to resize matrix user's avatar.
  */
-@property (nonatomic) MXRestClient* restClient;
+@property (nonatomic) MXRestClient* restClient __attribute__((deprecated("No longer defined")));
 
 /**
  The maximum number of avatars displayed in the container. 3 by default.
@@ -75,6 +76,17 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
 @property (nonatomic, readonly) NSArray <UIImage *> *placeholders;
 
 /**
+ Initializes an `MXKReceiptSendersContainer` object with a frame and a media manager.
+ 
+ This is the designated initializer.
+ 
+ @param frame the container frame. Note that avatar will be displayed in full height in this container.
+ @param mediaManager the media manager used to download the matrix user's avatar.
+ @return The newly-initialized MXKReceiptSendersContainer instance
+ */
+- (instancetype)initWithFrame:(CGRect)frame andMediaManager:(MXMediaManager*)mediaManager;
+
+/**
  Initializes an `MXKReceiptSendersContainer` object with a frame and a REST client.
  
  This is the designated initializer.
@@ -83,7 +95,7 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
  @param restclient the REST client used to resize matrix user's avatar.
  @return The newly-initialized MXKReceiptSendersContainer instance
  */
-- (instancetype)initWithFrame:(CGRect)frame andRestClient:(MXRestClient*)restclient;
+- (instancetype)initWithFrame:(CGRect)frame andRestClient:(MXRestClient*)restclient __attribute__((deprecated("Use [initWithFrame:andMediaManager:] instead")));
 
 /**
  Refresh the container content by using the provided room members.

--- a/MatrixKit/Views/MXKReceiptSendersContainer.m
+++ b/MatrixKit/Views/MXKReceiptSendersContainer.m
@@ -44,19 +44,6 @@
     return self;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame andRestClient:(MXRestClient*)restclient
-{
-    self = [super initWithFrame:frame];
-    if (self)
-    {
-        _restClient = restclient;
-        _maxDisplayedAvatars = 3;
-        _avatarMargin = 2.0;
-        _moreLabel = nil;
-    }
-    return self;
-}
-
 - (void)refreshReceiptSenders:(NSArray<MXRoomMember*>*)roomMembers withPlaceHolders:(NSArray<UIImage*>*)placeHolders andAlignment:(ReadReceiptsAlignment)alignment
 {
     // Store the room members and placeholders for showing in the details view controller
@@ -171,8 +158,6 @@
         [_moreLabel removeFromSuperview];
         _moreLabel = nil;
     }
-    
-    _restClient = nil;
 }
 
 @end

--- a/MatrixKit/Views/MXKReceiptSendersContainer.m
+++ b/MatrixKit/Views/MXKReceiptSendersContainer.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -23,11 +24,25 @@
 
 @property (nonatomic, readwrite) NSArray <MXRoomMember *> *roomMembers;
 @property (nonatomic, readwrite) NSArray <UIImage *> *placeholders;
+@property (nonatomic) MXMediaManager *mediaManager;
 
 @end
 
 
 @implementation MXKReceiptSendersContainer
+
+- (instancetype)initWithFrame:(CGRect)frame andMediaManager:(MXMediaManager*)mediaManager
+{
+    self = [super initWithFrame:frame];
+    if (self)
+    {
+        _mediaManager = mediaManager;
+        _maxDisplayedAvatars = 3;
+        _avatarMargin = 2.0;
+        _moreLabel = nil;
+    }
+    return self;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame andRestClient:(MXRestClient*)restclient
 {
@@ -82,13 +97,6 @@
         MXRoomMember *roomMember = [roomMembers objectAtIndex:index];
         UIImage *preview = index < placeHolders.count ? placeHolders[index] : nil;
         
-        // Compute the member avatar URL
-        NSString *avatarUrl = roomMember.avatarUrl;
-        if (_restClient && avatarUrl)
-        {
-            avatarUrl = [_restClient urlOfContentThumbnail:avatarUrl toFitViewSize:CGSizeMake(side, side) withMethod:MXThumbnailingMethodCrop];
-        }
-        
         MXKImageView *imageView = [[MXKImageView alloc] initWithFrame:CGRectMake(xOff, 0, side, side)];
         imageView.defaultBackgroundColor = [UIColor clearColor];
         
@@ -104,7 +112,13 @@
         [self addSubview:imageView];
         imageView.enableInMemoryCache = YES;
         
-        [imageView setImageURL:avatarUrl withType:nil andImageOrientation:UIImageOrientationUp previewImage:preview];
+        [imageView setImageURI:roomMember.avatarUrl
+                      withType:nil
+           andImageOrientation:UIImageOrientationUp
+                 toFitViewSize:CGSizeMake(side, side)
+                    withMethod:MXThumbnailingMethodCrop
+                  previewImage:preview
+                  mediaManager:_mediaManager];
         
         [imageView.layer setCornerRadius:imageView.frame.size.width / 2];
         imageView.clipsToBounds = YES;

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,8 +30,6 @@
 
 #import "NSBundle+MatrixKit.h"
 #import "MXKConstants.h"
-
-NSString *const kPasteboardItemPrefix = @"pasteboard-";
 
 @interface MXKRoomInputToolbarView()
 {
@@ -1201,8 +1200,8 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                 else if ([MIMEType hasPrefix:@"video/"] && [self.delegate respondsToSelector:@selector(roomInputToolbarView:sendVideo:withThumbnail:)])
                 {
                     NSData *pasteboardVideoData = [dict objectForKey:key];
-                    NSString *fakePasteboardURL = [NSString stringWithFormat:@"%@%@", kPasteboardItemPrefix, [[NSProcessInfo processInfo] globallyUniqueString]];
-                    NSString *cacheFilePath = [MXMediaManager cachePathForMediaWithURL:fakePasteboardURL andType:MIMEType inFolder:nil];
+                    // Get a unique cache path to store this video
+                    NSString *cacheFilePath = [MXMediaManager temporaryCachePathInFolder:nil withType:MIMEType];
                     
                     if ([MXMediaManager writeMediaData:pasteboardVideoData toFilePath:cacheFilePath])
                     {
@@ -1260,8 +1259,8 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                 else if ([MIMEType hasPrefix:@"application/"] && [self.delegate respondsToSelector:@selector(roomInputToolbarView:sendFile:withMimeType:)])
                 {
                     NSData *pasteboardDocumentData = [dict objectForKey:key];
-                    NSString *fakePasteboardURL = [NSString stringWithFormat:@"%@%@", kPasteboardItemPrefix, [[NSProcessInfo processInfo] globallyUniqueString]];
-                    NSString *cacheFilePath = [MXMediaManager cachePathForMediaWithURL:fakePasteboardURL andType:MIMEType inFolder:nil];
+                    // Get a unique cache path to store this data
+                    NSString *cacheFilePath = [MXMediaManager temporaryCachePathInFolder:nil withType:MIMEType];
                     
                     if ([MXMediaManager writeMediaData:pasteboardDocumentData toFilePath:cacheFilePath])
                     {

--- a/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
+++ b/MatrixKit/Views/RoomMemberList/MXKRoomMemberTableViewCell.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -76,15 +77,16 @@
         shouldUpdateActivityInfo = NO;
         
         // User thumbnail
-        NSString *thumbnailURL = nil;
-        if (memberCellData.roomMember.avatarUrl)
-        {
-            // Suppose this url is a matrix content uri, we use SDK to get the well adapted thumbnail from server
-            thumbnailURL = [mxSession.matrixRestClient urlOfContentThumbnail:memberCellData.roomMember.avatarUrl toFitViewSize:self.pictureView.frame.size withMethod:MXThumbnailingMethodCrop];
-        }
         self.pictureView.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
         self.pictureView.enableInMemoryCache = YES;
-        [self.pictureView setImageURL:thumbnailURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:self.picturePlaceholder];
+        // Consider here the member avatar is stored unencrypted on Matrix media repo
+        [self.pictureView setImageURI:memberCellData.roomMember.avatarUrl
+                             withType:nil
+                  andImageOrientation:UIImageOrientationUp
+                        toFitViewSize:self.pictureView.frame.size
+                           withMethod:MXThumbnailingMethodCrop
+                         previewImage:self.picturePlaceholder
+                         mediaManager:mxSession.mediaManager];
         
         // Shade invited users
         if (memberCellData.roomMember.membership == MXMembershipInvite)

--- a/MatrixKit/Views/Search/MXKSearchTableViewCell.m
+++ b/MatrixKit/Views/Search/MXKSearchTableViewCell.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -43,29 +44,8 @@
             
             if (searchCellData.isAttachmentWithThumbnail)
             {
-                // Set attached media folders
-                self.attachmentImageView.mediaFolder = searchCellData.roomId;
-                
-                NSString *mimetype = nil;
-                if (searchCellData.attachment.thumbnailInfo)
-                {
-                    mimetype = searchCellData.attachment.thumbnailInfo[@"mimetype"];
-                }
-                else if (searchCellData.attachment.contentInfo)
-                {
-                    mimetype = searchCellData.attachment.contentInfo[@"mimetype"];
-                }
-                
-                NSString *url = searchCellData.attachment.thumbnailURL;
-                
-                UIImage *preview = searchCellData.attachment.previewImage;
-                
-                if (url.length || preview)
-                {
-                    self.attachmentImageView.enableInMemoryCache = YES;
-                    [self.attachmentImageView setImageURL:url withType:mimetype andImageOrientation:searchCellData.attachment.thumbnailOrientation previewImage:preview];
-                    self.attachmentImageView.defaultBackgroundColor = [UIColor whiteColor];
-                }
+                [self.attachmentImageView setAttachmentThumb:searchCellData.attachment];
+                self.attachmentImageView.defaultBackgroundColor = [UIColor whiteColor];
             }
         }
         


### PR DESCRIPTION
Improvements:
 * Replace the deprecated MXMediaManager and MXMediaLoader interfaces use (see matrix-org/matrix-ios-sdk/pull/593).
 
Deprecated API:
 * MXKAttachment: the properties "actualURL" and "thumbnailURL" are deprecated because only Matrix Content URI should be considered now.
 * MXKAttachment: the property "cacheThumbnailPath" is deprecated, use "thumbnailCachePath" instead.
 * MXKAttachment: [initWithEvent:andMatrixSession:] is deprecated, use [initWithEvent:andMediaManager:] instead.
 * MXKImageView: [setImageURL:withType:andImageOrientation:previewImage:] is deprecated, use [setImageURI:withType:andImageOrientation:previewImage:mediaManager] or [setImageURI:withType:andImageOrientation:toFitViewSize:withMethod:previewImage:mediaManager] instead.
 * MXKReceiptSendersContainer: the property "restClient" is deprecated.
 * MXKReceiptSendersContainer: [initWithFrame:andRestClient:] is deprecated, use [initWithFrame:andMediaManager:] instead.