### PR TITLE
Fix status text of a remotely held call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * MXRoomSummary: Adapt removal of `lastMessageEvent` property (vector-im/element-ios/issues/4360).
 
 🐛 Bugfix
- * 
+ * MXKCallViewController: Fix status text of a remotely held call.
 
 ⚠️ API Changes
  * 

--- a/MatrixKit/Controllers/MXKCallViewController.m
+++ b/MatrixKit/Controllers/MXKCallViewController.m
@@ -58,6 +58,9 @@ static const CGFloat kLocalPreviewMargin = 20;
     
     // Current alert (if any).
     UIAlertController *currentAlert;
+    
+    //  Current peer display name
+    NSString *peerDisplayName;
 }
 
 @property (nonatomic, assign) Boolean isRinging;
@@ -455,7 +458,6 @@ static const CGFloat kLocalPreviewMargin = 20;
 
 - (void)updatePeerInfoDisplay
 {
-    NSString *peerDisplayName;
     NSString *peerAvatarURL;
     
     if (_peer)
@@ -965,7 +967,7 @@ static const CGFloat kLocalPreviewMargin = 20;
             speakerButton.enabled = NO;
             cameraSwitchButton.enabled = NO;
             _moreButton.enabled = NO;
-            callStatusLabel.text = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"call_remote_holded"], callerNameLabel.text];
+            callStatusLabel.text = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"call_remote_holded"], peerDisplayName];
             
             break;
         case MXCallStateInviteExpired:
@@ -1067,7 +1069,6 @@ static const CGFloat kLocalPreviewMargin = 20;
     if (assertedIdentity)
     {
         //  update caller display name and avatar with the asserted identity
-        NSString *peerDisplayName;
         NSString *peerAvatarURL = assertedIdentity.avatarUrl;
         
         if (assertedIdentity.displayname)


### PR DESCRIPTION
Fix https://github.com/matrix-org/element-ios-rageshakes/issues/10045