### PR TITLE
Pasteboard: Fix a crash when passing a nil object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in MatrixKit in 0.11.2 (2019-XX-XX)
 
 Bug fix:
  * MXKRoomBubbleCellData: Fix a crash in `shouldHideSenderName` method.
+ * Pasteboard: Fix a crash when passing a nil object to `UIPasteboard`.
 
 Changes in MatrixKit in 0.11.1 (2019-10-11)
 ==========================================

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2830,8 +2830,16 @@
                                                                    // Cancel event highlighting
                                                                    [roomBubbleTableViewCell highlightTextMessageForEvent:nil];
                                                                    
-                                                                   [[UIPasteboard generalPasteboard] setString:selectedComponent.textMessage];
+                                                                   NSString *textMessage = selectedComponent.textMessage;
                                                                    
+                                                                   if (textMessage)
+                                                                   {
+                                                                       [[UIPasteboard generalPasteboard] setString:textMessage];
+                                                                   }
+                                                                   else
+                                                                   {
+                                                                       NSLog(@"[MXKRoomViewController] Copy text failed. Text is nil.");
+                                                                   }
                                                                }]];
                 
                 [currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"share"]
@@ -3133,7 +3141,14 @@
 
 - (void)copy:(id)sender
 {
-    [[UIPasteboard generalPasteboard] setString:selectedText];
+    if (selectedText)
+    {
+        [[UIPasteboard generalPasteboard] setString:selectedText];
+    }
+    else
+    {
+        NSLog(@"[MXKRoomViewController] Selected text copy failed. Selected text is nil");
+    }
 }
 
 - (void)share:(id)sender

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -2838,7 +2838,7 @@
                                                                    }
                                                                    else
                                                                    {
-                                                                       NSLog(@"[MXKRoomViewController] Copy text failed. Text is nil.");
+                                                                       NSLog(@"[MXKRoomViewController] Copy text failed. Text is nil for room id/event id: %@/%@", selectedComponent.event.roomId, selectedComponent.event.eventId);
                                                                    }
                                                                }]];
                 

--- a/MatrixKit/Models/Room/MXKAttachment.m
+++ b/MatrixKit/Models/Room/MXKAttachment.m
@@ -364,7 +364,22 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
     [self getAttachmentData:^(NSData *data) {
         
         UIImage *img = [UIImage imageWithData:data];
-        if (onSuccess) onSuccess(self, img);
+        
+        if (img)
+        {
+            if (onSuccess)
+            {
+                onSuccess(self, img);
+            }
+        }
+        else
+        {
+            if (onFailure)
+            {
+                NSError *error = [NSError errorWithDomain:kMXKAttachmentErrorDomain code:0 userInfo:@{@"err": @"error_get_image_from_data"}];
+                onFailure(self, error);
+            }
+        }
         
     } failure:^(NSError *error) {
         


### PR DESCRIPTION
Passing nil to `-[UIPasteboard setString:]` causes a crash whereas `string` property is nullable (See Radar issue https://openradar.appspot.com/36063433).