### PR TITLE
MXKRoomDataSource.m: code enhancement

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -451,6 +451,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     
     [self unregisterScanManagerNotifications];
     [self unregisterReactionsChangeListener];
+    [self unregisterEventEditsListener];
     
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionDidUpdatePublicisedGroupsForUsersNotification object:self.mxSession];
 
@@ -775,7 +776,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 
     // Register a listener to handle redaction which can affect live and past timelines
-    redactionListener = [_room listenToEventsOfTypes:@[kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *redactionEvent, MXTimelineDirection direction, MXRoomState *roomState) {
+    redactionListener = [_timeline listenToEventsOfTypes:@[kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *redactionEvent, MXTimelineDirection direction, MXRoomState *roomState) {
 
         // Consider only live redaction events
         if (direction == MXTimelineDirectionForwards)
@@ -974,14 +975,14 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 {
     super.delegate = delegate;
     
+    [self unregisterScanManagerNotifications];
+    [self unregisterReactionsChangeListener];
+    [self unregisterEventEditsListener];
+    
     // Register to MXScanManager notification only when a delegate is set
     if (delegate && self.mxSession.scanManager)
     {
         [self registerScanManagerNotifications];
-    }
-    else
-    {
-        [self unregisterScanManagerNotifications];
     }
 
     // Register to reaction notification only when a delegate is set
@@ -989,11 +990,6 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     {
         [self registerReactionsChangeListener];
         [self registerEventEditsListener];
-    }
-    else
-    {
-        [self unregisterReactionsChangeListener];
-        [self unregisterEventEditsListener];
     }
 }
 


### PR DESCRIPTION
- some observers/listeners were not correctly removed. The delegate is defined as a weak property, it is not reseted anymore at the dataSource level when it is released.
These changes prevent us from creating multiple observers/listeners at each new delegate.
We have to think of a better solution if we really want to remove some observers/listener when the dataSource is unused (no delegate defined)