### PR TITLE
Logic to use a secondary appId for debug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Improvements:
  * MXKEventFormatter: E2E, hide the algo used when turning on encryption (vector-im/riot-ios#2939).
  * MXKRoomBubbleComponent: Add a property to indicate if an encryption badge should be shown.
  * MXKRoomBubbleCellData: Add a property to indicate if a bubble component needs to show encryption badge.
- * Push notifications: Implement logic to use a secondary appId for debug builds.
+ * Push notifications: Implement logic to use also a secondary appId for VoIP pusher on debug builds, like for APNS pusher.
 
 API break:
  * MXKRoomBubbleComponent: Add session parameter to init and update method.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * MXKEventFormatter: E2E, hide the algo used when turning on encryption (vector-im/riot-ios#2939).
  * MXKRoomBubbleComponent: Add a property to indicate if an encryption badge should be shown.
  * MXKRoomBubbleCellData: Add a property to indicate if a bubble component needs to show encryption badge.
+ * Push notifications: Implement logic to use a secondary appId for debug builds.
 
 API break:
  * MXKRoomBubbleComponent: Add session parameter to init and update method.

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1266,7 +1266,14 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
 {
     NSLog(@"[MXKAccount][Push] enablePushKitPusher: %@", @(enabled));
 
-    NSString *appId = [[NSUserDefaults standardUserDefaults] objectForKey:@"pushKitAppIdProd"];
+    NSString *appIdKey;
+    #ifdef DEBUG
+        appIdKey = @"pushKitAppIdDev";
+    #else
+        appIdKey = @"pushKitAppIdProd";
+    #endif
+
+    NSString *appId = [[NSUserDefaults standardUserDefaults] objectForKey:appIdKey];
     
     NSMutableDictionary *pushData = [NSMutableDictionary dictionaryWithDictionary:@{@"url": self.pushGatewayURL}];
     


### PR DESCRIPTION
Implemented logic to use a secondary appId for debug configuration.