### PR TITLE
MXKAttachment: Adapt `mimetype` Changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * MXRoomSummary: Adapt removal of `lastMessageEvent` property (vector-im/element-ios/issues/4360).
+ * MXKAttachment: Adapt removal of `mimetype` fields (vector-im/element-ios/issues/4303).
 
 🐛 Bugfix
  * MXKCallViewController: Fix status text of a remotely held call.

--- a/MatrixKit/Models/Room/MXKAttachment.m
+++ b/MatrixKit/Models/Room/MXKAttachment.m
@@ -193,11 +193,6 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
 
 - (NSString *)getThumbnailMimeType
 {
-    if (thumbnailFile)
-    {
-        return thumbnailFile.mimetype;
-    }
-    
     return _thumbnailInfo[@"mimetype"];
 }
 
@@ -311,6 +306,7 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
         else
         {
             [_mediaManager downloadEncryptedMediaFromMatrixContentFile:thumbnailFile
+                                                              mimeType:_thumbnailMimeType
                                                               inFolder:_eventRoomId
                                                                success:^(NSString *outputFilePath) {
                                                                    decryptAndCache();
@@ -481,6 +477,7 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
             if (_isEncrypted)
             {
                 loader = [_mediaManager downloadEncryptedMediaFromMatrixContentFile:contentFile
+                                                                           mimeType:mimetype
                                                                            inFolder:_eventRoomId];
             }
             else


### PR DESCRIPTION
Part of vector-im/element-ios#4303

Requires https://github.com/matrix-org/matrix-ios-sdk/pull/1125