### PR TITLE
MXKContactManager: Fix assertion failure because of early call of upd…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in MatrixKit in 0.11.1 (2019-10-11)
+==========================================
+
+Bug fix:
+ * MXKContactManager: Fix assertion failure because of early call of updateMatrixIDsForAllLocalContacts.
+
 Changes in MatrixKit in 0.11.0 (2019-10-11)
 ==========================================
 

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -1460,7 +1460,16 @@ NSString *const kMXKContactManagerDidInternationalizeNotification = @"kMXKContac
     if (self.identityService)
     {
         // Do a full lookup
-        [self updateMatrixIDsForAllLocalContacts];
+        // But check first if the data is loaded
+        if (!self->localContactByContactID )
+        {
+            // Load data. That will trigger updateMatrixIDsForAllLocalContacts if needed
+            [self refreshLocalContacts];
+        }
+        else
+        {
+            [self updateMatrixIDsForAllLocalContacts];
+        }
     }
     else
     {


### PR DESCRIPTION
…ateMatrixIDsForAllLocalContacts.

There can be a race condition. `updateMatrixIDsForAllLocalContacts` can be called whereas `refreshLocalContacts` is not finished.
Calling refreshLocalContacts will trigger `updateMatrixIDsForAllLocalContacts` if it is still needed.
