### PR TITLE
Edits: Fix edit of a message being sent

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -2004,6 +2004,9 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
             {
                 eventIdToBubbleMap[event.eventId] = bubbleData;
                 [eventIdToBubbleMap removeObjectForKey:previousId];
+
+                // The bubble data must use the final event id too
+                [bubbleData updateEvent:previousId withEvent:event];
             }
         }
         


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/2489:
- support edits on messages being sent

They stayed in sending (grey) state. The reason is that the id of the event has changed during the operation from a local event id to the final event id. We need to follow this change
