### PR TITLE
MXKEmail: force in lowercase the email address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Improvements:
  * Upgrade MatrixSDK version ([v0.13.1](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.13.1)).
  * Support soft logout (vector-im/riot-ios/issues/2540).
  * MXKRoomBubbleCellData: Add method to get bubble component index from event id.
+ * MXKEmail: force in lowercase the email address.
 
  Bug fix:
  * APNS Push: fix logic when enabling APNS push. Avoid calling nil callback method.

--- a/MatrixKit/Models/Contact/MXKContact.m
+++ b/MatrixKit/Models/Contact/MXKContact.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -352,7 +353,7 @@ NSString *const kMXKContactDefaultContactPrefixId = @"Default_";
     // Check email
     for (MXKEmail* email in _emailAddresses)
     {
-        if ([[email.emailAddress lowercaseString] hasPrefix:prefix])
+        if ([email.emailAddress hasPrefix:prefix])
         {
             return YES;
         }

--- a/MatrixKit/Models/Contact/MXKEmail.h
+++ b/MatrixKit/Models/Contact/MXKEmail.h
@@ -19,7 +19,7 @@
 
 @interface MXKEmail : MXKContactField
 
-// email info
+// email info (the address is stored in lowercase)
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *emailAddress;
 

--- a/MatrixKit/Models/Contact/MXKEmail.m
+++ b/MatrixKit/Models/Contact/MXKEmail.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@
     
     if (self)
     {
-        _emailAddress = anEmailAddress;
+        _emailAddress = [anEmailAddress lowercaseString];
         _type = aType;
     }
     

--- a/MatrixKit/Models/Contact/MXKEmail.m
+++ b/MatrixKit/Models/Contact/MXKEmail.m
@@ -74,7 +74,7 @@
     if (self)
     {
         _type = [coder decodeObjectForKey:@"type"];
-        _emailAddress = [coder decodeObjectForKey:@"emailAddress"];
+        _emailAddress = [[coder decodeObjectForKey:@"emailAddress"] lowercaseString];
     }
     
     return self;


### PR DESCRIPTION
Ease the email addresses handling by storing them in lowercase (and ignoring the fact that the the local part is supposed to be case sensitive).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
