### PR TITLE
MXKAuthenticationVC: Code cleaning

### DIFF
--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -211,9 +211,6 @@
 {
     [super viewWillAppear:animated];
     
-    // Force UI update and check the supported authentication flows for the current authentication type.
-    self.authType = _authType;
-    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onTextFieldChange:) name:UITextFieldTextDidChangeNotification object:nil];
 }
 

--- a/MatrixKit/Views/Authentication/MXKAuthInputsView.h
+++ b/MatrixKit/Views/Authentication/MXKAuthInputsView.h
@@ -75,8 +75,9 @@ typedef enum {
  
  @param authInputsView the authentication inputs view.
  @param viewControllerToPresent the view controller to present.
+ @param animated YES to animate the presentation.
  */
-- (void)authInputsView:(MXKAuthInputsView *)authInputsView presentViewController:(UIViewController*)viewControllerToPresent;
+- (void)authInputsView:(MXKAuthInputsView *)authInputsView presentViewController:(UIViewController*)viewControllerToPresent animated:(BOOL)animated;
 
 /**
  Tell the delegate to cancel the current operation.


### PR DESCRIPTION
We cannot see anymore a reason to reset everything with `self.authType = _authType;` in `viewWillAppear`.

That breaks navigation for https://github.com/vector-im/riot-ios/issues/1939. When user went back from a policy content screen, he ended up to the email screen instead of the expected list of policies.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
