### PR TITLE
MXKContactManager: Limit the number of full lookups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Improvements:
  * Privacy: Remove the ability to set an IS at login/registration (vector-im/riot-ios/issues/2661).
  * Privacy: Use wellknown to discover the IS of a custom HS (vector-im/riot-ios/issues/2686).
  * Tools: Add human readable MSISDN formatting method.
+ * MXKContactManager: Limit the number of full lookups. Do it once per new matrix session.
 
 Bug fix:
  * Display correctly the revoked third-party invite.

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -254,9 +254,6 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
             [self refreshMatrixContacts];
         });
     }
-    
-    // Lookup the matrix users in all the local contacts.
-    [self updateMatrixIDsForAllLocalContacts];
 }
 
 - (void)removeMatrixSession:(MXSession*)mxSession
@@ -782,6 +779,10 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
 
 - (void)updateMatrixIDsForAllLocalContacts
 {
+    // If localContactByContactID is not loaded, the manager will consider there is no local contacts
+    // and will reset its cache
+    NSAssert(localContactByContactID, @"[MXKContactManager] updateMatrixIDsForAllLocalContacts: refreshLocalContacts must be called before");
+
     // Check if the user allowed to sync local contacts.
     // + Check if at least an identity server is available, and if the loading step is not in progress.
     if (![MXKAppSettings standardAppSettings].syncLocalContacts || ![self isUsersDiscoveringEnabled] || isLocalContactListRefreshing)


### PR DESCRIPTION
Do it once per new matrix session.

The full lookup (done by updateMatrixIDsForAllLocalContacts) will be triggered by refreshMatrixContacts if needed.

Add an assert on updateMatrixIDsForAllLocalContacts to avoid to call it before data was loaded (by refreshMatrixContacts).