### PR TITLE
Pre share session keys when typing by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * Crypto: Pre share session keys when typing by default (vector-im/element-ios/issues/4075).
 
 🐛 Bugfix
  * 
@@ -83,7 +83,7 @@ Changes in 0.14.0 (2021-02-11)
  * 
 
 🙌 Improvements
- * Pre-share session keys when opening a room (vector-im/element-ios/issues/3934)
+ * Crypto: Add a MXKAppSettings option to pre-share session keys (vector-im/element-ios/issues/3934).
  * VoIP: DTMF support in calls (vector-im/element-ios/issues/3929).
 
 🐛 Bugfix

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -114,7 +114,7 @@ typedef NS_ENUM(NSUInteger, MXKKeyPreSharingStrategy)
 @property (nonatomic) BOOL hideUndecryptableEvents;
 
 /**
- Indicates the strategy for sharing the outbound session key to other devices of the room (bitmask)
+ Indicates the strategy for sharing the outbound session key to other devices of the room
  */
 @property (nonatomic) MXKKeyPreSharingStrategy outboundGroupSessionKeyPreSharingStrategy;
 

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -178,7 +178,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
         _messageDetailsAllowSaving = YES;
         _messageDetailsAllowCopyingMedia = YES;
         _messageDetailsAllowPastingMedia = YES;
-        _outboundGroupSessionKeyPreSharingStrategy = MXKKeyPreSharingNone;
+        _outboundGroupSessionKeyPreSharingStrategy = MXKKeyPreSharingWhenTyping;
     }
     return self;
 }


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/4075

comments from https://github.com/matrix-org/matrix-ios-kit/pull/762#pullrequestreview-586372393 are applied as well.