### PR TITLE
Fixed deep links to rooms from matrix.to no longer work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXKRoomDataSource: Fixed deep links to rooms from matrix.to no longer work
 
 ⚠️ API Changes
  * 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -200,7 +200,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     //  In order to successfully fetch the room, we should wait for store to be ready.
     if (mxSession.state >= MXSessionStateStoreDataReady)
     {
-        [self ensureInitialEventExistenceForDataSource:roomDataSource initialEventId:initialEventId andMatrixSession:mxSession onComplete:onComplete];
+        [self ensureInitialEventExistenceForDataSource:roomDataSource initialEventId:nil andMatrixSession:mxSession onComplete:onComplete];
     }
     else
     {


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/3897

Actually it was still working but it was taking around 30s to navigate to the dedicated room. Links to same room was working and link to another room without event ID was working.

**Note:**
- Application doesn't navigate to the room if link is clicked from outside the application, deep link is not working (application is launch but no navigation)
- Not really sure why it's working if I set the eventID to nil but my assumption is that navigation to the dedicated room and finding the message with the right event ID are blocking each others.