### PR TITLE
MXKRoomBubbleCellDataStoring: Introduce target user ID, display name and avatar URL for room membership events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * 
+ * MXKRoomBubbleCellDataStoring: Introduce target user ID, display name and avatar URL for room membership events (vector-im/element-ios/issues/4102).
 
 🗣 Translations
  * 

--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		71DE22E61BCE3FF200284153 /* MXKRoomBubbleCellDataWithIncomingAppendingMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomBubbleCellDataWithIncomingAppendingMode.h; sourceTree = "<group>"; };
 		71EBE6611C04608100E7D953 /* MXKRoomActivitiesView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKRoomActivitiesView.h; sourceTree = "<group>"; };
 		71EBE6621C04608100E7D953 /* MXKRoomActivitiesView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKRoomActivitiesView.m; sourceTree = "<group>"; };
+		8878281C260C85BB00429B35 /* MXKEventFormatter+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MXKEventFormatter+Tests.h"; sourceTree = "<group>"; };
 		8C751E43C4D87B309065E3C8 /* Pods-MatrixKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSoundPlayer.h; sourceTree = "<group>"; };
 		92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSoundPlayer.m; sourceTree = "<group>"; };
@@ -717,6 +718,7 @@
 			children = (
 				B125D10222D62A4800570CA4 /* UTI */,
 				32538D071D2EA100009FE744 /* MXKEventFormatterTests.m */,
+				8878281C260C85BB00429B35 /* MXKEventFormatter+Tests.h */,
 				A82C7BAE25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift */,
 				A8C4035925F0C33B00B3F18B /* MXKRoomDataSource+Tests.h */,
 				A8C4035A25F0C34D00B3F18B /* MXKRoomDataSource+Tests.m */,

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -27,7 +27,7 @@
 #import "MXKTools.h"
 
 @implementation MXKRoomBubbleCellData
-@synthesize senderId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, isEncryptedRoom, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment, senderFlair;
+@synthesize senderId, targetId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, targetDisplayName, targetAvatarUrl, targetAvatarPlaceholder, isEncryptedRoom, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment, senderFlair;
 @synthesize textMessage, attributedTextMessage;
 @synthesize shouldHideSenderName, isTyping, showBubbleDateTime, showBubbleReceipts, useCustomDateTimeLabel, useCustomReceipts, useCustomUnsentButton, hasNoDisplay;
 @synthesize tag;
@@ -53,10 +53,14 @@
             [bubbleComponents addObject:firstComponent];
             
             senderId = event.sender;
+            targetId = [event.type isEqualToString:kMXEventTypeStringRoomMember] ? event.stateKey : nil;
             roomId = roomDataSource.roomId;
             senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:roomState];
             senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:roomState];
             senderAvatarPlaceholder = nil;
+            targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:event withRoomState:roomState];
+            targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:event withRoomState:roomState];
+            targetAvatarPlaceholder = nil;
             isEncryptedRoom = roomState.isEncrypted;
             isIncoming = ([event.sender isEqualToString:roomDataSource.mxSession.myUser.userId] == NO);
             

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -40,6 +40,14 @@
 @property (nonatomic) NSString *senderId;
 
 /**
+ The target Id (may be nil)
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+ */
+@property (nonatomic) NSString *targetId;
+
+/**
  The room id
  */
 @property (nonatomic) NSString *roomId;
@@ -58,6 +66,30 @@
  The sender avatar placeholder (may be nil) - Used when url is nil, or during avatar download.
  */
 @property (nonatomic) UIImage *senderAvatarPlaceholder;
+
+/**
+ The target display name composed when event occured (may be nil)
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+ */
+@property (nonatomic) NSString *targetDisplayName;
+
+/**
+ The target avatar url retrieved when event occured (may be nil)
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+ */
+@property (nonatomic) NSString *targetAvatarUrl;
+
+/**
+ The target avatar placeholder (may be nil) - Used when url is nil, or during avatar download.
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+ */
+@property (nonatomic) UIImage *targetAvatarPlaceholder;
 
 /**
  The current sender flair (list of the publicised groups in the sender profile which matches the room flair settings)

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
@@ -140,6 +140,18 @@ typedef enum : NSUInteger {
 - (NSString*)senderDisplayNameForEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;
 
 /**
+ Compose the event target display name according to the current room state.
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+
+ @param event the event to format.
+ @param roomState the room state right before the event.
+ @return the target display name (if any)
+ */
+- (NSString*)targetDisplayNameForEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;
+
+/**
  Retrieve the avatar url of the event sender from the current room state.
  
  @param event the event to format.
@@ -147,6 +159,18 @@ typedef enum : NSUInteger {
  @return the sender avatar url
  */
 - (NSString*)senderAvatarUrlForEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;
+
+/**
+ Retrieve the avatar url of the event target from the current room state.
+
+ @discussion "target" refers to the room member who is the target of this event (if any), e.g.
+ the invitee, the person being banned, etc.
+
+ @param event the event to format.
+ @param roomState the room state right before the event.
+ @return the target avatar url (if any)
+ */
+- (NSString*)targetAvatarUrlForEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;
 
 /**
  Generate a displayable string representating the event.

--- a/MatrixKitTests/MXKEventFormatter+Tests.h
+++ b/MatrixKitTests/MXKEventFormatter+Tests.h
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKEventFormatter.h"
+
+@interface MXKEventFormatter (Tests)
+
+- (NSString*)userDisplayNameFromContentInEvent:(MXEvent*)event withMembershipFilter:(NSString *)filter;
+- (NSString*)userAvatarUrlFromContentInEvent:(MXEvent*)event withMembershipFilter:(NSString *)filter;
+
+@end


### PR DESCRIPTION
As reported in vector-im/element-ios#4102, collapsed membership changes in the Element iOS app currently _always_ display the sender avatar. In contrast, the Element web app shows the avatar of the user whose membership has changed in this case.

This commit introduces new properties `targetId`, `targetDisplayName`, `targetAvatarUrl` and `targetAvatarPlaceholder` on `MXKRoomBubbleCellDataStoring`. The values are populated from the event (in case it is an `m.room.member` event) in the initializer of `MXKRoomBubbleCellData` (where the corresponding sender properties are already being assigned). This way, clients can easily choose to present the target avatar instead of the sender avatar when processing the bubble data.

Note that the "target" terminology was taken over from matrix-js-sdk which populates the `target` property on `MatrixEvent` objects when they are added to the timeline.

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-kit/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
