### PR TITLE
MXKDeviceView: Make clear that device names are publicly readable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Changes in MatrixKit in 0.11.0 (2019-08-)
+==========================================
+
+Improvements:
+ * Upgrade MatrixSDK version ([v0.14.0](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.14.0)).
+ * MXKDeviceView: Make clear that device names are publicly readable (vector-im/riot-ios/issues/2662).
+
 Changes in MatrixKit in 0.10.2 (2019-08-08)
 ==========================================
 

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -150,11 +150,12 @@
 
 // Devices
 "device_details_title" = "Device information\n";
-"device_details_name" = "Name\n";
-"device_details_identifier" = "Device ID\n";
+"device_details_name" = "Public Name\n";
+"device_details_identifier" = "ID\n";
 "device_details_last_seen" = "Last seen\n";
 "device_details_last_seen_format" = "%@ @ %@\n";
-"device_details_rename_prompt_message" = "Device name:";
+"device_details_rename_prompt_title" = "Device Name";
+"device_details_rename_prompt_message" = "A device's public name is visible to people you communicate with";
 "device_details_delete_prompt_title" = "Authentication";
 "device_details_delete_prompt_message" = "This operation requires additional authentication.\nTo continue, please enter your password.";
 
@@ -171,8 +172,8 @@
 "room_event_encryption_info_event_none" = "none";
 "room_event_encryption_info_device" = "\nSender device information\n";
 "room_event_encryption_info_device_unknown" = "unknown device\n";
-"room_event_encryption_info_device_name" = "Name\n";
-"room_event_encryption_info_device_id" = "Device ID\n";
+"room_event_encryption_info_device_name" = "Public Name\n";
+"room_event_encryption_info_device_id" = "ID\n";
 "room_event_encryption_info_device_verification" = "Verification\n";
 "room_event_encryption_info_device_fingerprint" = "Ed25519 fingerprint\n";
 "room_event_encryption_info_device_verified" = "Verified";

--- a/MatrixKit/Views/DeviceView/MXKDeviceView.m
+++ b/MatrixKit/Views/DeviceView/MXKDeviceView.m
@@ -259,8 +259,9 @@ static NSAttributedString *verticalWhitespace = nil;
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
     __weak typeof(self) weakSelf = self;
     
-    currentAlert = [UIAlertController alertControllerWithTitle:nil message:[NSBundle mxk_localizedStringForKey:@"device_details_rename_prompt_message"] preferredStyle:UIAlertControllerStyleAlert];
-    
+    currentAlert = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"device_details_rename_prompt_title"]
+                                                       message:[NSBundle mxk_localizedStringForKey:@"device_details_rename_prompt_message"] preferredStyle:UIAlertControllerStyleAlert];
+
     [currentAlert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         
         textField.secureTextEntry = NO;


### PR DESCRIPTION
Part of vector-im/riot-ios/issues/2662

<img width="320" alt="Screenshot 2019-08-26 at 17 20 30" src="https://user-images.githubusercontent.com/8418515/63706852-bc05e880-c830-11e9-9b2b-084dbb2fbc0b.png">

<img width="320" alt="Screenshot 2019-08-26 at 18 40 41" src="https://user-images.githubusercontent.com/8418515/63706993-1dc65280-c831-11e9-91f5-be1e325798a6.png">

<img width="320" alt="Screenshot 2019-08-26 at 17 20 30" src="https://user-images.githubusercontent.com/8418515/63706903-d8098a00-c830-11e9-8f60-a91e164afc7c.png">

