### PR TITLE
Privacy: Use wellknown to discover the IS of a custom HS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * MXKDeviceView: Make clear that device names are publicly readable (vector-im/riot-ios/issues/2662).
  * Privacy: Remove the bind true flag from 3PID adds in settings (vector-im/riot-ios/issues/2650).
  * Privacy: Remove the ability to set an IS at login/registration (vector-im/riot-ios/issues/2661).
+ * Privacy: Use wellknown to discover the IS of a custom HS (vector-im/riot-ios/issues/2686).
 
 Changes in MatrixKit in 0.10.2 (2019-08-08)
 ==========================================

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.h
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.h
@@ -234,9 +234,10 @@
 - (void)setIdentityServerTextFieldText:(NSString *)identityServerUrl;
 
 /**
- Check if the selected homeserver requires an identity server.
+ Fetch the identity server from the wellknown API of the selected homeserver.
+ and check if the HS requires an identity server.
  */
-- (void)checkIdentityServerRequirement;
+- (void)checkIdentityServer;
 
 /**
  Force dismiss keyboard


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2686
Requires: https://github.com/matrix-org/matrix-ios-sdk/pull/714

Get the IS from wellknown before checking we need to display it.

