### PR TITLE
Release 0.14.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * 
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
 Changes in 0.14.0 (2021-02-11)
 =================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.14.1 (2021-02-12)
 =================================================
 
 ✨ Features
@@ -21,6 +21,9 @@ Changes to be released in next version
 
 Others
  * 
+
+Improvements:
+ * Upgrade MatrixSDK version ([v0.18.1](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.18.1)).
 
 Changes in 0.14.0 (2021-02-11)
 =================================================

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixKit"
-  s.version      = "0.14.0"
+  s.version      = "0.14.1"
   s.summary      = "The Matrix reusable UI library for iOS based on MatrixSDK."
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.dependency 'MatrixSDK', "= 0.18.0"
+  s.dependency 'MatrixSDK', "= 0.18.1"
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.9.13'
   s.dependency 'DTCoreText', '~> 1.6.23'

--- a/MatrixKit/MatrixKitVersion.m
+++ b/MatrixKit/MatrixKitVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixKitVersion = @"0.14.0";
+NSString *const MatrixKitVersion = @"0.14.1";

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ abstract_target 'MatrixKitSamplePods' do
     
     # Different flavours of pods to Matrix SDK
     # The tagged version on which this version of MatrixKit has been built
-    pod 'MatrixSDK', '= 0.18.0'
+    pod 'MatrixSDK', '= 0.18.1'
     
     # The lastest release available on the CocoaPods repository
     #pod 'MatrixSDK'


### PR DESCRIPTION
This PR prepares the release of MatrixKit v0.14.1.

Notes:
- This PR targets `release/0.14.1/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.14.1/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-kit/compare/develop...release/0.14.1/release)
