### PR TITLE
BF Riot: Quickly tapping on a URL in a message highlights the message rather than opening the URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,12 @@ Changes in MatrixKit in 0.9.6 (2019-02-)
 Improvements:
  * Upgrade MatrixSDK version ([v0.12.3](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.12.3)).
  * Use new MXLoginResponse class.
+ * Add `MXKMessageTextView` an UITextView with link detection without text selection.
 
 Bug fix:
  * Handle device_id returned from the fallback login page (vector-im/riot-ios/issues/2301).
- * Room details: the attachments list is empty (or almost) for the encrypted rooms. 
+ * Room details: the attachments list is empty (or almost) for the encrypted rooms.
+ * Quickly tapping on a URL in a message highlights the message rather than opening the URL (vector-im/riot-ios/issues/728).
 
 Changes in MatrixKit in 0.9.5 (2019-02-15)
 ==========================================

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		B12C470C20BECAF8004FBF96 /* MXKErrorViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470920BECAF7004FBF96 /* MXKErrorViewModel.m */; };
 		B12C470D20BECAF8004FBF96 /* MXKErrorAlertPresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470A20BECAF7004FBF96 /* MXKErrorAlertPresentation.m */; };
 		B12C471020BED312004FBF96 /* MXKErrorPresentableBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B12C470F20BED312004FBF96 /* MXKErrorPresentableBuilder.m */; };
+		B13652F8221E9E7A00313B09 /* MXKMessageTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = B13652F7221E9E7A00313B09 /* MXKMessageTextView.m */; };
 		B164380C210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.m in Sources */ = {isa = PBXBuildFile; fileRef = B164380B210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.m */; };
 		B1668AC021072F93002B14F1 /* MXKSlashCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = B1668ABF21072F93002B14F1 /* MXKSlashCommands.m */; };
 		CE14CA661E80122600E329A3 /* MXKAttachmentAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = CE14CA631E80122600E329A3 /* MXKAttachmentAnimator.m */; };
@@ -349,6 +350,8 @@
 		B12C470B20BECAF7004FBF96 /* MXKErrorPresentable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKErrorPresentable.h; sourceTree = "<group>"; };
 		B12C470E20BED312004FBF96 /* MXKErrorPresentableBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKErrorPresentableBuilder.h; sourceTree = "<group>"; };
 		B12C470F20BED312004FBF96 /* MXKErrorPresentableBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKErrorPresentableBuilder.m; sourceTree = "<group>"; };
+		B13652F6221E9E7A00313B09 /* MXKMessageTextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKMessageTextView.h; sourceTree = "<group>"; };
+		B13652F7221E9E7A00313B09 /* MXKMessageTextView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKMessageTextView.m; sourceTree = "<group>"; };
 		B164380A210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKSendReplyEventStringLocalizations.h; sourceTree = "<group>"; };
 		B164380B210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKSendReplyEventStringLocalizations.m; sourceTree = "<group>"; };
 		B1668ABE21072F93002B14F1 /* MXKSlashCommands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSlashCommands.h; sourceTree = "<group>"; };
@@ -865,6 +868,8 @@
 				F0868E0A1B18FC01004CBE80 /* MXKRoomCreationView.h */,
 				F0868E0B1B18FC01004CBE80 /* MXKRoomCreationView.m */,
 				F0868E0C1B18FC01004CBE80 /* MXKRoomCreationView.xib */,
+				B13652F6221E9E7A00313B09 /* MXKMessageTextView.h */,
+				B13652F7221E9E7A00313B09 /* MXKMessageTextView.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1720,6 +1725,7 @@
 				F0FDF2671E53586A00D23C47 /* MXKCountryPickerViewController.m in Sources */,
 				B12C471020BED312004FBF96 /* MXKErrorPresentableBuilder.m in Sources */,
 				F00FA85C1C0867F900E25826 /* MXKRoomIncomingAttachmentBubbleCell.m in Sources */,
+				B13652F8221E9E7A00313B09 /* MXKMessageTextView.m in Sources */,
 				F04356311B2EF6FD0096FA02 /* MXKContactDetailsViewController.m in Sources */,
 				F00FA8751C08A51B00E25826 /* MXKRoomOutgoingAttachmentWithoutSenderInfoBubbleCell.m in Sources */,
 				329CF77B1AA9FDE000A4753F /* MXKRoomIOSBubbleTableViewCell.m in Sources */,

--- a/MatrixKit/Views/MXKMessageTextView.h
+++ b/MatrixKit/Views/MXKMessageTextView.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2019 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ MXKMessageTextView is a UITextView subclass with link detection without text selection.
+ */
+@interface MXKMessageTextView : UITextView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixKit/Views/MXKMessageTextView.m
+++ b/MatrixKit/Views/MXKMessageTextView.m
@@ -1,0 +1,61 @@
+/*
+ Copyright 2019 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKMessageTextView.h"
+
+@implementation MXKMessageTextView
+
+- (BOOL)canBecomeFirstResponder
+{
+    return NO;
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+    return NO;
+}
+
+// Indicate to receive a touch event only if a link is hitted.
+// Otherwise it means that the touch event will pass through and could be received by a view below.
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+    UITextPosition *textPosition = [self closestPositionToPoint:point];
+
+    if (!textPosition)
+    {
+        return NO;
+    }
+
+    UITextRange *textRange = [self.tokenizer rangeEnclosingPosition:textPosition
+                                                    withGranularity:UITextGranularityCharacter
+                                                        inDirection:UITextLayoutDirectionLeft];
+
+    if (!textRange)
+    {
+        return NO;
+    }
+
+    NSInteger startIndex = [self offsetFromPosition:self.beginningOfDocument toPosition:textRange.start];
+
+    if (startIndex < 0)
+    {
+        return NO;
+    }
+
+    return [self.attributedText attribute:NSLinkAttributeName atIndex:startIndex effectiveRange:NULL] != nil;
+}
+
+@end

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.h
@@ -107,7 +107,7 @@ extern NSString *const kMXKRoomBubbleCellLongPressOnAvatarView;
 
  This action is sent via the MXKCellRenderingDelegate `shouldDoAction` operation.
 
- The `userInfo` dictionary contains a `NSURL` object under the `kMXKRoomBubbleCellUrl` key, representing the url the user wants to open.
+ The `userInfo` dictionary contains a `NSURL` object under the `kMXKRoomBubbleCellUrl` key, representing the url the user wants to open. And a NSNumber wrapping `UITextItemInteraction` raw value, representing the type of interaction expected with the URL, under the `kMXKRoomBubbleCellUrlItemInteraction` key.
 
  The shouldDoAction implementation must return NO to prevent the system (safari) from opening the link.
  
@@ -123,6 +123,7 @@ extern NSString *const kMXKRoomBubbleCellUserIdKey;
 extern NSString *const kMXKRoomBubbleCellEventKey;
 extern NSString *const kMXKRoomBubbleCellReceiptsContainerKey;
 extern NSString *const kMXKRoomBubbleCellUrl;
+extern NSString *const kMXKRoomBubbleCellUrlItemInteraction;
 
 #pragma mark - MXKRoomBubbleTableViewCell
 

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomBubbleTableViewCell.m
@@ -48,6 +48,7 @@ NSString *const kMXKRoomBubbleCellUserIdKey = @"kMXKRoomBubbleCellUserIdKey";
 NSString *const kMXKRoomBubbleCellEventKey = @"kMXKRoomBubbleCellEventKey";
 NSString *const kMXKRoomBubbleCellReceiptsContainerKey = @"kMXKRoomBubbleCellReceiptsContainerKey";
 NSString *const kMXKRoomBubbleCellUrl = @"kMXKRoomBubbleCellUrl";
+NSString *const kMXKRoomBubbleCellUrlItemInteraction = @"kMXKRoomBubbleCellUrlItemInteraction";
 
 static BOOL _disableLongPressGestureOnEvent;
 
@@ -1024,6 +1025,21 @@ static BOOL _disableLongPressGestureOnEvent;
     _isAutoAnimatedGif = NO;
 }
 
+- (BOOL)shouldInteractWithURL:(NSURL *)URL urlItemInteraction:(UITextItemInteraction)urlItemInteraction
+API_AVAILABLE(ios(10.0)) {
+    return [self shouldInteractWithURL:URL urlItemInteractionValue:@(urlItemInteraction)];
+}
+
+- (BOOL)shouldInteractWithURL:(NSURL *)URL urlItemInteractionValue:(NSNumber*)urlItemInteractionValue
+{
+    NSDictionary *userInfo = @{
+                               kMXKRoomBubbleCellUrl:URL,
+                               kMXKRoomBubbleCellUrlItemInteraction:urlItemInteractionValue
+                               };
+    
+    return [delegate cell:self shouldDoAction:kMXKRoomBubbleCellShouldInteractWithURL userInfo:userInfo defaultValue:YES];
+}
+
 #pragma mark - Attachment progress handling
 
 - (void)updateProgressUI:(NSDictionary*)statisticsDict
@@ -1179,36 +1195,68 @@ static NSMutableDictionary *childClasses;
         }
         else
         {
-            MXEvent *tappedEvent = nil;
-            NSArray *bubbleComponents = bubbleData.bubbleComponents;
-            if (bubbleComponents.count == 1)
+            NSURL *tappedUrl;
+            
+            // Hyperlinks in UITextView does not respond instantly to touch.
+            // To overcome this, check manually if a link has been touched in UITextView when performing a quick tap.
+            // Otherwise UITextViewDelegate method `- (BOOL)textView:shouldInteractWithURL:inRange:interaction:` is still called for long press and force touch.
+            if ([sender.view isEqual:self.messageTextView])
             {
-                MXKRoomBubbleComponent *component = [bubbleComponents firstObject];
-                tappedEvent = component.event;
-            }
-            else if (bubbleComponents.count)
-            {
-                // Look for the tapped component
-                UIView* view = sender.view;
-                CGPoint tapPoint = [sender locationInView:view];
-                
-                for (MXKRoomBubbleComponent *component in bubbleComponents)
-                {
-                    // Ignore components without display.
-                    if (!component.attributedTextMessage)
-                    {
-                        continue;
-                    }
-                        
-                    if (tapPoint.y < component.position.y)
-                    {
-                        break;
-                    }
-                    tappedEvent = component.event;
-                }
+                UITextView *textView = self.messageTextView;
+                CGPoint tapLocation = [sender locationInView:textView];
+                UITextPosition *textPosition = [textView closestPositionToPoint:tapLocation];
+                NSDictionary *attributes = [textView textStylingAtPosition:textPosition inDirection:UITextStorageDirectionForward];
+                tappedUrl = attributes[NSLinkAttributeName];
             }
             
-            [delegate cell:self didRecognizeAction:kMXKRoomBubbleCellTapOnMessageTextView userInfo:(tappedEvent ? @{kMXKRoomBubbleCellEventKey:tappedEvent} : nil)];
+            // If a link has been touched warn delegate immediately.
+            if (tappedUrl)
+            {
+                // Send default URL interaction `UITextItemInteractionInvokeDefaultAction` for a quick tap as received by UITextViewDelegate method `- (BOOL)textView:shouldInteractWithURL:inRange:interaction:` for a tap.
+                if (@available(iOS 10.0, *))
+                {
+                    [self shouldInteractWithURL:tappedUrl urlItemInteraction:UITextItemInteractionInvokeDefaultAction];
+                }
+                else
+                {
+                    // Use UITextItemInteractionInvokeDefaultAction raw value for iOS 9
+                    [self shouldInteractWithURL:tappedUrl urlItemInteractionValue:@(0)];
+                }
+            }
+            else
+            {
+                MXEvent *tappedEvent = nil;
+                NSArray *bubbleComponents = bubbleData.bubbleComponents;
+                if (bubbleComponents.count == 1)
+                {
+                    MXKRoomBubbleComponent *component = [bubbleComponents firstObject];
+                    tappedEvent = component.event;
+                }
+                else if (bubbleComponents.count)
+                {
+                    
+                    // Look for the tapped component
+                    UIView* view = sender.view;
+                    CGPoint tapPoint = [sender locationInView:view];
+                    
+                    for (MXKRoomBubbleComponent *component in bubbleComponents)
+                    {
+                        // Ignore components without display.
+                        if (!component.attributedTextMessage)
+                        {
+                            continue;
+                        }
+                        
+                        if (tapPoint.y < component.position.y)
+                        {
+                            break;
+                        }
+                        tappedEvent = component.event;
+                    }
+                }
+                
+                [delegate cell:self didRecognizeAction:kMXKRoomBubbleCellTapOnMessageTextView userInfo:(tappedEvent ? @{kMXKRoomBubbleCellEventKey:tappedEvent} : nil)];
+            }
         }
     }
 }
@@ -1357,14 +1405,31 @@ static NSMutableDictionary *childClasses;
 
 #pragma mark - UITextView delegate
 
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange
+// Hyperlink quick tap in `messageTextView` are intercepted by `-(void)onMessageTap:` method. Otherwise longer tap, long press and force touch on a link are still catched here.
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction API_AVAILABLE(ios(10.0))
 {
     BOOL shouldInteractWithURL = YES;
+    
     if (delegate && URL)
     {
         // Ask the delegate if iOS can open the link
-        shouldInteractWithURL = [delegate cell:self shouldDoAction:kMXKRoomBubbleCellShouldInteractWithURL userInfo:@{kMXKRoomBubbleCellUrl:URL} defaultValue:YES];
+        shouldInteractWithURL = [self shouldInteractWithURL:URL urlItemInteraction:interaction];
     }
+    
+    return shouldInteractWithURL;
+}
+
+// Delegate method only called on iOS 9. iOS 10+ use method above.
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange
+{
+    BOOL shouldInteractWithURL = YES;
+    
+    if (delegate && URL)
+    {
+        // Ask the delegate if iOS can open the link
+        shouldInteractWithURL = [self shouldInteractWithURL:URL urlItemInteractionValue:@(0)];
+    }
+    
     return shouldInteractWithURL;
 }
 

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomIncomingTextMsgBubbleCell.xib
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomIncomingTextMsgBubbleCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WmY-Jw-mqv" id="ef1-Tq-U3Z">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="49"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="49.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="hgp-Z5-rAj" userLabel="Picture View" customClass="MXKImageView">
@@ -42,8 +43,8 @@
                         <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5n-MSU">
-                        <rect key="frame" x="51" y="10" width="97" height="39"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5n-MSU" customClass="MXKMessageTextView">
+                        <rect key="frame" x="51" y="10" width="97" height="39.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="97" id="9EQ-AP-La0"/>
@@ -54,7 +55,7 @@
                         <dataDetectorType key="dataDetectorTypes" link="YES"/>
                     </textView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kwd-hP-feC" userLabel="showHideDateTime">
-                        <rect key="frame" x="531" y="0.0" width="69" height="49"/>
+                        <rect key="frame" x="531" y="0.0" width="69" height="49.5"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="69" id="9vA-4g-EE5"/>
                         </constraints>
@@ -66,7 +67,7 @@
                         </connections>
                     </button>
                     <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IOg-Kt-8vW" userLabel="bubbleInfoContainer">
-                        <rect key="frame" x="531" y="10" width="61" height="39"/>
+                        <rect key="frame" x="531" y="10" width="61" height="39.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="61" id="tLr-6k-ArA"/>

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomIncomingTextMsgWithoutSenderInfoBubbleCell.xib
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomIncomingTextMsgWithoutSenderInfoBubbleCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="35"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WmY-Jw-mqv" id="ef1-Tq-U3Z">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="34"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="34.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5n-MSU">
-                        <rect key="frame" x="51" y="0.0" width="97" height="34"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5n-MSU" customClass="MXKMessageTextView">
+                        <rect key="frame" x="51" y="0.0" width="97" height="34.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="29" id="SHB-dF-A5J"/>
@@ -29,7 +30,7 @@
                         <dataDetectorType key="dataDetectorTypes" link="YES"/>
                     </textView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kwd-hP-feC" userLabel="showHideDateTime">
-                        <rect key="frame" x="531" y="0.0" width="69" height="34"/>
+                        <rect key="frame" x="531" y="0.0" width="69" height="34.5"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="69" id="9vA-4g-EE5"/>
                         </constraints>
@@ -41,7 +42,7 @@
                         </connections>
                     </button>
                     <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IOg-Kt-8vW" userLabel="bubbleInfoContainer">
-                        <rect key="frame" x="531" y="0.0" width="61" height="34"/>
+                        <rect key="frame" x="531" y="0.0" width="61" height="34.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="61" id="tLr-6k-ArA"/>

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingTextMsgBubbleCell.xib
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingTextMsgBubbleCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pad-g3-2YJ" id="fCg-ju-gnG">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="49"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="49.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="ezT-Dl-ESR" userLabel="Picture View" customClass="MXKImageView">
@@ -25,8 +26,8 @@
                             <constraint firstAttribute="height" constant="40" id="lFb-Jo-C7R"/>
                         </constraints>
                     </view>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="tgO-Rv-C7R">
-                        <rect key="frame" x="452" y="10" width="97" height="39"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="tgO-Rv-C7R" customClass="MXKMessageTextView">
+                        <rect key="frame" x="452" y="10" width="97" height="39.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="39" id="2xF-Uv-zZv"/>
@@ -37,7 +38,7 @@
                         <dataDetectorType key="dataDetectorTypes" link="YES"/>
                     </textView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LVJ-Av-zVs" userLabel="showHideDateTime">
-                        <rect key="frame" x="0.0" y="0.0" width="69" height="49"/>
+                        <rect key="frame" x="0.0" y="0.0" width="69" height="49.5"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="69" id="ghQ-Qb-BBg"/>
                         </constraints>
@@ -49,7 +50,7 @@
                         </connections>
                     </button>
                     <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a51-cR-7FE" userLabel="bubbleInfoContainer">
-                        <rect key="frame" x="8" y="10" width="61" height="39"/>
+                        <rect key="frame" x="8" y="10" width="61" height="39.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="61" id="fDy-iL-hrD"/>

--- a/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingTextMsgWithoutSenderInfoBubbleCell.xib
+++ b/MatrixKit/Views/RoomBubbleList/MXKRoomOutgoingTextMsgWithoutSenderInfoBubbleCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="35"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pad-g3-2YJ" id="fCg-ju-gnG">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="34"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="34.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="tgO-Rv-C7R">
-                        <rect key="frame" x="452" y="0.0" width="97" height="34"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="text message" translatesAutoresizingMaskIntoConstraints="NO" id="tgO-Rv-C7R" customClass="MXKMessageTextView">
+                        <rect key="frame" x="452" y="0.0" width="97" height="34.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="97" id="QpI-TQ-x5C"/>
@@ -29,7 +30,7 @@
                         <dataDetectorType key="dataDetectorTypes" link="YES"/>
                     </textView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LVJ-Av-zVs" userLabel="showHideDateTime">
-                        <rect key="frame" x="0.0" y="0.0" width="69" height="34"/>
+                        <rect key="frame" x="0.0" y="0.0" width="69" height="34.5"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="69" id="ghQ-Qb-BBg"/>
                         </constraints>
@@ -41,7 +42,7 @@
                         </connections>
                     </button>
                     <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a51-cR-7FE" userLabel="bubbleInfoContainer">
-                        <rect key="frame" x="8" y="0.0" width="61" height="34"/>
+                        <rect key="frame" x="8" y="0.0" width="61" height="34.5"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="61" id="fDy-iL-hrD"/>


### PR DESCRIPTION
Handle quick tap on a link in a `MXKRoomBubbleTableViewCell`. Fix https://github.com/vector-im/riot-ios/issues/728.
Add `MXKMessageTextView` an UITextView with link detection without text selection.