### PR TITLE
BF: iOS13: Rooms do not load

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * MXKRoomBubbleCellData: Add method to get bubble component index from event id.
 
  Bug fix:
+ * iOS13: Rooms do not load (vector-im/riot-ios/issues/2619).
 
  API break:
 

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		3219CBBE1AA6FB470027D7E2 /* MXKRoomViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomViewController.h; sourceTree = "<group>"; };
 		3219CBBF1AA6FB470027D7E2 /* MXKRoomViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomViewController.m; sourceTree = "<group>"; };
 		3219CBC11AA6FB6B0027D7E2 /* MatrixKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixKit.h; sourceTree = "<group>"; };
+		3228E4C822F970D900120175 /* MXKTextContentSizeComputing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKTextContentSizeComputing.h; sourceTree = "<group>"; };
 		3230A3701ACA835400CC57F5 /* MXKSampleJSQMessageMediaData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSampleJSQMessageMediaData.h; sourceTree = "<group>"; };
 		3230A3711ACA835400CC57F5 /* MXKSampleJSQMessageMediaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSampleJSQMessageMediaData.m; sourceTree = "<group>"; };
 		3230A3731ACADC1800CC57F5 /* MXKRoomDataSourceManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomDataSourceManager.h; sourceTree = "<group>"; };
@@ -1247,6 +1248,7 @@
 				B164380B210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.m */,
 				B1668ABE21072F93002B14F1 /* MXKSlashCommands.h */,
 				B1668ABF21072F93002B14F1 /* MXKSlashCommands.m */,
+				3228E4C822F970D900120175 /* MXKTextContentSizeComputing.h */,
 			);
 			path = Room;
 			sourceTree = "<group>";

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -17,6 +17,7 @@
 
 #import "MXKCellData.h"
 #import "MXKRoomBubbleCellDataStoring.h"
+#import "MXKTextContentSizeComputing.h"
 
 #import "MXKRoomBubbleComponent.h"
 
@@ -93,6 +94,11 @@
  - Attached file: returns suitable content size of a text view to display the file name (no icon is used presently).
  */
 @property (nonatomic) CGSize contentSize;
+
+/**
+ Delegate to compute text size.
+*/
+@property (nonatomic, weak)  id<MXKTextContentSizeComputing> textContentSizeComputingDelegate;
 
 /**
  Set of flags indicating fixes that need to be applied at display time.

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -2,6 +2,7 @@
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -462,46 +463,18 @@
 
 - (CGSize)textContentSize:(NSAttributedString*)attributedText removeVerticalInset:(BOOL)removeVerticalInset
 {
-    static UITextView* measurementTextView = nil;
-    static UITextView* measurementTextViewWithoutInset = nil;
-    
-    if (attributedText.length)
+    if (!attributedText.length)
     {
-        if (!measurementTextView)
-        {
-            measurementTextView = [[UITextView alloc] init];
-            
-            measurementTextViewWithoutInset = [[UITextView alloc] init];
-            // Remove the container inset: this operation impacts only the vertical margin.
-            // Note: consider textContainer.lineFragmentPadding to remove horizontal margin
-            measurementTextViewWithoutInset.textContainerInset = UIEdgeInsetsZero;
-        }
-        
-        // Select the right text view for measurement
-        UITextView *selectedTextView = (removeVerticalInset ? measurementTextViewWithoutInset : measurementTextView);
-        
-        selectedTextView.frame = CGRectMake(0, 0, _maxTextViewWidth, MAXFLOAT);
-        selectedTextView.attributedText = attributedText;
-            
-        CGSize size = [selectedTextView sizeThatFits:selectedTextView.frame.size];
+        return CGSizeZero;
+    }
 
-        // Manage the case where a string attribute has a single paragraph with a left indent
-        // In this case, [UITextViex sizeThatFits] ignores the indent and return the width
-        // of the text only.
-        // So, add this indent afterwards
-        NSRange textRange = NSMakeRange(0, attributedText.length);
-        NSRange longestEffectiveRange;
-        NSParagraphStyle *paragraphStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex:0 longestEffectiveRange:&longestEffectiveRange inRange:textRange];
-
-        if (NSEqualRanges(textRange, longestEffectiveRange))
-        {
-            size.width = size.width + paragraphStyle.headIndent;
-        }
-
-        return size;
+    if (!self.textContentSizeComputingDelegate)
+    {
+        NSLog(@"[MXKRoomBubbleCellData] textContentSizeForAttributedString. Error: no self.textContentSizeComputingDelegate");
+        return CGSizeZero;
     }
     
-    return CGSizeZero;
+    return [self.textContentSizeComputingDelegate textContentSizeForAttributedString:attributedText withMaxWith:_maxTextViewWidth removeVerticalInset:removeVerticalInset];
 }
 
 #pragma mark - Properties

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -21,7 +21,7 @@
 #import "MXKDataSource.h"
 #import "MXKRoomBubbleCellDataStoring.h"
 #import "MXKEventFormatter.h"
-
+#import "MXKTextContentSizeComputing.h"
 
 /**
  Define the threshold which triggers a bubbles count flush.
@@ -232,6 +232,12 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  Note: The stickers are not retained by this filter.
  */
 @property (nonatomic) BOOL filterMessagesWithURL;
+
+/**
+ Delegate to compute text size.
+*/
+@property (nonatomic, weak)  id<MXKTextContentSizeComputing> textContentSizeComputingDelegate;
+
 
 #pragma mark - Life cycle
 

--- a/MatrixKit/Models/Room/MXKTextContentSizeComputing.h
+++ b/MatrixKit/Models/Room/MXKTextContentSizeComputing.h
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ `MXKTextContentSizeComputing` delegates the computation of size for rendered strings.
+ */
+@protocol MXKTextContentSizeComputing <NSObject>
+
+/**
+ Get the size of a UITextview for rendering a text.
+
+ @param attributedString the text to render.
+ @param maxWidth the max width.
+ @param removeVerticalInset YES to not take incount inset heigt.
+ */
+- (CGSize)textContentSizeForAttributedString:(NSAttributedString*)attributedString withMaxWith:(CGFloat)maxWidth removeVerticalInset:(BOOL)removeVerticalInset;
+
+@end


### PR DESCRIPTION
closes vector-im/riot-ios/issues/2619

From what I have experienced, [UIView setFrame:] hangs on iOS13 if the view is not part of a view controller and if the viewDidAppear of this view controller is not called.

This means we cannot use anymore a random UITextView within MXKRoomBubbleCellData to compute text height.
I have thus created delegation up to the VC and moved the computation code there. It computes the height when it can.
