### PR TITLE
MXKSessionRecentsDataSource: Throttle room summary updates

### DIFF
--- a/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
+++ b/MatrixKit/Models/RoomList/MXKSessionRecentsDataSource.m
@@ -271,8 +271,7 @@ static NSTimeInterval const roomSummaryChangeThrottlerDelay = .5;
 }
 
 - (void)didRoomSummaryChanged:(NSNotification *)notif
-{
-    MXRoomSummary *roomSummary = notif.object;
+{    
     [roomSummaryChangeThrottler throttle:^{
         [self didRoomSummaryChanged2:notif];
     }];
@@ -387,8 +386,6 @@ static NSTimeInterval const roomSummaryChangeThrottlerDelay = .5;
 // Order cells
 - (void)sortCellDataAndNotifyChanges
 {
-    NSLog(@"###### [MXKSessionRecentsDataSource] sortCellDataAndNotifyChanges");
-    
     // Order them by origin_server_ts
     [internalCellDataArray sortUsingComparator:^NSComparisonResult(id<MXKRecentCellDataStoring> cellData1, id<MXKRecentCellDataStoring> cellData2)
     {


### PR DESCRIPTION
to make the app breath again.

On my  account,  just after signing in,`[RecentsDataSource refreshRoomsSections]` is now called 30 times instead of more than 2000 before.


Requires https://github.com/matrix-org/matrix-ios-sdk/pull/823.
Part of the work for vector-im/riot-ios#3105.