### PR TITLE
Bug Fix: Unexpected empty local contacts list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Improvements:
  * MXKWebViewController: Improve back navigation by resetting initial right buttons.
  * Replace the deprecated MXMediaManager and MXMediaLoader interfaces use (see matrix-ios-sdk/pull/593).
  
+Bug fix:
+ * Unexpected empty local contacts list.
+ 
 Deprecated API:
  * MXKAttachment: the properties "actualURL" and "thumbnailURL" are deprecated because only Matrix Content URI should be considered now.
  * MXKAttachment: the property "cacheThumbnailPath" is deprecated, use "thumbnailCachePath" instead.

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -569,6 +569,9 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
         {
             self->isLocalContactListRefreshing = YES;
             
+            // Reset the internal contact lists (These arrays will be prepared only if need).
+            self->localContactsWithMethods = self->splitLocalContacts = nil;
+            
             BOOL isColdStart = NO;
             
             // Check whether the local contacts sync has been disabled.
@@ -580,8 +583,6 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                 
                 // Reload the local contacts from the system
                 self->localContactByContactID = nil;
-                self->localContactsWithMethods = nil;
-                self->splitLocalContacts = nil;
                 [self cacheLocalContacts];
             }
             
@@ -686,9 +687,6 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
                 // something has been modified in the local contact book
                 if (didContactBookChange)
                 {
-                    // Reset the internal contact lists (These arrays will be prepared only if need).
-                    self->localContactsWithMethods = self->splitLocalContacts = nil;
-                    
                     [self cacheLocalContacts];
                 }
                 


### PR DESCRIPTION
The list of the local contacts with methods is empty if they are retrieved before triggering [MXKContactManager refreshLocalContacts].

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
