### PR TITLE
MXKRoomDataSourceManager: enhancement

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSourceManager.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSourceManager.m
@@ -201,9 +201,7 @@ static Class _roomDataSourceClass;
     if (!roomDataSource && create && roomId)
     {
         [_roomDataSourceClass loadRoomDataSourceWithRoomId:roomId andMatrixSession:mxSession onComplete:^(id roomDataSource) {
-            [roomDataSource finalizeInitialization];
             [self addRoomDataSource:roomDataSource];
-
             onComplete(roomDataSource);
         }];
     }


### PR DESCRIPTION
Do not call `[finalizeInitialization]` on the new loaded RoomDataSource. This is already done by RoomDataSource class before returning the instance

