### PR TITLE
Reactions: Hide all reactions that aren't a single emoji

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		32BDC986211AD6D20064AF51 /* CHANGES.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32BDC982211AD6D10064AF51 /* CHANGES.rst */; };
 		32BDC987211AD6D20064AF51 /* README.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32BDC983211AD6D10064AF51 /* README.rst */; };
 		32BDC988211AD6D20064AF51 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 32BDC984211AD6D10064AF51 /* Podfile */; };
+		32C3ABBA22C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C3ABB922C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.m */; };
 		32CEE2231AB1E37600F7C74D /* MXKRecentListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2211AB1E37600F7C74D /* MXKRecentListViewController.m */; };
 		32CEE22B1AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2271AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m */; };
 		32CEE22C1AB1EC9B00F7C74D /* MXKRecentCellData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CEE2291AB1EC9B00F7C74D /* MXKRecentCellData.m */; };
@@ -308,6 +309,8 @@
 		32BDC982211AD6D10064AF51 /* CHANGES.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGES.rst; sourceTree = "<group>"; };
 		32BDC983211AD6D10064AF51 /* README.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.rst; sourceTree = "<group>"; };
 		32BDC984211AD6D10064AF51 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		32C3ABB822C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MXAggregatedReactions+MatrixKit.h"; sourceTree = "<group>"; };
+		32C3ABB922C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MXAggregatedReactions+MatrixKit.m"; sourceTree = "<group>"; };
 		32CEE2201AB1E37600F7C74D /* MXKRecentListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRecentListViewController.h; sourceTree = "<group>"; };
 		32CEE2211AB1E37600F7C74D /* MXKRecentListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRecentListViewController.m; sourceTree = "<group>"; };
 		32CEE2261AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSessionRecentsDataSource.h; sourceTree = "<group>"; };
@@ -1210,6 +1213,8 @@
 				F049FC1F1B2B878A00DD9D3C /* NSBundle+MatrixKit.m */,
 				323F9AF41F1E53730013AFDE /* NSBundle+MXKLanguage.h */,
 				323F9AF51F1E53730013AFDE /* NSBundle+MXKLanguage.m */,
+				32C3ABB822C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.h */,
+				32C3ABB922C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.m */,
 				F07E18121ABC563900DE3766 /* MXEvent+MatrixKit.h */,
 				F07E18131ABC563900DE3766 /* MXEvent+MatrixKit.m */,
 				32B046702101EB5E002A24A1 /* MXRoom+Sync.h */,
@@ -1809,6 +1814,7 @@
 				F07E180D1ABC2EDA00DE3766 /* MXKQueuedEvent.m in Sources */,
 				71352D691C1588BE001D50B0 /* MXKTableViewCellWithLabelAndMXKImageView.m in Sources */,
 				328AC4931AA8B05C0044A6FB /* MXKCellData.m in Sources */,
+				32C3ABBA22C4F23B00CA0449 /* MXAggregatedReactions+MatrixKit.m in Sources */,
 				F00BB44A1AB840B300AE388E /* MXKRoomInputToolbarViewWithHPGrowingText.m in Sources */,
 				32CEE22B1AB1EC9B00F7C74D /* MXKSessionRecentsDataSource.m in Sources */,
 				71EBE6631C04608100E7D953 /* MXKRoomActivitiesView.m in Sources */,

--- a/MatrixKit/Categories/MXAggregatedReactions+MatrixKit.h
+++ b/MatrixKit/Categories/MXAggregatedReactions+MatrixKit.h
@@ -1,0 +1,32 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <MatrixSDK/MatrixSDK.h>
+
+#import "MXKEventFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Define a `MXEvent` category at matrixKit level to store data related to UI handling.
+ */
+@interface MXAggregatedReactions (MatrixKit)
+
+- (nullable MXAggregatedReactions *)aggregatedReactionsWithSingleEmoji;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixKit/Categories/MXAggregatedReactions+MatrixKit.m
+++ b/MatrixKit/Categories/MXAggregatedReactions+MatrixKit.m
@@ -1,0 +1,44 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregatedReactions+MatrixKit.h"
+
+#import "MXKTools.h"
+
+@implementation MXAggregatedReactions (MatrixKit)
+
+- (nullable MXAggregatedReactions *)aggregatedReactionsWithSingleEmoji
+{
+    NSMutableArray *reactions = [NSMutableArray arrayWithCapacity:self.reactions.count];
+    for (MXReactionCount *reactionCount in self.reactions)
+    {
+        if ([MXKTools isSingleEmojiString:reactionCount.reaction])
+        {
+            [reactions addObject:reactionCount];
+        }
+    }
+
+    MXAggregatedReactions *aggregatedReactionsWithSingleEmoji;
+    if (reactions.count)
+    {
+        aggregatedReactionsWithSingleEmoji = [MXAggregatedReactions new];
+        aggregatedReactionsWithSingleEmoji.reactions = reactions;
+    }
+
+    return aggregatedReactionsWithSingleEmoji;
+}
+
+@end

--- a/MatrixKit/MatrixKit.h
+++ b/MatrixKit/MatrixKit.h
@@ -23,6 +23,7 @@
 
 #import "MXKAppSettings.h"
 
+#import "MXAggregatedReactions+MatrixKit.h"
 #import "MXEvent+MatrixKit.h"
 #import "MXRoom+Sync.h"
 #import "NSBundle+MatrixKit.h"

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -25,6 +25,7 @@
 #import "MXKRoomBubbleCellData.h"
 
 #import "MXKTools.h"
+#import "MXAggregatedReactions+MatrixKit.h"
 
 #import "MXKAppSettings.h"
 
@@ -3163,7 +3164,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
     MXKRoomBubbleCellData *roomBubbleCellData = (MXKRoomBubbleCellData*)cellData;
 
-    MXAggregatedReactions *aggregatedReactions = [self.mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:self.roomId].aggregatedReactionsWithNonZeroCount;
+    MXAggregatedReactions *aggregatedReactions = [self.mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:self.roomId].aggregatedReactionsWithNonZeroCount.aggregatedReactionsWithSingleEmoji;
     if (aggregatedReactions)
     {
         if (!roomBubbleCellData.reactions)


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2508.

Note this PR is based on the `[MXKTools isSingleEmojiString:]` method that has a [bug](https://github.com/vector-im/riot-ios/issues/2479) with latest emojis but it works for the 8 emojis we use by default 

