### PR TITLE
Podspec: Update DTCoreText dependency to 1.6.23 minimum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in MatrixKit in 0.12.7 (2020-05-xx)
+=========================================
+
+Improvements:
+* DTCoreText: Update DTCoreText dependency to 1.6.23 minimum to be sure to not reference UIWebView.
+
 Changes in MatrixKit in 0.12.6 (2020-05-18)
 =========================================
 

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.dependency 'MatrixSDK', '0.16.5'
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.9.13'
-  s.dependency 'DTCoreText', '~> 1.6.21'
+  s.dependency 'DTCoreText', '~> 1.6.23'
   s.dependency 'cmark', '~> 0.24.1'
 
   s.default_subspec = 'Core'


### PR DESCRIPTION
Update DTCoreText library to 1.6.23 minimum to be sure to not reference UIWebView.