### PR TITLE
BF Riot: Room Upgrades: Room appears twice in the rooms list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
 
 Bug fix:
  * Fix some potential crashes with ivar using a weak self (PR #537).
+ * MXKSessionRecentsDataSource: Hide a room if needed on room summary change (vector-im/riot-ios/issues/2148).
 
 Changes in MatrixKit in 0.9.8 (2019-03-21)
 ==========================================

--- a/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
@@ -278,12 +278,19 @@ NSString *const kMXKRecentCellIdentifier = @"kMXKRecentCellIdentifier";
         
         if (index < internalCellDataArray.count)
         {
-            // Create a new instance to not modify the content of 'cellDataArray' (the copy is not a deep copy).
-            Class class = [self cellDataClassForCellIdentifier:kMXKRecentCellIdentifier];
-            id<MXKRecentCellDataStoring> cellData = [[class alloc] initWithRoomSummary:roomSummary andRecentListDataSource:self];
-            if (cellData)
+            if (roomSummary.hiddenFromUser)
             {
-                [internalCellDataArray replaceObjectAtIndex:index withObject:cellData];
+                [internalCellDataArray removeObjectAtIndex:index];
+            }
+            else
+            {
+                // Create a new instance to not modify the content of 'cellDataArray' (the copy is not a deep copy).
+                Class class = [self cellDataClassForCellIdentifier:kMXKRecentCellIdentifier];
+                id<MXKRecentCellDataStoring> cellData = [[class alloc] initWithRoomSummary:roomSummary andRecentListDataSource:self];
+                if (cellData)
+                {
+                    [internalCellDataArray replaceObjectAtIndex:index withObject:cellData];
+                }
             }
             
             // Report change except if sync is in progress


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/2148