### PR TITLE
Reactions: Reinstate the ability to react with non-unicode keys

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -196,6 +196,11 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic) BOOL showReactions;
 
 /**
+ Show only reactions with single Emoji. NO by default.
+ */
+@property (nonatomic) BOOL showOnlySingleEmojiReactions;
+
+/**
  A Boolean value that determines whether the unsent button is customized (By default an 'Unsent' button is displayed by MatrixKit in front of unsent events). NO by default.
  */
 @property (nonatomic) BOOL useCustomUnsentButton;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -3164,7 +3164,13 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 
     MXKRoomBubbleCellData *roomBubbleCellData = (MXKRoomBubbleCellData*)cellData;
 
-    MXAggregatedReactions *aggregatedReactions = [self.mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:self.roomId].aggregatedReactionsWithNonZeroCount.aggregatedReactionsWithSingleEmoji;
+    MXAggregatedReactions *aggregatedReactions = [self.mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:self.roomId].aggregatedReactionsWithNonZeroCount;
+    
+    if (self.showOnlySingleEmojiReactions)
+    {
+        aggregatedReactions = aggregatedReactions.aggregatedReactionsWithSingleEmoji;
+    }
+    
     if (aggregatedReactions)
     {
         if (!roomBubbleCellData.reactions)


### PR DESCRIPTION
vector-im/riot-ios/issues/2553