### PR TITLE
CI: Introduce GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MX_GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+
 jobs:
   build:
     name: Build
@@ -41,8 +44,6 @@ jobs:
 
       - name: Use right MatrixSDK version
         run: bundle exec fastlane point_sample_app_to_related_branches
-        env:
-          MX_GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
 
       # Main step
       - name: Build iOS simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,24 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
-      - name: Use right MatrixSDK versions
-        run: bundle exec fastlane point_sample_app_to_pending_releases
+      # Selection of MatrixSDK
+      - uses: nelonoel/branch-name@v1.0.1
+      - name: Extract branch name
+        shell: sh
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+        id: extract_branch
+      - name: Use the pending release of MatrixSDK ${{ github.event.inputs.from_branch }}
+        if: startsWith(github.event.inputs.from_branch, 'release/')
+        run: |
+          echo 'branch  ${{ github.event.inputs.from_branch }}'
+          echo ${BRANCH_NAME}
+          bundle exec fastlane point_sample_app_to_pending_releases
+      - name: Use the same feature branch of MatrixSDK
+        if: startsWith(github.event.inputs.from_branch, 'release/') != true
+        run: |
+          echo 'branch  ${{ github.event.inputs.from_branch }}'
+          echo ${BRANCH_NAME}
+          bundle exec fastlane point_sample_app_to_same_feature
 
       # Main step
       - name: Build iOS simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,24 +39,8 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
-      # Selection of MatrixSDK
-      - uses: nelonoel/branch-name@v1.0.1
-      - name: Extract branch name
-        shell: sh
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
-        id: extract_branch
-      - name: Use the pending release of MatrixSDK ${{ github.event.inputs.from_branch }}
-        if: startsWith(github.event.inputs.from_branch, 'release/')
-        run: |
-          echo 'branch  ${{ github.event.inputs.from_branch }}'
-          echo ${BRANCH_NAME}
-          bundle exec fastlane point_sample_app_to_pending_releases
-      - name: Use the same feature branch of MatrixSDK
-        if: startsWith(github.event.inputs.from_branch, 'release/') != true
-        run: |
-          echo 'branch  ${{ github.event.inputs.from_branch }}'
-          echo ${BRANCH_NAME}
-          bundle exec fastlane point_sample_app_to_same_feature
+      - name: Use right MatrixSDK versions
+        run: bundle exec fastlane point_sample_app_to_related_branches
 
       # Main step
       - name: Build iOS simulator
@@ -93,11 +77,12 @@ jobs:
           bundle install --jobs 4 --retry 3
    
       - name: Use right MatrixSDK versions
-        run: bundle exec fastlane point_sample_app_to_pending_releases
+        run: bundle exec fastlane point_sample_app_to_related_branches
 
       # Main step
       - name: Unit tests
         run: bundle exec fastlane test
+
 
   cocoapods:
     name: CocoaPods
@@ -129,7 +114,7 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Use right MatrixSDK versions
-        run: bundle exec fastlane point_podspec_to_pending_releases
+        run: bundle exec fastlane point_podspec_to_related_branches
 
       # Main step
       - name: Lint MatrixKit.podspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  # Make the git branch for a PR available to our Fastfile
   MX_GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
 
 jobs:
@@ -79,7 +80,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
    
-      - name: Use right MatrixSDK versions
+      - name: Use right MatrixSDK version
         run: bundle exec fastlane point_sample_app_to_related_branches
 
       # Main step
@@ -116,7 +117,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
-      - name: Use right MatrixSDK versions
+      - name: Use right MatrixSDK version
         run: bundle exec fastlane point_podspec_to_related_branches
 
       # Main step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,10 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
-      # - name: Use right MatrixSDK versions
-      #   run: |
-      #     echo ${{ toJson(github) }}
-      #     echo ${{ github.event.pull_request.head.ref }}
-      #     bundle exec fastlane point_sample_app_to_related_branches
-
-      - name: Use the pending release of MatrixSDK ${{ github.event.pull_request.head.ref }}
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo 'branch ${{ github.event.pull_request.head.ref }}'
-          bundle exec fastlane point_sample_app_to_pending_releases
-      - name: Use the same feature branch of MatrixSDK
-        if: startsWith(github.event.pull_request.head.ref, 'release/') != true
-        run: |
-          echo 'branch ${{ github.event.pull_request.head.ref }}'
-          bundle exec fastlane point_sample_app_to_same_feature
+      - name: Use right MatrixSDK version
+        run: bundle exec fastlane point_sample_app_to_related_branches
+        env:
+          MX_GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
 
       # Main step
       - name: Build iOS simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,22 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
-      - name: Use right MatrixSDK versions
-        run: bundle exec fastlane point_sample_app_to_related_branches
+      # - name: Use right MatrixSDK versions
+      #   run: |
+      #     echo ${{ toJson(github) }}
+      #     echo ${{ github.event.pull_request.head.ref }}
+      #     bundle exec fastlane point_sample_app_to_related_branches
+
+      - name: Use the pending release of MatrixSDK ${{ github.event.pull_request.head.ref }}
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          echo 'branch ${{ github.event.pull_request.head.ref }}'
+          bundle exec fastlane point_sample_app_to_pending_releases
+      - name: Use the same feature branch of MatrixSDK
+        if: startsWith(github.event.pull_request.head.ref, 'release/') != true
+        run: |
+          echo 'branch ${{ github.event.pull_request.head.ref }}'
+          bundle exec fastlane point_sample_app_to_same_feature
 
       # Main step
       - name: Build iOS simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  # Triggers the workflow on any pull request and push to develop
+  push:
+    branches: [ develop ]
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Common cache
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      # Common setup
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3    
+      - name: Use right MatrixSDK versions
+        run: bundle exec fastlane point_sample_app_to_pending_releases
+
+      # Main step
+      - name: Build iOS simulator
+        run: bundle exec fastlane build_sample_app
+
+
+  tests:
+    name: Tests
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Common cache
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      # Common setup
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3    
+      - name: Use right MatrixSDK versions
+        run: bundle exec fastlane point_sample_app_to_pending_releases
+
+      # Main step
+      - name: Unit tests
+        run: bundle exec fastlane test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Bundle install
         run: |
           bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3    
+          bundle install --jobs 4 --retry 3
+
       - name: Use right MatrixSDK versions
         run: bundle exec fastlane point_sample_app_to_pending_releases
 
@@ -73,10 +74,47 @@ jobs:
       - name: Bundle install
         run: |
           bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3    
+          bundle install --jobs 4 --retry 3
+   
       - name: Use right MatrixSDK versions
         run: bundle exec fastlane point_sample_app_to_pending_releases
 
       # Main step
       - name: Unit tests
         run: bundle exec fastlane test
+
+  cocoapods:
+    name: CocoaPods
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Common cache
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      # Common setup
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Use right MatrixSDK versions
+        run: bundle exec fastlane point_podspec_to_pending_releases
+
+      # Main step
+      - name: Lint MatrixKit.podspec
+        run: bundle exec fastlane lint_local_pod_MatrixKit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changes to be released in next version
  * 
     
 🧱 Build
- * 
+ * CI: Introduce GH actions.
 
 Others
  * 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ platform :ios do
 
   desc "Modify the MatrixKit.podspec locally to point to the related MatrixSDK branch if such one exists,"
   lane :point_podspec_to_related_branches do
-    current_branch = git_branch
+    current_branch = mx_git_branch
     UI.message("Current branch: #{current_branch}")
     if current_branch.start_with?("release/")
         point_podspec_to_pending_releases
@@ -61,13 +61,13 @@ platform :ios do
 
   desc "Modify the MatrixKit.podspec locally to point to the same branch of 'MatrixSDK' as the current one if such one exists, or to develop otherwise"
   lane :point_podspec_to_same_feature do
-    edit_podspec(branch_pattern: git_branch)
+    edit_podspec(branch_pattern: mx_git_branch)
   end
 
 
   desc "Modify the Podfile of the sample app locally to point to the related MatrixSDK branch if such one exists,"
   lane :point_sample_app_to_related_branches do
-    current_branch = git_branch
+    current_branch = mx_git_branch
     UI.message("Current branch: #{current_branch}")
     if current_branch.start_with?("release/")
         point_sample_app_to_pending_releases
@@ -83,7 +83,7 @@ platform :ios do
 
   desc "Modify the Podfile of the sample app locally to point to the same branch of 'MatrixSDK' as the current one if such one exists, or to develop otherwise"
   lane :point_sample_app_to_same_feature do
-    edit_podfile(branch_pattern: git_branch)
+    edit_podfile(branch_pattern: mx_git_branch)
   end
 
 
@@ -133,6 +133,18 @@ platform :ios do
     podfile_content = File.read('../Podfile')
     podfile_content.gsub!(/(pod\s+(['"])MatrixSDK\2).*$/, "\\1, :git => 'https://github.com/#{sdk_slug}.git', :branch => '#{sdk_branch}'")
     File.write('../Podfile', podfile_content)
+  end
+
+  #
+  def mx_git_branch
+    mx_git_branch = git_branch
+    if mx_git_branch == ""
+        ensure_env_vars(
+            env_vars: ['MX_GIT_BRANCH']
+          )
+        mx_git_branch = ENV["MX_GIT_BRANCH"]
+    end
+    return mx_git_branch
   end
 
   # Find the latest branch with the given name pattern in the given repo

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,8 @@ platform :ios do
     File.write('../Podfile', podfile_content)
   end
 
-  #
+  # git_branch can return an empty screen with some CI tools (like GH actions) 
+  # The CI build script needs to define MX_GIT_BRANCH with the right branch.
   def mx_git_branch
     mx_git_branch = git_branch
     if mx_git_branch == ""
@@ -174,4 +175,5 @@ platform :ios do
 
     sh(command.join(" "))
   end
+
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ platform :ios do
 
   desc "Lint local MatrixKit podspec"
   lane :lint_local_pod_MatrixKit do
-    # MatrixKit-*.podspec and MatrixKit-*.pospec are created by the `bundle exec fastlane point_podspec_to_…` lanes supposed to be run beforehand
-    custom_pod_lib_lint(podspec: "../local-podspecs/MatrixKit.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Debug", " --external-podspecs=local-podspecs/MatrixSDK.podspec"])
+    # MatrixKit.podspec and MatrixKit.pospec are updated or created by the `bundle exec fastlane point_podspec_to_…` lanes supposed to be run beforehand
+    custom_pod_lib_lint(podspec: "../MatrixKit.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Debug", " --external-podspecs=MatrixSDK.podspec"])
   end
 
   desc "Run tests"
@@ -84,7 +84,7 @@ platform :ios do
     sdk_slug = "matrix-org/matrix-ios-sdk"
     sdk_branch = find_branch(sdk_slug, options[:branch_pattern]) || 'develop'
     
-    local_podspec_dir = '../local-podspecs/' # current dir is 'fastlane/' hence the '../'
+    local_podspec_dir = '../' # current dir is 'fastlane/' hence the '../'
     FileUtils.mkdir_p(local_podspec_dir)
 
     UI.message("✏️ Making a local copy of MatrixSDK.podspec from the \`#{sdk_branch}\` branch...")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,18 @@ platform :ios do
     )
   end
 
+  desc "Lint MatrixKit podspec"
+  lane :lint_pod_MatrixKit do
+    # Build only Debug config to divide build time by 3
+    custom_pod_lib_lint(podspec: "../MatrixKit.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Debug"])
+  end
+
+  desc "Lint local MatrixKit podspec"
+  lane :lint_local_pod_MatrixKit do
+    # MatrixKit-*.podspec and MatrixKit-*.pospec are created by the `bundle exec fastlane point_podspec_to_…` lanes supposed to be run beforehand
+    custom_pod_lib_lint(podspec: "../local-podspecs/MatrixKit.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Debug", " --external-podspecs=local-podspecs/MatrixSDK.podspec"])
+  end
+
   desc "Run tests"
   lane :test do
     cocoapods
@@ -103,5 +115,25 @@ platform :ios do
     list.split("\n")
         .map { |line| line.sub(%r{[0-9a-f]+\trefs/heads/}, '').chomp }
         .last # Latest ref found, in "version:refname" semantic order
+  end
+
+  desc "Returns bundle Cocoapods version"
+  private_lane :cocoapods_version do
+    sh("bundle exec pod --version", log: false)
+  end
+
+  desc "Pod lib lint with podspec parameter"
+  private_lane :custom_pod_lib_lint do |options|
+    puts "Lint pod " << options[:podspec] << " with Cocoapods version " << cocoapods_version
+
+    command = []
+    command << "bundle exec pod lib lint"
+    command << options[:podspec]
+
+    if options[:parameters]
+      command.concat(options[:parameters])
+    end
+
+    sh(command.join(" "))
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,6 +42,18 @@ platform :ios do
     )
   end
 
+
+  desc "Modify the MatrixKit.podspec locally to point to the related MatrixSDK branch if such one exists,"
+  lane :point_podspec_to_related_branches do
+    current_branch = git_branch
+    UI.message("Current branch: #{current_branch}")
+    if current_branch.start_with?("release/")
+        point_podspec_to_pending_releases
+    else
+        point_podspec_to_same_feature
+    end
+  end
+
   desc "Modify the MatrixKit.podspec locally to point to the latest 'release/*/release' branch of 'MatrixSDK' if such one exists, or to develop otherwise"
   lane :point_podspec_to_pending_releases do
     edit_podspec(branch_pattern: "release/*/release")
@@ -50,6 +62,18 @@ platform :ios do
   desc "Modify the MatrixKit.podspec locally to point to the same branch of 'MatrixSDK' as the current one if such one exists, or to develop otherwise"
   lane :point_podspec_to_same_feature do
     edit_podspec(branch_pattern: git_branch)
+  end
+
+
+  desc "Modify the Podfile of the sample app locally to point to the related MatrixSDK branch if such one exists,"
+  lane :point_sample_app_to_related_branches do
+    current_branch = git_branch
+    UI.message("Current branch: #{current_branch}")
+    if current_branch.start_with?("release/")
+        point_sample_app_to_pending_releases
+    else
+        point_sample_app_to_same_feature
+    end
   end
 
   desc "Modify the Podfile of the sample app locally to point to the latest 'release/*/release' branch of 'MatrixSDK' if such one exists, or to develop otherwise"
@@ -61,6 +85,7 @@ platform :ios do
   lane :point_sample_app_to_same_feature do
     edit_podfile(branch_pattern: git_branch)
   end
+
 
   desc "Send code to SonarCloud for analysis"
   lane :sonarcloud do |options|
@@ -83,7 +108,8 @@ platform :ios do
 
     sdk_slug = "matrix-org/matrix-ios-sdk"
     sdk_branch = find_branch(sdk_slug, options[:branch_pattern]) || 'develop'
-    
+    UI.message("✏️ Editing MatrixKit.podspec to point MatrixSDK to #{sdk_branch}...")
+
     local_podspec_dir = '../' # current dir is 'fastlane/' hence the '../'
     FileUtils.mkdir_p(local_podspec_dir)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,21 @@ platform :ios do
     )
   end
 
+  desc "Run tests"
+  lane :test do
+    cocoapods
+
+    run_tests(
+      workspace: "MatrixKit.xcworkspace",
+      scheme: "MatrixKitSample",
+      code_coverage: true,
+      # Test result configuration
+      result_bundle: true,
+      output_directory: "./build/test",
+      open_report: !is_ci?
+    )
+  end
+
   desc "Modify the MatrixKit.podspec locally to point to the latest 'release/*/release' branch of 'MatrixSDK' if such one exists, or to develop otherwise"
   lane :point_podspec_to_pending_releases do
     edit_podspec(branch_pattern: "release/*/release")


### PR DESCRIPTION
Those GH actions check:
 - pod lib lint
 - tests
 - Sample app build

BK checks are broken. I am going to disable it. 
The tests build is going to be fixed in the SDK with https://github.com/vector-im/element-ios/issues/4258. 

History is a bit useless. I needed to play to make fastlane `git_branch` lane work so that we can have a different behavior between release PRS and others.
Element-iOS GH actions will need to have this update.
