### PR TITLE
Allow users to search in encrypted room locally [#783].

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -708,4 +708,6 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  */
 - (NSString*)editableTextMessageForEvent:(MXEvent*)event;
 
+- (void)search:(NSString* )text filter:(MXRoomEventFilter *)filter success:(void (^)(MXSearchRoomEventResults *result))success;
+
 @end


### PR DESCRIPTION
- Search is now available only for unencrypted rooms, and not available for encrypted rooms.
- Search can be enabled for encrypted rooms by searching from locally cached datas.
- For now the search can work within locally available data, and may be enhanced to efficiently load the entire history on users need.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
