### PR TITLE
Groups: Load them only after the session got sync'ed with the homeserver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in MatrixKit in 0.11.2 (2019-XX-XX)
 
 Improvements:
  * MXKEventFormatter: In the case of "in reply to" event, replace the user Matrix ID by his display name when available (vector-im/riot-ios/issues/2154).
+ * Groups: Load them only after the session got sync'ed with the homeserver (vector-im/riot-ios/issues/2793).
 
 Bug fix:
  * MXKRoomBubbleCellData: Fix a crash in `shouldHideSenderName` method.

--- a/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
+++ b/MatrixKit/Models/Group/MXKSessionGroupsDataSource.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -89,7 +90,7 @@ NSString *const kMXKGroupCellIdentifier = @"kMXKGroupCellIdentifier";
 
 - (void)didMXSessionStateChange
 {
-    if (MXSessionStateStoreDataReady <= self.mxSession.state)
+    if (MXSessionStateRunning <= self.mxSession.state)
     {
         // Check whether some data have been already load
         if (0 == internalCellDataArray.count)


### PR DESCRIPTION
Part of vector-im/riot-ios/issues/2793