### PR TITLE
Allow users to search in encrypted room locally [#783].

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -110,8 +110,6 @@
  */
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
-@property (nonatomic, weak) MXEvent *event;
-
 /**
  Check and refresh the position of each component.
  */
@@ -150,6 +148,11 @@
  */
 - (MXKRoomBubbleComponent*)getFirstBubbleComponentWithDisplay;
 
-- (BOOL)searchText:(NSString *)text;
+/**
+ Search for the matching text
+ 
+ @return Returns array events matching text or empty array
+ */
+- (NSArray *)searchText:(NSString *)text;
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -110,6 +110,8 @@
  */
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
+@property (nonatomic, weak) MXEvent *event;
+
 /**
  Check and refresh the position of each component.
  */
@@ -147,5 +149,7 @@
  @return First visible component or nil.
  */
 - (MXKRoomBubbleComponent*)getFirstBubbleComponentWithDisplay;
+
+- (BOOL)searchText:(NSString *)text;
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -51,7 +51,6 @@
         {
             bubbleComponents = [NSMutableArray array];
             [bubbleComponents addObject:firstComponent];
-            _event = event;
             senderId = event.sender;
             roomId = roomDataSource.roomId;
             senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:roomState];
@@ -90,8 +89,14 @@
     return self;
 }
 
-- (BOOL)searchText:(NSString *)text {
-    return [self.textMessage rangeOfString:text  options:NSCaseInsensitiveSearch].location != NSNotFound;
+- (NSArray *)searchText:(NSString *)text {
+    NSMutableArray *events = [[NSMutableArray alloc] init];
+    for (MXKRoomBubbleComponent *item in bubbleComponents) {
+        if (item.textMessage && [item.textMessage rangeOfString:text  options:NSCaseInsensitiveSearch].location != NSNotFound) {
+            [events addObject:item.event];
+        }
+    }
+    return [NSArray arrayWithArray:events];
 }
 
 - (void)dealloc

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -51,7 +51,7 @@
         {
             bubbleComponents = [NSMutableArray array];
             [bubbleComponents addObject:firstComponent];
-            
+            _event = event;
             senderId = event.sender;
             roomId = roomDataSource.roomId;
             senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:roomState];
@@ -88,6 +88,10 @@
         }
     }
     return self;
+}
+
+- (BOOL)searchText:(NSString *)text {
+    return [self.textMessage rangeOfString:text  options:NSCaseInsensitiveSearch].location != NSNotFound;
 }
 
 - (void)dealloc

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -708,4 +708,6 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  */
 - (NSString*)editableTextMessageForEvent:(MXEvent*)event;
 
+- (MXSearchRoomEventResults *)search:(NSString* )text filter:(MXRoomEventFilter *)filter;
+
 @end

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -3582,4 +3582,28 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 }
 
+#pragma mark - Search from locally in encrypted room.
+
+- (MXSearchRoomEventResults *)search:(NSString* )text filter:(MXRoomEventFilter *)filter {
+    NSArray *bubbles = self->bubbles;
+    NSMutableArray *searchResult = [[NSMutableArray alloc] init];
+    
+    for (MXKRoomBubbleCellData* item in bubbles) {
+        if([item searchText:text]) {
+            if ( (filter.containsURL && item.event.isMediaAttachment) || !filter.containsURL) {
+                MXSearchResult *result = [[MXSearchResult alloc] init];
+                result.result = item.event;
+                [searchResult addObject:result];
+            }
+        }
+    }
+    
+    MXSearchRoomEventResults *result = [[MXSearchRoomEventResults alloc] init];
+    result.count = searchResult.count;
+    result.nextBatch = nil;
+    result.groups = nil;
+    result.results = [NSArray arrayWithArray:searchResult];
+    
+    return result;
+}
 @end

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -3582,17 +3582,17 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 }
 
-#pragma mark - Search from locally in encrypted room.
-
+#pragma mark - Search
 - (MXSearchRoomEventResults *)search:(NSString* )text filter:(MXRoomEventFilter *)filter {
     NSArray *bubbles = self->bubbles;
     NSMutableArray *searchResult = [[NSMutableArray alloc] init];
     
     for (MXKRoomBubbleCellData* item in bubbles) {
-        if([item searchText:text]) {
-            if ( (filter.containsURL && item.event.isMediaAttachment) || !filter.containsURL) {
+        NSArray *events = [item searchText:text];
+        for (MXEvent *event in events) {
+            if ( (filter.containsURL && event.isMediaAttachment) || !filter.containsURL) {
                 MXSearchResult *result = [[MXSearchResult alloc] init];
-                result.result = item.event;
+                result.result = event;
                 [searchResult addObject:result];
             }
         }

--- a/MatrixKit/Models/Search/MXKSearchDataSource.h
+++ b/MatrixKit/Models/Search/MXKSearchDataSource.h
@@ -16,6 +16,7 @@
 
 #import "MXKDataSource.h"
 #import "MXKSearchCellDataStoring.h"
+#import "MXKRoomDataSource.h"
 
 #import "MXKEventFormatter.h"
 
@@ -70,6 +71,8 @@ extern NSString *const kMXKSearchCellDataIdentifier;
  Tell whether the room display name should be displayed in each result cell. NO by default.
  */
 @property (nonatomic) BOOL shouldShowRoomDisplayName;
+
+@property (nonatomic) MXKRoomDataSource *roomDataSource;
 
 
 /**


### PR DESCRIPTION
- Search is now available only for unencrypted rooms, and not available for encrypted rooms.
- Search can be enabled for encrypted rooms by searching from locally cached datas.
- For now the search can work within locally available data, and may be enhanced to efficiently load the entire history on users need.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
