### PR TITLE
MXKEventFormatter: E2E, hide the algo used when turning on encryption

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes in MatrixKit in 0.11.4 (2019-xx-xx)
 Improvements:
  * MXKRoomBubbleTableViewCell: Handle content view tap and long press when there is no `messageTextView` or `attachmentView` properties.
  * MXKEventFormatter: E2E, hide duplicate message warnings (vector-im/riot-ios#2910).
-
+ * MXKEventFormatter: E2E, hide the algo used when turning on encryption (vector-im/riot-ios#2939).
 
 Changes in MatrixKit in 0.11.3 (2019-12-05)
 ==========================================

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -113,7 +113,8 @@
 "notice_room_aliases" = "The room aliases are: %@";
 "notice_room_related_groups" = "The groups associated with this room are: %@";
 "notice_encrypted_message" = "Encrypted message";
-"notice_encryption_enabled" = "%@ turned on end-to-end encryption (algorithm %@)";
+"notice_encryption_enabled_ok" = "%@ turned on end-to-end encryption.";
+"notice_encryption_enabled_unknown_algorithm" = "%1$@ turned on end-to-end encryption (unrecognised algorithm %2$@).";
 "notice_image_attachment" = "image attachment";
 "notice_audio_attachment" = "audio attachment";
 "notice_video_attachment" = "video attachment";

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -806,7 +806,14 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
                 algorithm = redactedInfo;
             }
             
-            displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_encryption_enabled"], senderDisplayName, algorithm];
+            if ([algorithm isEqualToString:kMXCryptoMegolmAlgorithm])
+            {
+                displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_encryption_enabled_ok"], senderDisplayName];
+            }
+            else
+            {
+                displayText = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"notice_encryption_enabled_unknown_algorithm"], senderDisplayName, algorithm];
+            }
             
             break;
         }


### PR DESCRIPTION
Closes vector-im/riot-ios#2939.

![image](https://user-images.githubusercontent.com/8418515/73427296-c1fb7a80-4336-11ea-8677-5a8c5b6b8190.png)
