### PR TITLE
Added allowActionsInDocumentPreview property to MXKRoomViewController

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changes in 0.13.2 (2020-12-02)
 
 ✨ Features
  * Added AES encryption support in MXKContactManager (vector-im/element-ios/issues/3833).
+ * Added allowActionsInDocumentPreview property in MXKRoomViewController to show or hide the actions button in document preview. (#3864)
 
 🙌 Improvements
  * 

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		32D9F4E221D54A08008007F2 /* UIViewController+MatrixKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D9F4E121D54A08008007F2 /* UIViewController+MatrixKit.m */; };
 		32FBDAF81E4484C40033C519 /* MXKEncryptionKeysImportView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FBDAF71E4484C40033C519 /* MXKEncryptionKeysImportView.m */; };
 		32FBDAFB1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FBDAFA1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m */; };
+		3A1293A825801D9400F3474B /* MXKPreviewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1293A625801D9400F3474B /* MXKPreviewViewController.m */; };
 		4F236C27EC459185548BEF4F /* Pods_MatrixKitSamplePods_MatrixKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B455B95A7B9ECAD75BA21E12 /* Pods_MatrixKitSamplePods_MatrixKitTests.framework */; };
 		550A36BD1DE484DB005C1647 /* EncryptedAttachmentsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */; };
 		71352D551C0ED240001D50B0 /* MXKRoomSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71352D531C0ED240001D50B0 /* MXKRoomSettingsViewController.m */; };
@@ -348,6 +349,8 @@
 		32FBDAF91E44B0FC0033C519 /* MXKEncryptionKeysExportView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKEncryptionKeysExportView.h; sourceTree = "<group>"; };
 		32FBDAFA1E44B0FC0033C519 /* MXKEncryptionKeysExportView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKEncryptionKeysExportView.m; sourceTree = "<group>"; };
 		392A579537BBF28A9436C420 /* Pods-MatrixKitSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSample/Pods-MatrixKitSample.release.xcconfig"; sourceTree = "<group>"; };
+		3A1293A625801D9400F3474B /* MXKPreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKPreviewViewController.m; sourceTree = "<group>"; };
+		3A1293A725801D9400F3474B /* MXKPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKPreviewViewController.h; sourceTree = "<group>"; };
 		550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncryptedAttachmentsTest.m; sourceTree = "<group>"; };
 		5537B7A941FDD5CF92368345 /* Pods-MatrixKitSamplePods-MatrixKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitSamplePods-MatrixKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitSamplePods-MatrixKitTests/Pods-MatrixKitSamplePods-MatrixKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5891CE7965783A3890D40ED9 /* Pods_MatrixKitSamplePods_MatrixKitSample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MatrixKitSamplePods_MatrixKitSample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -845,6 +848,8 @@
 				F00C25281ADBC3C100065077 /* MXKViewControllerHandling.h */,
 				F0026B641C91EED1001D2C04 /* MXKWebViewViewController.h */,
 				F0026B651C91EED1001D2C04 /* MXKWebViewViewController.m */,
+				3A1293A725801D9400F3474B /* MXKPreviewViewController.h */,
+				3A1293A625801D9400F3474B /* MXKPreviewViewController.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1973,6 +1978,7 @@
 				F09A66671FD812CA004B13B5 /* MXKGroupCellData.m in Sources */,
 				F0036EEF1AB98DC40008E432 /* MXKRoomInputToolbarView.m in Sources */,
 				F0CF98E01B0B7FDC00EAE373 /* MXKTableViewCellWithPicker.m in Sources */,
+				3A1293A825801D9400F3474B /* MXKPreviewViewController.m in Sources */,
 				F07E180D1ABC2EDA00DE3766 /* MXKQueuedEvent.m in Sources */,
 				71352D691C1588BE001D50B0 /* MXKTableViewCellWithLabelAndMXKImageView.m in Sources */,
 				328AC4931AA8B05C0044A6FB /* MXKCellData.m in Sources */,

--- a/MatrixKit/Controllers/MXKPreviewViewController.h
+++ b/MatrixKit/Controllers/MXKPreviewViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2020 Vector Creations Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixKit/Controllers/MXKPreviewViewController.h
+++ b/MatrixKit/Controllers/MXKPreviewViewController.h
@@ -1,0 +1,74 @@
+/*
+ Copyright 2020 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MXKPreviewViewControllerDelegate;
+
+/**
+ @brief A view controller that previews, opens, or prints files whose file format cannot be handled directly by your app.
+ 
+ Use this class to present an appropriate user interface for previewing, opening, copying, or printing a specified file. For example, an email program might use this class to allow the user to preview attachments and open them in other apps.
+ 
+ After presenting its user interface, a document interaction controller handles all interactions needed to support file preview and menu display.
+ 
+ Unlike UIDocumentInteractionController, this view controller aims to be modal presented.
+ */
+@interface MXKPreviewViewController : UINavigationController
+
+/**
+ @brief presents a new instance of MXKPreviewViewController as modal.
+ 
+ @param presenting view controller that presents the MXKPreviewViewController
+ @param fileUrl URL of the file. This URL should point to a local file.
+ @param allowActions YES to display actions Button. NO otherwise
+ @param delegate delegate (optional) that receives some events about the lifecycle of the MXKPreviewViewController
+ 
+ @return the instance of MXKPreviewViewController
+ */
++ (MXKPreviewViewController *)presentFrom:(nonnull UIViewController *)presenting
+            fileUrl: (nonnull NSURL *)fileUrl
+       allowActions: (BOOL)allowActions
+           delegate: (nullable id<MXKPreviewViewControllerDelegate>)delegate;
+
+@end
+
+/**
+ A set of methods you can implement to respond to messages from a preview controller.
+ */
+@protocol MXKPreviewViewControllerDelegate <NSObject>
+
+@optional
+
+/**
+ The MXKPreviewViewController will present the preview
+ 
+ @param controller the instance of MXKPreviewViewController
+ */
+- (void)previewViewControllerWillBeginPreview:(MXKPreviewViewController *)controller;
+
+/**
+ The MXKPreviewViewController did end presenting the preview
+ 
+ @param controller the instance of MXKPreviewViewController
+ */
+- (void)previewViewControllerDidEndPreview:(MXKPreviewViewController *)controller;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixKit/Controllers/MXKPreviewViewController.m
+++ b/MatrixKit/Controllers/MXKPreviewViewController.m
@@ -79,7 +79,8 @@
     }
 }
 
-- (IBAction)doneAction:(id)sender {
+- (IBAction)doneAction:(id)sender
+{
     [self dismissViewControllerAnimated:YES completion:^{
         if ([self.previewDelegate respondsToSelector:@selector(previewViewControllerDidEndPreview:)]) {
             [self.previewDelegate previewViewControllerDidEndPreview:self];

--- a/MatrixKit/Controllers/MXKPreviewViewController.m
+++ b/MatrixKit/Controllers/MXKPreviewViewController.m
@@ -1,0 +1,102 @@
+/*
+ Copyright 2020 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKPreviewViewController.h"
+@import QuickLook;
+
+@interface MXKPreviewViewController () <QLPreviewControllerDataSource>
+
+/// A specialized view controller for previewing an item.
+@property (nonatomic, weak) QLPreviewController *previewController;
+
+/// URL of the file to preview
+@property (nonatomic, strong) NSURL *fileURL;
+
+/// YES to display actions Button. NO otherwise
+@property (nonatomic) BOOL allowActions;
+
+@property (nonatomic, weak) id<MXKPreviewViewControllerDelegate> previewDelegate;
+
+@end
+
+@implementation MXKPreviewViewController
+
++ (MXKPreviewViewController *)presentFrom:(UIViewController *)presenting fileUrl:(NSURL *)fileUrl allowActions:(BOOL)allowActions delegate:(nullable id<MXKPreviewViewControllerDelegate>)delegate
+{
+    MXKPreviewViewController *previewController = [[MXKPreviewViewController alloc] initWithFileUrl: fileUrl allowActions: allowActions];
+    previewController.previewDelegate = delegate;
+    if ([delegate respondsToSelector:@selector(previewViewControllerWillBeginPreview:)]) {
+        [delegate previewViewControllerWillBeginPreview:previewController];
+    }
+    [presenting presentViewController:previewController animated:YES completion:^{
+    }];
+    
+    return previewController;
+}
+
+- (instancetype)initWithFileUrl: (NSURL *)fileUrl allowActions: (BOOL)allowActions
+{
+    QLPreviewController *previewController = [[QLPreviewController alloc] init];
+    self = [super initWithRootViewController:previewController];
+    self.previewController = previewController;
+    
+    if (self)
+    {
+        self.modalPresentationStyle = UIModalPresentationFullScreen;
+        self.fileURL = fileUrl;
+        self.allowActions = allowActions;
+        self.previewController.dataSource = self;
+        self.previewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneAction:)];
+    }
+    
+    return self;
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    
+    if (!self.allowActions) {
+        NSMutableArray *items = [NSMutableArray arrayWithArray: self.previewController.navigationItem.rightBarButtonItems];
+        if (items.count > 0)
+        {
+            [items removeObjectAtIndex:0];
+        }
+        self.previewController.navigationItem.rightBarButtonItems = items;
+    }
+}
+
+- (IBAction)doneAction:(id)sender {
+    [self dismissViewControllerAnimated:YES completion:^{
+        if ([self.previewDelegate respondsToSelector:@selector(previewViewControllerDidEndPreview:)]) {
+            [self.previewDelegate previewViewControllerDidEndPreview:self];
+        }
+    }];
+}
+
+#pragma mark - QLPreviewControllerDataSource
+
+- (NSInteger)numberOfPreviewItemsInPreviewController:(nonnull QLPreviewController *)controller
+{
+    return self.fileURL ? 1 : 0;
+}
+
+- (nonnull id<QLPreviewItem>)previewController:(nonnull QLPreviewController *)controller previewItemAtIndex:(NSInteger)index
+{
+    return self.fileURL;
+}
+
+@end

--- a/MatrixKit/Controllers/MXKPreviewViewController.m
+++ b/MatrixKit/Controllers/MXKPreviewViewController.m
@@ -69,7 +69,8 @@
 {
     [super viewDidLayoutSubviews];
     
-    if (!self.allowActions) {
+    if (!self.allowActions)
+    {
         NSMutableArray *items = [NSMutableArray arrayWithArray: self.previewController.navigationItem.rightBarButtonItems];
         if (items.count > 0)
         {

--- a/MatrixKit/Controllers/MXKRoomViewController.h
+++ b/MatrixKit/Controllers/MXKRoomViewController.h
@@ -177,6 +177,11 @@
 @property BOOL scrollHistoryToTheBottomOnKeyboardPresentation;
 
 /**
+ YES (default) to show actions button in document preview. NO otherwise.
+ */
+@property BOOL allowActionsInDocumentPreview;
+
+/**
  This object is defined when the displayed room is left. It is added into the bubbles table header.
  This label is used to display the reason why the room has been left.
  */

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -3718,7 +3718,7 @@
                         if (self.allowActionsInDocumentPreview)
                         {
                             // We could get rid of this part of code and use only a MXKPreviewViewController
-                            // Nevertheless, MXKRoomViewController is complient to UIDocumentInteractionControllerDelegate
+                            // Nevertheless, MXKRoomViewController is compliant to UIDocumentInteractionControllerDelegate
                             // and remove all this code could have effect on some custom implementations.
                             self->documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:fileURL];
                             [self->documentInteractionController setDelegate:self];


### PR DESCRIPTION
This property is used for showing or hiding the actions button in document preview. Part of fix for https://github.com/vector-im/element-ios/issues/3864 property