### PR TITLE
Support soft logout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+Changes in MatrixKit in 0.10.2 (2019-07-)
+==========================================
+
+Improvements:
+ * Upgrade MatrixSDK version ([v0.13.1](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.13.1)).
+ * Support soft logout (vector-im/riot-ios/issues/2540).
+
+ Bug fix:
+
+ API break:
+
 Changes in MatrixKit in 0.10.1 (2019-07-16)
 ==========================================
 

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.h
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -119,6 +120,11 @@
  Use this property to pursue a registration from the next_link sent in an email validation email.
  */
 @property (nonatomic) NSDictionary* externalRegistrationParameters;
+
+/**
+ Use a login process based on the soft logout credentials.
+ */
+@property (nonatomic) MXCredentials *softLogoutCredentials;
 
 /**
  Enable/disable overall the user interaction option.

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -1195,6 +1195,10 @@
     
     // Update authentication inputs view to return in initial step
     [self.authInputsView setAuthSession:self.authInputsView.authSession withAuthType:_authType];
+    if (self.softLogoutCredentials)
+    {
+        self.authInputsView.softLogoutCredentials = self.softLogoutCredentials;
+    }
 }
 
 - (void)showResourceLimitExceededError:(NSDictionary *)errorDict onAdminContactTapped:(void (^)(NSURL *adminContact))onAdminContactTapped

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -1,7 +1,8 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
- 
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -663,6 +664,11 @@
                 self.authType = MXKAuthenticationTypeLogin;
             }
         }
+
+        if (_softLogoutCredentials)
+        {
+            [authInputsView setSoftLogoutCredentials:_softLogoutCredentials];
+        }
     }
     else
     {
@@ -755,6 +761,35 @@
         // Restore default UI
         self.authType = _authType;
     }
+}
+
+- (void)setSoftLogoutCredentials:(MXCredentials *)softLogoutCredentials
+{
+    NSLog(@"[MXKAuthenticationVC] setSoftLogoutCredentials");
+
+    // Cancel the current operation if any.
+    [self cancel];
+
+    // Load the view controller’s view if it has not yet been loaded.
+    // This is required before updating view's textfields (homeserver url...)
+    [self loadViewIfNeeded];
+
+    // Force register mode
+    self.authType = MXKAuthenticationTypeLogin;
+
+    [self setHomeServerTextFieldText:softLogoutCredentials.homeServer];
+    [self setIdentityServerTextFieldText:softLogoutCredentials.identityServer];
+
+    // Cancel potential request in progress
+    [mxCurrentOperation cancel];
+    mxCurrentOperation = nil;
+
+    // Remove the current auth inputs view
+    self.authInputsView = nil;
+
+    // Set parameters and trigger a refresh (the parameters will be taken into account during [handleAuthenticationSession:])
+    _softLogoutCredentials = softLogoutCredentials;
+    [self refreshAuthenticationSession];
 }
 
 - (void)setOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertificateBlock
@@ -1239,9 +1274,20 @@
     mxCurrentOperation = nil;
     [_authenticationActivityIndicator stopAnimating];
     self.userInteractionEnabled = YES;
-    
+
+    if (self.softLogoutCredentials)
+    {
+        // Hydrate the account with the new access token
+        MXKAccount *account = [[MXKAccountManager sharedManager] accountForUserId:self.softLogoutCredentials.userId];
+        [[MXKAccountManager sharedManager] hydrateAccount:account withCredentials:credentials];
+
+        if (_delegate)
+        {
+            [_delegate authenticationViewController:self didLogWithUserId:credentials.userId];
+        }
+    }
     // Sanity check: check whether the user is not already logged in with this id
-    if ([[MXKAccountManager sharedManager] accountForUserId:credentials.userId])
+    else if ([[MXKAccountManager sharedManager] accountForUserId:credentials.userId])
     {
         //Alert user
         __weak typeof(self) weakSelf = self;

--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -282,6 +282,28 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 - (void)logoutSendingServerRequest:(BOOL)sendLogoutServerRequest
                         completion:(void (^)(void))completion;
 
+
+#pragma mark - Soft logout
+
+/**
+ Flag to indicate if the account has been logged out by the homeserver admin.
+ */
+@property (nonatomic, readonly) BOOL isSoftLogout;
+
+/**
+ Soft logout the account.
+
+ The matix session is stopped but the data is kept.
+ */
+- (void)softLogout;
+
+/**
+ Hydrate the account using the credentials provided.
+
+ @param credentials the new credentials.
+*/
+- (void)hydrateWithCredentials:(MXCredentials*)credentials;
+
 /**
  Pause the current matrix session.
  

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -901,6 +901,24 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 
 - (void)logout:(void (^)(void))completion 
 {
+    if (!mxSession)
+    {
+        NSLog(@"[MXKAccount] logout: Need to open the closed session to make a logout request");
+        id<MXStore> store = [[[MXKAccountManager sharedManager].storeClass alloc] init];
+        mxSession = [[MXSession alloc] initWithMatrixRestClient:mxRestClient];
+
+        MXWeakify(self);
+        [mxSession setStore:store success:^{
+            MXStrongifyAndReturnIfNil(self);
+
+            [self logout:completion];
+
+        } failure:^(NSError *error) {
+            completion();
+        }];
+        return;
+    }
+
     [self deletePusher];
     [self enablePushKitNotifications:NO success:nil failure:nil];
     

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -194,6 +194,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         _enableInAppNotifications = [coder decodeBoolForKey:@"enableInAppNotifications"];
         
         _disabled = [coder decodeBoolForKey:@"disabled"];
+        _isSoftLogout = [coder decodeBoolForKey:@"isSoftLogout"];
 
         _warnedAboutEncryption = [coder decodeBoolForKey:@"warnedAboutEncryption"];
         
@@ -252,6 +253,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     [coder encodeBool:_enableInAppNotifications forKey:@"enableInAppNotifications"];
     
     [coder encodeBool:_disabled forKey:@"disabled"];
+    [coder encodeBool:_isSoftLogout forKey:@"isSoftLogout"];
 
     [coder encodeBool:_warnedAboutEncryption forKey:@"warnedAboutEncryption"];
     
@@ -969,6 +971,7 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 - (void)softLogout
 {
     _isSoftLogout = YES;
+    [[MXKAccountManager sharedManager] saveAccounts];
 
     // Stop SDK making requests to the homeserver
     [mxSession close];

--- a/MatrixKit/Models/Account/MXKAccountManager.h
+++ b/MatrixKit/Models/Account/MXKAccountManager.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,6 +31,12 @@ extern NSString *const kMXKAccountManagerDidAddAccountNotification;
  The notification object is the removed account.
  */
 extern NSString *const kMXKAccountManagerDidRemoveAccountNotification;
+
+/**
+ Posted when an existing account is soft logged out.
+ The notification object is the account.
+ */
+extern NSString *const kMXKAccountManagerDidSoftlogoutAccountNotification;
 
 
 /**
@@ -146,6 +153,26 @@ extern NSString *const kMXKAccountManagerDidRemoveAccountNotification;
  @param completion the block to execute at the end of the operation.
  */
 - (void)logoutWithCompletion:(void (^)(void))completion;
+
+/**
+ Soft logout an account.
+
+ @param account a matrix account.
+ */
+- (void)softLogout:(MXKAccount*)account;
+
+/**
+ Hydrate an existing account by using the credentials provided.
+
+ This updates account credentials and restarts the account session
+
+ If the credentials belong to a different user from the account already stored,
+ the old account will be cleared automatically.
+
+ @param account a matrix account.
+ @param credentials the new credentials.
+ */
+- (void)hydrateAccount:(MXKAccount*)account withCredentials:(MXCredentials*)credentials;
 
 /**
  Retrieve the account for a user id.

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -26,6 +26,7 @@ static NSString *const kMXKAccountsKey = @"accounts";
 
 NSString *const kMXKAccountManagerDidAddAccountNotification = @"kMXKAccountManagerDidAddAccountNotification";
 NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountManagerDidRemoveAccountNotification";
+NSString *const kMXKAccountManagerDidSoftlogoutAccountNotification = @"kMXKAccountManagerDidSoftlogoutAccountNotification";
 
 @interface MXKAccountManager()
 {
@@ -75,7 +76,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
     for (MXKAccount *account in mxAccounts)
     {
         // Check whether the account is enabled. Open a new matrix session if none.
-        if (!account.isDisabled && !account.mxSession)
+        if (!account.isDisabled && !account.isSoftLogout && !account.mxSession)
         {
             NSLog(@"[MXKAccountManager] openSession for %@ account", account.mxCredentials.userId);
             
@@ -195,6 +196,39 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
     }
 }
 
+- (void)softLogout:(MXKAccount*)account
+{
+    [account softLogout];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKAccountManagerDidSoftlogoutAccountNotification
+                                                        object:account
+                                                      userInfo:nil];
+}
+
+- (void)hydrateAccount:(MXKAccount*)account withCredentials:(MXCredentials*)credentials
+{
+    NSLog(@"[MXKAccountManager] hydrateAccount: %@", account.mxCredentials.userId);
+
+    if ([account.mxCredentials.userId isEqualToString:credentials.userId])
+    {
+        // Restart the account
+        [account hydrateWithCredentials:credentials];
+
+        NSLog(@"[MXKAccountManager] hydrateAccount: Open session");
+
+        id<MXStore> store = [[_storeClass alloc] init];
+        [account openSessionWithStore:store];
+
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKAccountManagerDidAddAccountNotification
+                                                            object:account
+                                                          userInfo:nil];
+    }
+    else
+    {
+        // TODO
+        NSLog(@"[MXKAccountManager] hydrateAccount: Credentials given for another account: %@", credentials.userId);
+    }
+}
+
 - (MXKAccount *)accountForUserId:(NSString *)userId
 {
     for (MXKAccount *account in mxAccounts)
@@ -272,7 +306,7 @@ NSString *const kMXKAccountManagerDidRemoveAccountNotification = @"kMXKAccountMa
     NSMutableArray *activeAccounts = [NSMutableArray arrayWithCapacity:mxAccounts.count];
     for (MXKAccount *account in mxAccounts)
     {
-        if (!account.disabled)
+        if (!account.disabled && !account.isSoftLogout)
         {
             [activeAccounts addObject:account];
         }

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -224,8 +224,13 @@ NSString *const kMXKAccountManagerDidSoftlogoutAccountNotification = @"kMXKAccou
     }
     else
     {
-        // TODO
         NSLog(@"[MXKAccountManager] hydrateAccount: Credentials given for another account: %@", credentials.userId);
+
+        // Logout the old account and create a new one with the new credentials
+        [self removeAccount:account sendLogoutRequest:YES completion:nil];
+
+        MXKAccount *newAccount = [[MXKAccount alloc] initWithCredentials:credentials];
+        [self addAccount:newAccount andOpenSession:YES];
     }
 }
 

--- a/MatrixKit/Views/Authentication/MXKAuthInputsView.h
+++ b/MatrixKit/Views/Authentication/MXKAuthInputsView.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -205,6 +206,11 @@ typedef enum {
  @return YES if the provided set of parameters is supported.
  */
 - (BOOL)setExternalRegistrationParameters:(NSDictionary *)registrationParameters;
+
+/**
+ Update the current authentication session by providing soft logout credentials.
+ */
+@property (nonatomic) MXCredentials *softLogoutCredentials;
 
 /**
  Tell whether all required fields are set


### PR DESCRIPTION
vector-im/riot-ios/issues/2540

- [x] Rehydrate session reusing `device_id` and restart
- [x] Cache the softLogout state to display the login page directly on startup
- [x] If the hydrated user ID doesn't match the session's user ID, overwrite