### PR TITLE
MXKAccount: Log reasons for incompatible sync filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Changes to be released in next version
 🙌 Improvements
  * MXKEventFormatter: Expose defaultRoomSummaryUpdater ivar as protected.
  * MXKCallViewController: Add transfer button and implement actions.
- * MXKAuthenticationVC: Expose current HTTP Operation (vector-im/element-ios/issues/4276)
+ * MXKAuthenticationVC: Expose current HTTP Operation (vector-im/element-ios/issues/4276).
+ * MXKAccount: Log reasons for incompatible sync filter (vector-im/element-ios/issues/3921).
 
 🐛 Bugfix
  * 

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -2019,6 +2019,8 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
     else if (!syncFilter || !mxSession.syncFilterId)
     {
         // Change from no filter with using a filter or vice-versa. So, there is a filter change
+        NSLog(@"[MXKAccount] checkSyncFilterCompatibility: Incompatible filter. New or old is nil. mxSession.syncFilterId: %@ - syncFilter: %@",
+              mxSession.syncFilterId, syncFilter.JSONDictionary);
         completion(NO);
     }
     else
@@ -2032,7 +2034,11 @@ static MXKAccountOnCertificateChange _onCertificateChangeBlock;
             // Note: We could be more tolerant here
             // We could accept filter hot change if the change is limited to the `limit` filter value
             // But we do not have this requirement yet
-            completion([filterId isEqualToString:self.mxSession.syncFilterId]);
+            BOOL compatible = [filterId isEqualToString:self.mxSession.syncFilterId];
+            NSLog(@"[MXKAccount] checkSyncFilterCompatibility: Incompatible filter id. New or old is nil. mxSession.syncFilterId: %@ -  store.filterId: %@ - syncFilter: %@",
+                  self.mxSession.syncFilterId, filterId, syncFilter.JSONDictionary);
+            
+            completion(compatible);
 
         } failure:^(NSError * _Nullable error) {
             // Should never happen


### PR DESCRIPTION
To be better understand what is happening in https://github.com/vector-im/element-ios/issues/3921#issuecomment-833517115
