### PR TITLE
Handle device_id returned from the fallback login page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Changes in MatrixKit in 0.9.6 (2019-02-)
+==========================================
+
+Improvements:
+ * Upgrade MatrixSDK version ([v0.12.3](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.12.3)).
+
+Bug fix:
+ * Handle device_id returned from the fallback login page (vector-im/riot-ios/issues/2301).
+
 Changes in MatrixKit in 0.9.5 (2019-02-15)
 ==========================================
 

--- a/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
+++ b/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
@@ -130,10 +130,15 @@ sendObjectMessage({  \
             else if ([@"onLogin" isEqualToString:parameters[@"action"]])
             {
                 // Translate the JS login event to MXCredentials
-                MXCredentials *credentials = [MXCredentials modelFromJSON:parameters[@"response"]];
+                MXCredentials *credentials;
+                MXJSONModelSetMXJSONModel(credentials, MXCredentials, parameters[@"response"]);
 
-                // And inform the client
-                onSuccess(credentials);
+                // Sanity check
+                if (credentials.homeServer.length && credentials.userId.length && credentials.accessToken.length)
+                {
+                    // And inform the client
+                    onSuccess(credentials);
+                }
             }
         }
         return NO;

--- a/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
+++ b/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
@@ -126,17 +126,10 @@ sendObjectMessage({  \
             else if ([@"onLogin" isEqualToString:parameters[@"action"]])
             {
                 // Translate the JS login event to MXCredentials
-                NSString *homeServer = parameters[@"response"][@"home_server"];
-                NSString *userId = parameters[@"response"][@"user_id"];
-                NSString *accessToken = parameters[@"response"][@"access_token"];
-                
-                // Sanity check
-                if (homeServer.length && userId.length && accessToken.length)
-                {
-                    MXCredentials *credentials = [[MXCredentials alloc] initWithHomeServer:homeServer userId:userId accessToken:accessToken];
-                    // And inform the client
-                    onSuccess(credentials);
-                }                
+                MXCredentials *credentials = [MXCredentials modelFromJSON:parameters[@"response"]];
+
+                // And inform the client
+                onSuccess(credentials);
             }
         }
         return NO;

--- a/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
+++ b/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
@@ -119,7 +119,11 @@ sendObjectMessage({  \
             if ([@"onRegistered" isEqualToString:parameters[@"action"]])
             {
                 // Translate the JS registration event to MXCredentials
+                // We cannot use [MXCredentials modelFromJSON:] because of https://github.com/matrix-org/synapse/issues/4756
+                // Because of this, we cannot get the device_id allocated by the homeserver
+                // TODO: Fix it once the homeserver issue is fixed
                 MXCredentials *credentials = [[MXCredentials alloc] initWithHomeServer:parameters[@"homeServer"] userId:parameters[@"userId"] accessToken:parameters[@"accessToken"]];
+
                 // And inform the client
                 onSuccess(credentials);
             }

--- a/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
+++ b/MatrixKit/Views/Authentication/MXKAuthenticationFallbackWebView.m
@@ -120,8 +120,8 @@ sendObjectMessage({  \
             {
                 // Translate the JS registration event to MXCredentials
                 // We cannot use [MXCredentials modelFromJSON:] because of https://github.com/matrix-org/synapse/issues/4756
-                // Because of this, we cannot get the device_id allocated by the homeserver
-                // TODO: Fix it once the homeserver issue is fixed
+                // Because of this issue, we cannot get the device_id allocated by the homeserver
+                // TODO: Fix it once the homeserver issue is fixed (filed at https://github.com/vector-im/riot-meta/issues/273).
                 MXCredentials *credentials = [[MXCredentials alloc] initWithHomeServer:parameters[@"homeServer"] userId:parameters[@"userId"] accessToken:parameters[@"accessToken"]];
 
                 // And inform the client


### PR DESCRIPTION
Fixes vector-im/riot-ios#2301.
