### PR TITLE
MXKWebViewController:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changes in MatrixKit in 0.8.x (2018-xx-xx)
 
 Improvements:
  * MXKAccount: Add "antivirusServerURL" property. Set a non-null url to configure the antivirus scanner use.
+ * MXKWebViewController: Make it open links with `target="_blank"` within the webview.
+ * MXKWebViewController: Improve back navigation by resetting initial right buttons.
  * Replace the deprecated MXMediaManager and MXMediaLoader interfaces use (see matrix-ios-sdk/pull/593).
  
 Deprecated API:

--- a/MatrixKit/Controllers/MXKWebViewViewController.h
+++ b/MatrixKit/Controllers/MXKWebViewViewController.h
@@ -21,7 +21,7 @@
 /**
  'MXKWebViewViewController' instance is used to display a webview.
  */
-@interface MXKWebViewViewController : MXKViewController <WKNavigationDelegate, WKScriptMessageHandler>
+@interface MXKWebViewViewController : MXKViewController <WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>
 {
 @protected
     /**

--- a/MatrixKit/Controllers/MXKWebViewViewController.m
+++ b/MatrixKit/Controllers/MXKWebViewViewController.m
@@ -38,6 +38,9 @@ NSString *const kMXKWebViewViewControllerJavaScriptEnableLog =
 @interface MXKWebViewViewController ()
 {
     BOOL enableDebug;
+
+    //  Right buttons bar state before loading the webview
+    NSArray<UIBarButtonItem *> *originalRightBarButtonItems;
 }
 
 @end
@@ -99,11 +102,14 @@ NSString *const kMXKWebViewViewControllerJavaScriptEnableLog =
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+
+    originalRightBarButtonItems = self.navigationItem.rightBarButtonItems;
     
     // Init the webview
     webView = [[WKWebView alloc] initWithFrame:self.view.frame];
     webView.backgroundColor= [UIColor whiteColor];
     webView.navigationDelegate = self;
+    webView.UIDelegate = self;
 
     [webView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self.view addSubview:webView];
@@ -246,8 +252,22 @@ NSString *const kMXKWebViewViewControllerJavaScriptEnableLog =
     }
     else
     {
-        self.navigationItem.rightBarButtonItem = nil;
+        // Reset the original state
+        self.navigationItem.rightBarButtonItems = originalRightBarButtonItems;
     }
+}
+
+#pragma mark - WKUIDelegate
+
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(nonnull WKWebViewConfiguration *)configuration forNavigationAction:(nonnull WKNavigationAction *)navigationAction windowFeatures:(nonnull WKWindowFeatures *)windowFeatures
+{
+    // Make sure we open links with `target="_blank"` within this webview
+    if (!navigationAction.targetFrame.isMainFrame)
+    {
+        [webView loadRequest:navigationAction.request];
+    }
+
+    return nil;
 }
 
 #pragma mark - WKScriptMessageHandler


### PR DESCRIPTION
 - Make it open links with `target="_blank"` within the webview.
 - Improve back navigation by resetting initial right buttons.

Required to display html pages for https://github.com/vector-im/riot-ios/issues/1939.