### PR TITLE
MXKRoomDataSource: Fix memory leak in doubly-linked bubble list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXKRoomDataSource: Fix memory leak in `bubbles` array.
 
 ⚠️ API Changes
  * 

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		71EBE6631C04608100E7D953 /* MXKRoomActivitiesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71EBE6621C04608100E7D953 /* MXKRoomActivitiesView.m */; };
 		8EE45E64044E107FAB59C7D1 /* Pods_MatrixKitSamplePods_MatrixKitSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5891CE7965783A3890D40ED9 /* Pods_MatrixKitSamplePods_MatrixKitSample.framework */; };
 		92663A6C1EF6E5B3005FB712 /* MXKSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */; };
+		A82C7BAF25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82C7BAE25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift */; };
+		A8C4035B25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C4035A25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m */; };
 		B11D3C7E20C032BD00938BCB /* MXKBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B11D3C7D20C032BD00938BCB /* MXKBarButtonItem.m */; };
 		B125D0FD22D5D2C200570CA4 /* MXKUTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D0FC22D5D2C200570CA4 /* MXKUTI.swift */; };
 		B125D10522D62A4900570CA4 /* MXKUTITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D10322D62A4800570CA4 /* MXKUTITests.swift */; };
@@ -367,6 +369,9 @@
 		8C751E43C4D87B309065E3C8 /* Pods-MatrixKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSoundPlayer.h; sourceTree = "<group>"; };
 		92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSoundPlayer.m; sourceTree = "<group>"; };
+		A82C7BAE25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKRoomDataSourceTests.swift; sourceTree = "<group>"; };
+		A8C4035925F0C33B00B3F18B /* MXKRoomDataSource+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MXKRoomDataSource+Tests.h"; sourceTree = "<group>"; };
+		A8C4035A25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MXKRoomDataSource+Tests.m"; sourceTree = "<group>"; };
 		B11D3C7C20C032BD00938BCB /* MXKBarButtonItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKBarButtonItem.h; sourceTree = "<group>"; };
 		B11D3C7D20C032BD00938BCB /* MXKBarButtonItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKBarButtonItem.m; sourceTree = "<group>"; };
 		B125D0FC22D5D2C200570CA4 /* MXKUTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKUTI.swift; sourceTree = "<group>"; };
@@ -712,6 +717,9 @@
 			children = (
 				B125D10222D62A4800570CA4 /* UTI */,
 				32538D071D2EA100009FE744 /* MXKEventFormatterTests.m */,
+				A82C7BAE25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift */,
+				A8C4035925F0C33B00B3F18B /* MXKRoomDataSource+Tests.h */,
+				A8C4035A25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m */,
 				3203F26C1D2E9CAE0021F170 /* Info.plist */,
 				550A36BC1DE484DB005C1647 /* EncryptedAttachmentsTest.m */,
 				B125D0FF22D61F1D00570CA4 /* MatrixKitTests-Bridging-Header.h */,
@@ -1843,9 +1851,11 @@
 			files = (
 				F07B9C2B1D3587D3000CB20E /* MXKAppSettings.m in Sources */,
 				550A36BD1DE484DB005C1647 /* EncryptedAttachmentsTest.m in Sources */,
+				A82C7BAF25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift in Sources */,
 				328E410424CB135100DC4490 /* MatrixKitVersion.m in Sources */,
 				B125D10522D62A4900570CA4 /* MXKUTITests.swift in Sources */,
 				F07B9C2C1D3587E5000CB20E /* MXKTools.m in Sources */,
+				A8C4035B25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m in Sources */,
 				32538D081D2EA100009FE744 /* MXKEventFormatterTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -476,6 +476,10 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
         
         @synchronized(bubbles)
         {
+            for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles) {
+                bubble.prevCollapsableCellData = nil;
+                bubble.nextCollapsableCellData = nil;
+            }
             [bubbles removeAllObjects];
         }
         

--- a/MatrixKitTests/MXKRoomDataSource+Tests.h
+++ b/MatrixKitTests/MXKRoomDataSource+Tests.h
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKRoomDataSource.h"
+
+@interface MXKRoomDataSource (Tests)
+
+- (NSArray<id<MXKRoomBubbleCellDataStoring>> *)getBubbles;
+- (void)replaceBubbles:(NSArray<id<MXKRoomBubbleCellDataStoring>> *)newBubbles;
+
+@end

--- a/MatrixKitTests/MXKRoomDataSource+Tests.m
+++ b/MatrixKitTests/MXKRoomDataSource+Tests.m
@@ -1,0 +1,29 @@
+/*
+ Copyright 2021 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKRoomDataSource+Tests.h"
+
+@implementation MXKRoomDataSource (Tests)
+
+- (NSArray<id<MXKRoomBubbleCellDataStoring>> *)getBubbles {
+    return bubbles;
+}
+
+- (void)replaceBubbles:(NSArray<id<MXKRoomBubbleCellDataStoring>> *)newBubbles {
+    bubbles = [NSMutableArray arrayWithArray:newBubbles];
+}
+
+@end

--- a/MatrixKitTests/MXKRoomDataSourceTests.swift
+++ b/MatrixKitTests/MXKRoomDataSourceTests.swift
@@ -1,0 +1,58 @@
+/*
+ Copyright 2021 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import XCTest
+
+@testable import MatrixKit
+
+class MXKRoomDataSourceTests: XCTestCase {
+
+    func testDestroyRemovesAllBubbles() {
+        let dataSource = StubMXKRoomDataSource()
+        dataSource.destroy()
+        XCTAssert(dataSource.getBubbles()?.isEmpty != false)
+    }
+
+    func testDestroyDeallocatesAllBubbles() throws {
+        let dataSource = StubMXKRoomDataSource()
+        weak var first = try XCTUnwrap(dataSource.getBubbles()?.first)
+        weak var last = try XCTUnwrap(dataSource.getBubbles()?.last)
+        dataSource.destroy()
+        XCTAssertNil(first)
+        XCTAssertNil(last)
+    }
+
+}
+
+private final class StubMXKRoomDataSource: MXKRoomDataSource {
+
+    override init() {
+        super.init()
+
+        let data1 = MXKRoomBubbleCellData()
+        let data2 = MXKRoomBubbleCellData()
+        let data3 = MXKRoomBubbleCellData()
+
+        data1.nextCollapsableCellData = data2
+        data2.prevCollapsableCellData = data1
+        data2.nextCollapsableCellData = data3
+        data3.prevCollapsableCellData = data2
+
+        replaceBubbles([data1, data2, data3])
+    }
+
+}

--- a/MatrixKitTests/MatrixKitTests-Bridging-Header.h
+++ b/MatrixKitTests/MatrixKitTests-Bridging-Header.h
@@ -2,3 +2,5 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "MXKRoomBubbleCellData.h"
+#import "MXKRoomDataSource+Tests.h"


### PR DESCRIPTION
Collapsible elements of the `bubbles` array form a doubly-linked list with strong references stored in `prevCollapsableCellData` and `nextCollapsableCellData`. This retain cycle prevents the bubbles from being deallocated even when the `bubbles` array itself is destroyed.

This is easy to reproduce on the Element iOS app:

1. Open a large room (e.g. [#main:postmarketos.org](https://matrix.to/#/#main:postmarketos.org))
2. Scroll up a few pages (new collapsed bubbles are added)
3. Tap back out of the room (the `MXKRoomDataSource` instance will be reset)
4. Fire up the memory graph debugger in Xcode

At this point, you'll notice orphaned chains of mutual strong references that cannot be deallocated.

![Screenshot 2021-03-05 at 20 20 06](https://user-images.githubusercontent.com/1137962/110166295-6ed6df80-7df4-11eb-8070-0bb0a720bbfc.png)

The present fix breaks the strong reference cycle by nilifying both `prevCollapsableCellData` and `nextCollapsableCellData` on all objects in the `bubbles` array when `MXKRoomDataSource` is reset.

Note that this commit does *not* fix the very same leak in the `bubblesSnapshot` array. The latter depends on a race condition though so it is a lot less likely to occur. I believe that fixing it requires a more careful review of the threading and synchronisation in `MXKRoomDataSource` and I did not want to delay getting the much more probable `bubbles` leak fix applied first.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
