### PR TITLE
Login screen: Unexpected request to access the contact book

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Login screen: Unexpected request to access the contact book (vector-im/element-ios/issues/3984).
 
 ⚠️ API Changes
  * 

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -1521,7 +1521,12 @@ NSString *const MXKContactManagerDataType = @"org.matrix.kit.MXKContactManagerDa
         dispatch_async(dispatch_get_main_queue(), ^{
             
             [self internationalizePhoneNumbers:[[MXKAppSettings standardAppSettings] phonebookCountryCode]];
-            [self refreshLocalContacts];
+            
+            // Refresh local contacts if we have some
+            if (!self->localContactByContactID)
+            {
+                [self refreshLocalContacts];
+            }
             
         });
     }


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3984

Thanks to the magic of our auth screens, we can have such bugs :/
