### PR TITLE
MXKRoomDataSource: Decrypt unsent messages to follow MatrixSDK changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXKRoomDataSource: Decrypt unsent messages to follow MatrixSDK changes.
 
 🐛 Bugfix
  * 


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/1091
Part of vector-im/element-ios#4306.

Decryptions are also no more required. They must be done upstream now from asynchronous operations.