### PR TITLE
Edits: support local echo

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1427,7 +1427,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 - (BOOL)canReplyToEventWithId:(NSString*)eventIdToReply
 {
     MXEvent *eventToReply = [self eventWithEventId:eventIdToReply];
-    return [self canPerformActionOnEvent:eventToReply] && [self.room canReplyToEvent:eventToReply];
+    return [self.room canReplyToEvent:eventToReply];
 }
 
 - (void)sendImage:(NSData *)imageData mimeType:(NSString *)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
@@ -3043,9 +3043,12 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 - (BOOL)canEditEventWithId:(NSString*)eventId
 {
     MXEvent *event = [self eventWithEventId:eventId];
+    BOOL isRoomMessage = event.eventType == MXEventTypeRoomMessage;
     NSString *messageType = event.content[@"msgtype"];
     
-    return [self canPerformActionOnEvent:event] && [messageType isEqualToString:kMXMessageTypeText] && [event.sender isEqualToString:self.mxSession.myUser.userId];
+    return isRoomMessage
+    && [messageType isEqualToString:kMXMessageTypeText]
+    && [event.sender isEqualToString:self.mxSession.myUser.userId];
 }
 
 - (void)registerEventEditsListener

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -3162,11 +3162,12 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     
     if (![sanitizedText isEqualToString:eventBody] && (!eventFormattedBody || ![formattedText isEqualToString:eventFormattedBody]))
     {
-        MXEvent *replaceEventLocalEcho;
-        [self.mxSession.aggregations replaceTextMessageEvent:event withTextMessage:sanitizedText formattedText:formattedText localEcho:&replaceEventLocalEcho success:success failure:failure];
+        [self.mxSession.aggregations replaceTextMessageEvent:event withTextMessage:sanitizedText formattedText:formattedText localEchoBlock:^(MXEvent * _Nonnull replaceEventLocalEcho) {
 
-        // Apply the local echo to the timeline
-        [self updateEventWithReplaceEvent:replaceEventLocalEcho];
+            // Apply the local echo to the timeline
+            [self updateEventWithReplaceEvent:replaceEventLocalEcho];
+            
+        } success:success failure:failure];
     }
     else
     {


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/676

Main use cases for vector-im/riot-ios#2489.
 - manage local echoes for edits on sent messages
 - support edits on local echoes

There is still an issue with:
- support edits on messages being sent
The edited message stays displayed in sending state. But this issue is due to a MatrixKit behavior and will be managed in a separate PR.

![Screen Recording 2019-06-14 at 15 56 46](https://user-images.githubusercontent.com/8418515/59514553-6078bf80-8ebd-11e9-9120-2ac46229fe84.gif)
