### PR TITLE
BF: Set the identity server before creating the MXKAccount too

### DIFF
--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -1457,8 +1457,12 @@
     else
     {
         // Report the new account in account manager
+        if (!credentials.identityServer)
+        {
+            credentials.identityServer = _identityServerTextField.text;
+        }
         MXKAccount *account = [[MXKAccount alloc] initWithCredentials:credentials];
-        account.identityServerURL = _identityServerTextField.text;
+        account.identityServerURL = credentials.identityServer;
         
         [[MXKAccountManager sharedManager] addAccount:account andOpenSession:YES];
         


### PR DESCRIPTION
so that MXKAccountManager has one

Before this fix, MXKAccountManager uses the IS only after an app restart.
