### PR TITLE
E2E: Hide duplicate message warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in MatrixKit in 0.11.4 (2019-xx-xx)
 
 Improvements:
  * MXKRoomBubbleTableViewCell: Handle content view tap and long press when there is no `messageTextView` or `attachmentView` properties.
+ * MXKEventFormatter: E2E, hide duplicate message warnings (vector-im/riot-ios#2910).
 
 
 Changes in MatrixKit in 0.11.3 (2019-12-05)

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -766,12 +766,22 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
                         // Make the unknown inbound session id error description more user friendly
                         errorDescription = [NSBundle mxk_localizedStringForKey:@"notice_crypto_error_unknown_inbound_session_id"];
                     }
+                    else if ([event.decryptionError.domain isEqualToString:MXDecryptingErrorDomain]
+                           && event.decryptionError.code == MXDecryptingErrorDuplicateMessageIndexCode)
+                    {
+                        // Hide duplicate message warnings
+                        NSLog(@"[MXKEventFormatter] Warning: Duplicate message with error description %@", event.decryptionError);
+                        displayText = nil;
+                    }
                     else
                     {
                         errorDescription = event.decryptionError.localizedDescription;
                     }
 
-                    displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_crypto_unable_to_decrypt"], errorDescription];
+                    if (errorDescription)
+                    {
+                        displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_crypto_unable_to_decrypt"], errorDescription];
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/2910