### PR TITLE
PushKit: Delete any pending PushKit pusher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  * 
 
 Bugfix:
- * 
+ * PushKit: Delete any pending PushKit pusher (vector-im/riot-ios/issues/3577).
 
 API Change:
  * 

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -173,10 +173,6 @@
     [_cancelAuthFallbackButton setTitle:[NSBundle mxk_localizedStringForKey:@"cancel"] forState:UIControlStateHighlighted];
 }
 
-- (void)dealloc
-{
-}
-
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -534,6 +534,11 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
             }
         }];
     }
+    else
+    {
+        NSLog(@"[MXKAccount][Push] enablePushKitNotifications: PushKit is already disabled for %@", self.mxCredentials.userId);
+        success();
+    }
 }
 
 - (void)setEnableInAppNotifications:(BOOL)enableInAppNotifications

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1164,11 +1164,23 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
                            NSLog(@"[MXKAccount][Push] ;: Error: %@", error);
                        }];
     }
-    else if (_hasPusherForPushNotifications && mxSession)
+    else if (_hasPusherForPushNotifications)
     {
-        // Turn off pusher if user denied remote notification.
-        NSLog(@"[MXKAccount][Push] refreshAPNSPusher: Disable APNS pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
-        [self enableAPNSPusher:NO success:nil failure:nil];
+        if ([MXKAccountManager sharedManager].apnsDeviceToken)
+        {
+            if (mxSession)
+            {
+                // Turn off pusher if user denied remote notification.
+                NSLog(@"[MXKAccount][Push] refreshAPNSPusher: Disable APNS pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
+                [self enableAPNSPusher:NO success:nil failure:nil];
+            }
+        }
+        else
+        {
+            NSLog(@"[MXKAccount][Push] refreshAPNSPusher: APNS pusher for %@ account is already disabled. Reset _hasPusherForPushNotifications", self.mxCredentials.userId);
+            _hasPusherForPushNotifications = NO;
+            [[MXKAccountManager sharedManager] saveAccounts];
+        }
     }
 }
 
@@ -1258,11 +1270,23 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
                               NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Error: %@", error);
                           }];
     }
-    else if (_hasPusherForPushKitNotifications && mxSession)
+    else if (_hasPusherForPushKitNotifications)
     {
-        // Turn off pusher if user denied remote notification.
-        NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Disable PushKit pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
-        [self enablePushKitPusher:NO success:nil failure:nil];
+        if ([MXKAccountManager sharedManager].pushDeviceToken)
+        {
+            if (mxSession)
+            {
+                // Turn off pusher if user denied remote notification.
+                NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Disable PushKit pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
+                [self enablePushKitPusher:NO success:nil failure:nil];
+            }
+        }
+        else
+        {
+            NSLog(@"[MXKAccount][Push] refreshPushKitPusher: PushKit pusher for %@ account is already disabled. Reset _hasPusherForPushKitNotifications", self.mxCredentials.userId);
+            _hasPusherForPushKitNotifications = NO;
+            [[MXKAccountManager sharedManager] saveAccounts];
+        }
     }
 }
 

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1255,13 +1255,9 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     }
     else if (_hasPusherForPushKitNotifications && mxSession)
     {
-        NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Do nothing. User denied notifications (account: %@)", self.mxCredentials.userId);
-        
-        // XXX: The following code has been commented to avoid automatic deactivation of push notifications
-        
         // Turn off pusher if user denied remote notification.
-        //NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Disable PushKit pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
-        //[self enablePushKitPusher:NO success:nil failure:nil];
+        NSLog(@"[MXKAccount][Push] refreshPushKitPusher: Disable PushKit pusher for %@ account (notifications are denied)", self.mxCredentials.userId);
+        [self enablePushKitPusher:NO success:nil failure:nil];
     }
 }
 

--- a/MatrixKit/Models/Account/MXKAccountManager.m
+++ b/MatrixKit/Models/Account/MXKAccountManager.m
@@ -402,6 +402,10 @@ NSString *const kMXKAccountManagerDidSoftlogoutAccountNotification = @"kMXKAccou
                 }
             }
         }
+        else
+        {
+            NSLog(@"[MXKAccountManager][Push] setApnsDeviceToken: Same token. Nothing to do.");
+        }
     }
 }
 
@@ -541,6 +545,10 @@ NSString *const kMXKAccountManagerDidSoftlogoutAccountNotification = @"kMXKAccou
                     NSLog(@"[MXKAccountManager][Push] setPushDeviceToken: hasPusherForPushKitNotifications = NO for %@ account. Do not enable Push", account.mxCredentials.userId);
                 }
             }
+        }
+        else
+        {
+            NSLog(@"[MXKAccountManager][Push] setPushDeviceToken: Same token. Nothing to do.");
         }
     }
 }

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -169,10 +169,6 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
     return self;
 }
 
-- (void)dealloc
-{
-}
-
 - (void)reset
 {
     if (self == [MXKAppSettings standardAppSettings])

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -63,10 +63,6 @@
     return self;
 }
 
-- (void)dealloc
-{
-}
-
 - (void)updateWithEvent:(MXEvent*)event roomState:(MXRoomState*)roomState session:(MXSession*)session
 {
     // Report the new event

--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -58,10 +58,6 @@
     self.hiddenTopic = YES;
 }
 
-- (void)dealloc
-{
-}
-
 - (void)refreshDisplay
 {
     [super refreshDisplay];


### PR DESCRIPTION
vector-im/riot-ios/issues/3577.

This reverts #646. Game rules have changed. We cannot use/abuse PushKit as before iOS13 SDK. We have to use APNS. So, we can safely clean PushKit pusher.

This mitigates the race condition where https://github.com/vector-im/element-ios/pull/3578 removes the pusher while `MXAccount` can refresh it in parallel on a `MXSession` state change. At the end of the refresh, the pusher is restored :/

This works because https://github.com/vector-im/element-ios/pull/3578 does not clear the `MXKAccount.hasPusherForPushKitNotifications`, which is still true after https://github.com/vector-im/element-ios/pull/3578

