### PR TITLE
App state: Infinite loading spinner when resuming the app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * App state: Infinite loading spinner when resuming the app (vector-im/element-ios/issues/4073).
 
 ⚠️ API Changes
  * 

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1088,6 +1088,16 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
         
         if (mxSession.state == MXSessionStateSyncInProgress || mxSession.state == MXSessionStateInitialised || mxSession.state == MXSessionStateStoreDataReady)
         {
+            // Make sure the SDK finish its work before the app goes sleeping in background
+            id<MXBackgroundModeHandler> handler = [MXSDKOptions sharedInstance].backgroundModeHandler;
+            if (handler)
+            {
+                if (!self.backgroundTask.isRunning)
+                {
+                    self.backgroundTask = [handler startBackgroundTaskWithName:@"[MXKAccount] pauseInBackgroundTask" expirationHandler:nil];
+                }
+            }
+            
             NSLog(@"[MXKAccount] Pause is delayed at the end of sync (current state %tu)", mxSession.state);
             isPauseRequested = YES;
         }


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4073

I do not like this fix. I think we should fix it at the SDK level. We need to do much more cleaning like:
 - Kit should not have a UIBackground task to manage the pause. It should be manage the sdk itself
 - We should remove things related to `[MXSession backgroundSync:]` we have `MXBackgroundSyncService`
 
 At least, this PR is doing the same thing as upper in this same method but it does it now for the particular case where the app is put in background while `MXSession` is doing its first sync (`MXSessionStateSyncInProgress`).