### PR TITLE
Fix display of emote replies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes to be released in next version
  * MXKCallViewController: Fix status text of a remotely held call.
  * MXKCallViewController: Fix avatar image for outgoing on hold calls.
  * MXKRoomViewController: Fix virtual timeline issues.
+ * MXKEventFormatter: Fix display of emote replies (vector-im/element-ios/issues/4081).
 
 ⚠️ API Changes
  * Exposed methods for sending audio files and voice messages (vector-im/element-ios/issues/4090).

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -26,6 +26,9 @@
 #define MXKTOOLS_EVENT_IDENTIFIER_BITWISE 0x08
 #define MXKTOOLS_GROUP_IDENTIFIER_BITWISE 0x10
 
+// Attribute in an NSAttributeString that marks a blockquote block that was in the original HTML string.
+extern NSString *const kMXKToolsBlockquoteMarkAttribute;
+
 /**
  Structure representing an the size of an image and its file size.
  */


### PR DESCRIPTION
This adjusts the position of the emote prefix in the case of replies by looking for the end of the quoted parent content.

![image](https://user-images.githubusercontent.com/279572/122660705-2e208d80-d17b-11eb-8682-d6449d54aca7.png)

Fixes https://github.com/vector-im/element-ios/issues/4081