### PR TITLE
Release 0.12.10

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
-Changes to be released in next version
+Changes in 0.12.10 (2020-07-31)
 =================================================
 
 Features:
  * 
 
 Improvements:
+ * Upgrade MatrixSDK version ([v0.16.9](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.16.9)).
  * 
 
 Bugfix:

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixKit"
-  s.version      = "0.12.9"
+  s.version      = "0.12.10"
   s.summary      = "The Matrix reusable UI library for iOS based on MatrixSDK."
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.dependency 'MatrixSDK', "0.16.8"
+  s.dependency 'MatrixSDK', "0.16.9"
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.9.13'
   s.dependency 'DTCoreText', '~> 1.6.23'

--- a/MatrixKit/MatrixKitVersion.m
+++ b/MatrixKit/MatrixKitVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixKitVersion = @"0.12.9";
+NSString *const MatrixKitVersion = @"0.12.10";


### PR DESCRIPTION
This PR prepares the release of MatrixKit v0.12.10.

Notes:
- This PR targets `release/0.12.10/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI run its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
  then run `bundle exec rake release:finish` to close the release. This is only then that `pod update` will be run -- updating the `Podfile.lock`
  to use the now officially released dependencies -- before ultimately merging `release/0.12.10/master` into `master` to tag the release.

Tip: if you want to review _only_ the changes made since the release branch was cut from `develop`,
     you can [check those here](git@github.com:matrix-org/matrix-ios-kit.git/compare/develop...release/0.12.10/release)

---

:warning: As of now, there are still some steps to do manually before going forward with the release process:

- [ ] After cloning the PR locally, update the `MatrixKit.podspec` to point it to the pending release branches of any of the dependencies,
      then run `pod lib lint` manually to validate the podspec [^1]

Once the PR has been reviewed and merged, run the `rake release:finish` command from the element-ios-tools to finish the process.
:warning: Be sure to merge the PRs in the right order before continuing the release process (`MatrixSDK`, then `MatrixKit`, then `Element`)      

[^1]: In the future, that will be performed by our CI
