### PR TITLE
 BF: Push notifications are spontaneously disabling themselves

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,9 +19,11 @@ Bug fix:
  * Read receipts: They are now counted by MatrixKit.
  * Read receipts: Attach read receipts on non displayed events to their nearest displayed events.
  * MXKRoomBubbleTableViewCell: Add possibility to reset attachement view bottom constraint constant to default value.
+ * Push notifications are spontaneously disabling themselves (vector-im/riot-ios/issues/2348).
  
  API break:
   * MXKRoomViewController: Add viaServers parameter to joinRoomWithRoomIdOrAlias.
+  * MXKAccount: make setEnablePushKitNotifications async.
 
 Changes in MatrixKit in 0.9.9 (2019-05-03)
 ==========================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Bug fix:
   * MXKRoomViewController: Add viaServers parameter to joinRoomWithRoomIdOrAlias.
   * MXKAccount: Make setEnablePushKitNotifications async.
   * MXKAccount: Rename enablePushKitNotifications to hasPusherForPushKitNotifications.
+  * MXKAccount: Remove deletePushKitPusher. Use setEnablePushKitNotifications:NO instead.
 
 Changes in MatrixKit in 0.9.9 (2019-05-03)
 ==========================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,9 +23,9 @@ Bug fix:
  
  API break:
   * MXKRoomViewController: Add viaServers parameter to joinRoomWithRoomIdOrAlias.
-  * MXKAccount: Make setEnablePushKitNotifications async.
+  * MXKAccount: Remove setEnablePushKitNotifications and replace it by the async enablePushKitNotifications method.
   * MXKAccount: Rename enablePushKitNotifications to hasPusherForPushKitNotifications.
-  * MXKAccount: Remove deletePushKitPusher. Use setEnablePushKitNotifications:NO instead.
+  * MXKAccount: Remove deletePushKitPusher. Use enablePushKitNotifications:NO instead.
 
 Changes in MatrixKit in 0.9.9 (2019-05-03)
 ==========================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,8 @@ Bug fix:
  
  API break:
   * MXKRoomViewController: Add viaServers parameter to joinRoomWithRoomIdOrAlias.
-  * MXKAccount: make setEnablePushKitNotifications async.
+  * MXKAccount: Make setEnablePushKitNotifications async.
+  * MXKAccount: Rename enablePushKitNotifications to hasPusherForPushKitNotifications.
 
 Changes in MatrixKit in 0.9.9 (2019-05-03)
 ==========================================

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -206,6 +206,7 @@
 "account_error_email_wrong_description" = "This doesn't appear to be a valid email address";
 "account_error_msisdn_wrong_title" = "Invalid Phone Number";
 "account_error_msisdn_wrong_description" = "This doesn't appear to be a valid phone number";
+"account_error_push_not_allowed" = "Notifications not allowed";
 
 // Room creation
 "room_creation_name_title" = "Room name:";

--- a/MatrixKit/Controllers/MXKAccountDetailsViewController.m
+++ b/MatrixKit/Controllers/MXKAccountDetailsViewController.m
@@ -889,7 +889,7 @@ NSString* const kMXKAccountDetailsLinkedEmailCellId = @"kMXKAccountDetailsLinked
     }
     else if (sender == apnsNotificationsSwitch)
     {
-        _mxAccount.enablePushNotifications = apnsNotificationsSwitch.on;
+        [_mxAccount enablePushNotifications:apnsNotificationsSwitch.on success:nil failure:nil];
         apnsNotificationsSwitch.enabled = NO;
     }
     else if (sender == inAppNotificationsSwitch)

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -154,15 +155,29 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 @property (nonatomic) BOOL enablePushNotifications;
 
 /**
- The Push notification activity (based on PushKit) for this account. YES when Push is turned on (locally available and synced with server).
+ The Push notification activity (based on PushKit) for this account.
+ YES when Push is turned on (locally available and enabled homeserver side).
  */
 @property (nonatomic, readonly) BOOL isPushKitNotificationActive;
 
 /**
- Enable Push notification based on Pushkit. Set YES to sync the device with the server.
- NO by default.
+ Enable Push notification based on PushKit.
+
+ This method creates or removes a pusher on the homeserver.
+
+ @param enablePushKitNotifications YES to enable it.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
  */
-@property (nonatomic) BOOL enablePushKitNotifications;
+- (void)setEnablePushKitNotifications:(BOOL)enablePushKitNotifications
+                              success:(void (^)(void))success
+                              failure:(void (^)(NSError *))failure;
+
+/**
+ Flag to indicate that a PushKit pusher has been set on the homeserver for this device.
+ */
+@property (nonatomic, readonly) BOOL enablePushKitNotifications;
+
 
 /**
  Enable In-App notifications based on Remote notifications rules.

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -277,12 +277,6 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 - (void)deletePusher;
 
 /**
- Delete the potential pusher used to receive push notifications via PushKit, without changing 'enablePushKitNotifications' property.
- Used to delete existing pusher related to out-of-date Push device token.
- */
-- (void)deletePushKitPusher;
-
-/**
  Pause the current matrix session.
  
  @warning: This matrix session is paused without using background task if no background mode handler

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -165,13 +165,13 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 
  This method creates or removes a pusher on the homeserver.
 
- @param enablePushKitNotifications YES to enable it.
+ @param enable YES to enable it.
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)setEnablePushKitNotifications:(BOOL)enablePushKitNotifications
-                              success:(void (^)(void))success
-                              failure:(void (^)(NSError *))failure;
+- (void)enablePushKitNotifications:(BOOL)enable
+                           success:(void (^)(void))success
+                           failure:(void (^)(NSError *))failure;
 
 /**
  Flag to indicate that a PushKit pusher has been set on the homeserver for this device.

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -176,7 +176,7 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 /**
  Flag to indicate that a PushKit pusher has been set on the homeserver for this device.
  */
-@property (nonatomic, readonly) BOOL enablePushKitNotifications;
+@property (nonatomic, readonly) BOOL hasPusherForPushKitNotifications;
 
 
 /**

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -149,10 +149,22 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 @property (nonatomic, readonly) BOOL pushNotificationServiceIsActive;
 
 /**
- Enable Apple Push Notification Service (APNS). Set YES to sync the device with the server.
- NO by default.
+ Enable Push notification based on Apple Push Notification Service (APNS).
+
+ This method creates or removes a pusher on the homeserver.
+
+ @param enable YES to enable it.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
  */
-@property (nonatomic) BOOL enablePushNotifications;
+- (void)enablePushNotifications:(BOOL)enable
+                        success:(void (^)(void))success
+                        failure:(void (^)(NSError *))failure;
+
+/**
+ Flag to indicate that an APNS pusher has been set on the homeserver for this device.
+ */
+@property (nonatomic, readonly) BOOL hasPusherForPushNotifications;
 
 /**
  The Push notification activity (based on PushKit) for this account.
@@ -269,12 +281,6 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
  */
 - (void)logoutSendingServerRequest:(BOOL)sendLogoutServerRequest
                         completion:(void (^)(void))completion;
-
-/**
- Delete the potential APNS pusher, without changing 'enablePushNotifications' property.
- Used to delete existing pusher related to out-of-date APNS device token.
- */
-- (void)deletePusher;
 
 /**
  Pause the current matrix session.

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -421,29 +421,29 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     return isPushKitNotificationActive;
 }
 
-- (void)setEnablePushKitNotifications:(BOOL)enablePushKitNotifications
+- (void)enablePushKitNotifications:(BOOL)enable
                               success:(void (^)(void))success
                               failure:(void (^)(NSError *))failure;
 {
-    NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: %@", @(enablePushKitNotifications));
+    NSLog(@"[MXKAccount][Push] enablePushKitNotifications: %@", @(enable));
 
-    if (enablePushKitNotifications)
+    if (enable)
     {
         if ([[MXKAccountManager sharedManager] isPushAvailable])
         {
-            NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Enable Push for %@ account", self.mxCredentials.userId);
+            NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Enable Push for %@ account", self.mxCredentials.userId);
 
             // Create/restore the pusher
             [self enablePushKitPusher:YES success:^{
 
-                NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Enable Push: Success");
+                NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Enable Push: Success");
                 if (success)
                 {
                     success();
                 }
             } failure:^(NSError *error) {
 
-                NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Enable Push: Error: %@", error);
+                NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Enable Push: Error: %@", error);
                 if (failure)
                 {
                     failure(error);
@@ -452,25 +452,25 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         }
         else
         {
-            NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Error: Cannot enable Push");
+            NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Error: Cannot enable Push");
             failure(nil);
         }
     }
     else if (_hasPusherForPushKitNotifications)
     {
-        NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Disable Push for %@ account", self.mxCredentials.userId);
+        NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Disable Push for %@ account", self.mxCredentials.userId);
 
         // Delete the pusher, report the new value only on success.
         [self enablePushKitPusher:NO success:^{
 
-            NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Disable Push: Success");
+            NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Disable Push: Success");
             if (success)
             {
                 success();
             }
         } failure:^(NSError *error) {
 
-            NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Disable Push: Error: %@", error);
+            NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Disable Push: Error: %@", error);
             if (failure)
             {
                 failure(error);
@@ -498,7 +498,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         if (_disabled)
         {
             [self deletePusher];
-            [self setEnablePushKitNotifications:NO success:nil failure:nil];
+            [self enablePushKitNotifications:NO success:nil failure:nil];
             
             // Close session (keep the storage).
             [self closeSession:NO];
@@ -858,7 +858,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)logout:(void (^)(void))completion 
 {
     [self deletePusher];
-    [self setEnablePushKitNotifications:NO success:nil failure:nil];
+    [self enablePushKitNotifications:NO success:nil failure:nil];
     
     MXHTTPOperation *operation = [mxSession logout:^{
         
@@ -887,7 +887,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)logoutLocally:(void (^)(void))completion
 {
     [self deletePusher];
-    [self setEnablePushKitNotifications:NO success:nil failure:nil];
+    [self enablePushKitNotifications:NO success:nil failure:nil];
     
     [mxSession enableCrypto:NO success:^{
         [self closeSession:YES];

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1134,6 +1134,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         NSLog(@"[MXKAccount][Push] enableAPNSPusher: Succeeded to update APNS pusher for %@ (%d)", self.mxCredentials.userId, enabled);
 
         self->_hasPusherForPushNotifications = enabled;
+        [[MXKAccountManager sharedManager] saveAccounts];
         
         if (success)
         {

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -498,7 +498,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         if (_disabled)
         {
             [self deletePusher];
-            [self deletePushKitPusher];
+            [self setEnablePushKitNotifications:NO success:nil failure:nil];
             
             // Close session (keep the storage).
             [self closeSession:NO];
@@ -858,7 +858,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)logout:(void (^)(void))completion 
 {
     [self deletePusher];
-    [self deletePushKitPusher];
+    [self setEnablePushKitNotifications:NO success:nil failure:nil];
     
     MXHTTPOperation *operation = [mxSession logout:^{
         
@@ -887,7 +887,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)logoutLocally:(void (^)(void))completion
 {
     [self deletePusher];
-    [self deletePushKitPusher];
+    [self setEnablePushKitNotifications:NO success:nil failure:nil];
     
     [mxSession enableCrypto:NO success:^{
         [self closeSession:YES];
@@ -926,14 +926,6 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     if (self.pushNotificationServiceIsActive)
     {
         [self enableAPNSPusher:NO success:nil failure:nil];
-    }
-}
-
-- (void)deletePushKitPusher
-{
-    if (self.isPushKitNotificationActive)
-    {
-        [self enablePushKitPusher:NO success:nil failure:nil];
     }
 }
 

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -2,6 +2,7 @@
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -1133,11 +1134,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         [self enablePushKitPusher:YES
                           success:nil
                           failure:^(NSError *error) {
-                              
-                              self->_enablePushKitNotifications = NO;
-                              
-                              // Archive updated field
-                              [[MXKAccountManager sharedManager] saveAccounts];
+                              NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Error: %@", error);
                           }];
     }
     else if (_enablePushKitNotifications && mxSession)

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -190,7 +190,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         }
         
         _enablePushNotifications = [coder decodeBoolForKey:@"_enablePushNotifications"];
-        _enablePushKitNotifications = [coder decodeBoolForKey:@"enablePushKitNotifications"];
+        _hasPusherForPushKitNotifications = [coder decodeBoolForKey:@"enablePushKitNotifications"];
         _enableInAppNotifications = [coder decodeBoolForKey:@"enableInAppNotifications"];
         
         _disabled = [coder decodeBoolForKey:@"disabled"];
@@ -248,7 +248,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     }
     
     [coder encodeBool:_enablePushNotifications forKey:@"_enablePushNotifications"];
-    [coder encodeBool:_enablePushKitNotifications forKey:@"enablePushKitNotifications"];
+    [coder encodeBool:_hasPusherForPushKitNotifications forKey:@"enablePushKitNotifications"];
     [coder encodeBool:_enableInAppNotifications forKey:@"enableInAppNotifications"];
     
     [coder encodeBool:_disabled forKey:@"disabled"];
@@ -415,7 +415,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 
 - (BOOL)isPushKitNotificationActive
 {
-    BOOL isPushKitNotificationActive = ([[MXKAccountManager sharedManager] isPushAvailable] && _enablePushKitNotifications && mxSession);
+    BOOL isPushKitNotificationActive = ([[MXKAccountManager sharedManager] isPushAvailable] && _hasPusherForPushKitNotifications && mxSession);
     NSLog(@"[MXKAccount][Push] isPushKitNotificationActive: %@", @(isPushKitNotificationActive));
 
     return isPushKitNotificationActive;
@@ -456,7 +456,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
             failure(nil);
         }
     }
-    else if (_enablePushKitNotifications)
+    else if (_hasPusherForPushKitNotifications)
     {
         NSLog(@"[MXKAccount][Push] setEnablePushKitNotifications: Disable Push for %@ account", self.mxCredentials.userId);
 
@@ -1165,7 +1165,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
                               NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Error: %@", error);
                           }];
     }
-    else if (_enablePushKitNotifications && mxSession)
+    else if (_hasPusherForPushKitNotifications && mxSession)
     {
         // Turn off pusher if user denied remote notification.
         NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Disable PushKit pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
@@ -1193,7 +1193,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         
         NSLog(@"[MXKAccount][Push] enablePushKitPusher: Succeeded to update PushKit pusher for %@. Enabled: %@. Token: %@", self.mxCredentials.userId, @(enabled), [MXKTools logForPushToken:token]);
 
-        self->_enablePushKitNotifications = enabled;
+        self->_hasPusherForPushKitNotifications = enabled;
         [[MXKAccountManager sharedManager] saveAccounts];
         
         if (success)

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -453,7 +453,14 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         else
         {
             NSLog(@"[MXKAccount][Push] enablePushKitNotifications: Error: Cannot enable Push");
-            failure(nil);
+
+            NSError *error = [NSError errorWithDomain:kMXKAccountErrorDomain
+                                                 code:0
+                                             userInfo:@{
+                                                        NSLocalizedDescriptionKey:
+                                                            [NSBundle mxk_localizedStringForKey:@"account_error_push_not_allowed"]
+                                                        }];
+            failure (error);
         }
     }
     else if (_hasPusherForPushKitNotifications)

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -458,7 +458,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
             // Delete the pushers related to the old token
             for (MXKAccount *account in activeAccounts)
             {
-                if (account.enablePushKitNotifications)
+                if (account.hasPusherForPushKitNotifications)
                 {
                     [accountsWithPushKitPusher addObject:account];
                 }

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -418,7 +418,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
             // turn off the Push flag for all accounts if any
             for (MXKAccount *account in mxAccounts)
             {
-                [account setEnablePushKitNotifications:NO success:nil failure:nil];
+                [account enablePushKitNotifications:NO success:nil failure:nil];
             }
         }
         
@@ -446,7 +446,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
             // turn on the Push flag for all accounts
             for (MXKAccount *account in activeAccounts)
             {
-                [account setEnablePushKitNotifications:YES success:nil failure:nil];
+                [account enablePushKitNotifications:YES success:nil failure:nil];
             }
         }
         else if (![oldToken isEqualToData:pushDeviceToken])
@@ -463,7 +463,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
                     [accountsWithPushKitPusher addObject:account];
                 }
 
-                [account setEnablePushKitNotifications:NO success:nil failure:nil];
+                [account enablePushKitNotifications:NO success:nil failure:nil];
             }
             
             // Update the token
@@ -483,7 +483,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
                 if ([accountsWithPushKitPusher containsObject:account])
                 {
                     NSLog(@"[MXKAccountManager][Push] setPushDeviceToken: Resync Push for %@ account", account.mxCredentials.userId);
-                    [account setEnablePushKitNotifications:YES success:nil failure:nil];
+                    [account enablePushKitNotifications:YES success:nil failure:nil];
                 }
                 else
                 {

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -463,7 +463,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
                     [accountsWithPushKitPusher addObject:account];
                 }
 
-                [account deletePushKitPusher];
+                [account setEnablePushKitNotifications:NO success:nil failure:nil];
             }
             
             // Update the token

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -307,7 +307,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
             // turn off the Apns flag for all accounts if any
             for (MXKAccount *account in mxAccounts)
             {
-                [account enablePushNotifications:YES success:nil failure:nil];
+                [account enablePushNotifications:NO success:nil failure:nil];
             }
         }
         
@@ -498,7 +498,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
                 }
                 else
                 {
-                    NSLog(@"[MXKAccountManager][Push] setPushDeviceToken: hasPusherForPushNotifications = NO for %@ account. Do not enable Push", account.mxCredentials.userId);
+                    NSLog(@"[MXKAccountManager][Push] setPushDeviceToken: hasPusherForPushKitNotifications = NO for %@ account. Do not enable Push", account.mxCredentials.userId);
                 }
             }
         }


### PR DESCRIPTION
Closes vector-im/riot-ios#2348.

PR can be reviewed commit by commit.

Key changes:
- `[MXKAccount enablePushKitNotifications:::]` is now async.
- There is a new `hasPusherForPushKitNotifications` property replacing the old `enablePushKitNotifications` property. Its meaning has changed a bit. It now indicates the last successful pusher operation (enabling or disabling).
- We do not reset it anymore in case of error, which was the root of the issue.