### PR TITLE
Release 0.12.22

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * 
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
 Changes in 0.12.21 (2020-09-30)
 =================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.12.22 (2020-10-02)
 =================================================
 
 ✨ Features
@@ -21,6 +21,9 @@ Changes to be released in next version
 
 Others
  * 
+
+Improvements:
+
 
 Changes in 0.12.21 (2020-09-30)
 =================================================

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixKit"
-  s.version      = "0.12.21"
+  s.version      = "0.12.22"
   s.summary      = "The Matrix reusable UI library for iOS based on MatrixSDK."
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.dependency 'MatrixSDK', "0.16.16"
+  s.dependency 'MatrixSDK', "= 0.16.16"
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.9.13'
   s.dependency 'DTCoreText', '~> 1.6.23'

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/ru.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/ru.lproj/MatrixKit.strings
@@ -67,7 +67,7 @@
 "notice_room_topic_removed" = "%@ удалил(а) тему";
 "notice_event_redacted_reason" = " [причина: %@]";
 "notice_profile_change_redacted" = "%@ обновил(а) свой профиль %@";
-"notice_room_created" = "%@ создал(а) комнату";
+"notice_room_created" = "%@ создал(а) и настроил(а) комнату.";
 "notice_room_power_level_intro" = "Уровень доступа членов комнаты:";
 "notice_room_power_level_acting_requirement" = "Минимальные уровни доступа пользователя для совершения действия:";
 "notice_room_power_level_event_requirement" = "Минимальные уровни доступа, связанные с событиями:";
@@ -143,8 +143,8 @@
 "notice_display_name_set" = "%@ сделал(а) своим отображаемым именем %@";
 "notice_display_name_changed_from" = "%@ изменил(а) свое отображаемое имя с %@ на %@";
 "notice_display_name_removed" = "%@ удалил(а) свое отображаемое имя";
-"notice_topic_changed" = "%@ изменил(а) тему на: %@";
-"notice_room_name_changed" = "%@ изменил(а) название комнаты на: %@";
+"notice_topic_changed" = "%@ изменил(а) тему на \"%@\".";
+"notice_room_name_changed" = "%@ изменил(а) название комнаты на %@.";
 "notice_placed_voice_call" = "%@ совершил(а) голосовой вызов";
 "notice_placed_video_call" = "%@ совершил(а) видео вызов";
 "notice_answered_video_call" = "%@ ответил(а) на вызов";
@@ -397,8 +397,8 @@
 "notice_display_name_set_by_you" = "Вы установили своё отображаемое имя как %@";
 "notice_display_name_changed_from_by_you" = "Вы сменили своё отображаемое имя с %@ на %@";
 "notice_display_name_removed_by_you" = "Вы удалили своё отображаемое имя";
-"notice_topic_changed_by_you" = "Вы сменили тему на: %@";
-"notice_room_name_changed_by_you" = "Вы сменили имя и комнаты на: %@";
+"notice_topic_changed_by_you" = "Вы сменили тему на \"%@\".";
+"notice_room_name_changed_by_you" = "Вы сменили имя и комнаты на %@.";
 "notice_room_withdraw_by_you" = "Вы отозвали приглашение %@";
 "notice_placed_voice_call_by_you" = "Вы начали звонок";
 "notice_placed_video_call_by_you" = "Вы начали видеозвонок";
@@ -409,7 +409,7 @@
 "notice_room_topic_removed_by_you" = "Вы удалили эту тему";
 "notice_event_redacted_by_you" = " вами";
 "notice_profile_change_redacted_by_you" = "Вы обновили свой профиль %@";
-"notice_room_created_by_you" = "Вы создали комнату";
+"notice_room_created_by_you" = "Вы создали и настроили комнату.";
 "notice_encryption_enabled_ok_by_you" = "Вы активировали сквозное шифрование.";
 "notice_encryption_enabled_unknown_algorithm_by_you" = "Вы активировали сквозное шифрование (неопознанный алгоритм %@).";
 "notice_redaction_by_you" = "Вы отредактировали событие (id: %@)";
@@ -417,3 +417,8 @@
 "notice_room_history_visible_to_members_by_you" = "Вы сделали будущую историю комнаты видимой для всех членов комнаты.";
 "notice_room_history_visible_to_members_from_invited_point_by_you" = "Вы сделали будущую историю комнаты видимой для всех членов комнаты, с того момента, как они приглашены.";
 "notice_room_history_visible_to_members_from_joined_point_by_you" = "Вы сделали будущую историю комнаты видимой для всех членов комнаты, с того момента, как они присоединились.";
+//  New
+"notice_room_join_rule_invite" = "%@ сделал(а) комнату доступной только по приглашению.";
+"notice_room_join_rule_invite_by_you" = "Вы сделали комнату только по приглашению.";
+"notice_room_join_rule_public" = "%@ сделал(а) комнату публичной.";
+"notice_room_join_rule_public_by_you" = "Вы сделали комнату публичной.";

--- a/MatrixKit/MatrixKitVersion.m
+++ b/MatrixKit/MatrixKitVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixKitVersion = @"0.12.21";
+NSString *const MatrixKitVersion = @"0.12.22";

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ abstract_target 'MatrixKitSamplePods' do
     
     # Different flavours of pods to Matrix SDK
     # The tagged version on which this version of MatrixKit has been built
-    pod 'MatrixSDK', '0.16.16'
+    pod 'MatrixSDK', '= 0.16.16'
     
     # The lastest release available on the CocoaPods repository
     #pod 'MatrixSDK'


### PR DESCRIPTION
This PR prepares the release of MatrixKit v0.12.22.

Notes:
- This PR targets `release/0.12.22/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.12.22/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-kit/compare/develop...release/0.12.22/release)
