### PR TITLE
Expose current HTTP Operation in MXKAuthenticationViewController

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXKAuthenticationVC: Expose current HTTP Operation (vector-im/element-ios/issues/4276)
 
 🐛 Bugfix
  * 

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.h
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.h
@@ -148,6 +148,11 @@
 @property (nonatomic) id<MXKAuthenticationViewControllerDelegate> delegate;
 
 /**
+ current ongoing MXHTTPOperation. Nil if none.
+ */
+@property (nonatomic, nullable, readonly) MXHTTPOperation *currentHttpOperation;
+
+/**
  Returns the `UINib` object initialized for a `MXKAuthenticationViewController`.
  
  @return The initialized `UINib` object or `nil` if there were errors during initialization

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -1435,6 +1435,11 @@
     }
 }
 
+- (MXHTTPOperation *)currentHttpOperation
+{
+    return mxCurrentOperation;
+}
+
 #pragma mark - Privates
 
 - (NSString *)deviceDisplayName


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/4276