### PR TITLE
BF: Chat screen: wrong thumbnail observed during scrollback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in MatrixKit in 0.9.3 (2019-01-)
+==========================================
+
+Bug fix:
+ * Chat screen: wrong thumbnail observed during scrollback (vector-im/riot-ios/issues/1122).
+
 Changes in MatrixKit in 0.9.2 (2019-01-04)
 ==========================================
 

--- a/MatrixKit/Models/Room/MXKAttachment.h
+++ b/MatrixKit/Models/Room/MXKAttachment.h
@@ -133,7 +133,7 @@ typedef enum : NSUInteger {
 /**
  For image attachments, gets a UIImage for the full-res image
  */
-- (void)getImage:(void (^)(UIImage *))onSuccess failure:(void (^)(NSError *error))onFailure;
+- (void)getImage:(void (^)(MXKAttachment *, UIImage *))onSuccess failure:(void (^)(MXKAttachment *, NSError *error))onFailure;
 
 /**
  Decrypt the attachment data into memory and provide it as an NSData
@@ -154,7 +154,7 @@ typedef enum : NSUInteger {
  Gets the thumbnails for this attachment, downloading it or loading it from disk cache
  if necessary
  */
-- (void)getThumbnail:(void (^)(UIImage *))onSuccess failure:(void (^)(NSError *error))onFailure;
+- (void)getThumbnail:(void (^)(MXKAttachment *, UIImage *))onSuccess failure:(void (^)(MXKAttachment *, NSError *error))onFailure;
 
 /**
  Download the attachment data if it is not already cached.

--- a/MatrixKit/Views/MXKImageView.m
+++ b/MatrixKit/Views/MXKImageView.m
@@ -55,6 +55,9 @@
     
     // Subviews
     UIScrollView *scrollView;
+
+    // Current attachment being displayed in the MXKImageView
+    MXKAttachment *currentAttachment;
 }
 @end
 
@@ -678,16 +681,30 @@ andImageOrientation:(UIImageOrientation)orientation
     {
         [self startActivityIndicator];
     }
+
+    currentAttachment = attachment;
     
     MXWeakify(self);
-    [attachment getImage:^(UIImage *img) {
+    [attachment getImage:^(MXKAttachment *attachment2, UIImage *img) {
         MXStrongifyAndReturnIfNil(self);
+
+        if (self->currentAttachment != attachment2)
+        {
+            return;
+        }
+
         self.image = img;
         [self stopActivityIndicator];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXMediaLoaderStateDidChangeNotification object:nil];
-    } failure:^(NSError *error) {
+    } failure:^(MXKAttachment *attachment2, NSError *error) {
         NSLog(@"Unable to fetch image attachment! %@", error);
         MXStrongifyAndReturnIfNil(self);
+        
+        if (self->currentAttachment != attachment2)
+        {
+            return;
+        }
+
         [self stopActivityIndicator];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXMediaLoaderStateDidChangeNotification object:nil];
     }];
@@ -722,10 +739,18 @@ andImageOrientation:(UIImageOrientation)orientation
     {
         [self startActivityIndicator];
     }
+
+    currentAttachment = attachment;
     
     MXWeakify(self);
-    [attachment getThumbnail:^(UIImage *img) {
+    [attachment getThumbnail:^(MXKAttachment *attachment2, UIImage *img) {
         MXStrongifyAndReturnIfNil(self);
+
+        if (self->currentAttachment != attachment2)
+        {
+            return;
+        }
+
         if (img && self->imageOrientation != UIImageOrientationUp)
         {
             self.image = [UIImage imageWithCGImage:img.CGImage scale:1.0 orientation:self->imageOrientation];
@@ -735,8 +760,14 @@ andImageOrientation:(UIImageOrientation)orientation
             self.image = img;
         }
         [self stopActivityIndicator];
-    } failure:^(NSError *error) {
+    } failure:^(MXKAttachment *attachment2, NSError *error) {
         MXStrongifyAndReturnIfNil(self);
+
+        if (self->currentAttachment != attachment2)
+        {
+            return;
+        }
+
         [self stopActivityIndicator];
     }];
 }

--- a/MatrixKit/Views/MXKImageView.m
+++ b/MatrixKit/Views/MXKImageView.m
@@ -550,6 +550,9 @@ andImageOrientation:(UIImageOrientation)orientation
 {
     // Remove any pending observers
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    // Reset other data
+    currentAttachment = nil;
     
     mxcURI = mxContentURI;
     if (!mxcURI)


### PR DESCRIPTION
fixes vector-im/riot-ios/issues/1122

Fix a race condition where the image download completes whereas the cell has been reused for another image.
