### PR TITLE
Add authentication indicator container outlet.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * MXKCallViewController: Adapt new audio routing APIs.
+ * MXKAuthenticationViewController: Add authentication indicator container outlet (vector-im/element-ios/issues/4485).
 
 🐛 Bugfix
  * 

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.h
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.h
@@ -89,6 +89,7 @@
 @property (weak, nonatomic) IBOutlet UIButton *authSwitchButton;
 
 @property (strong, nonatomic) IBOutlet UIActivityIndicatorView *authenticationActivityIndicator;
+@property (weak, nonatomic) IBOutlet UIView *authenticationActivityIndicatorContainerView;
 @property (weak, nonatomic) IBOutlet UILabel *noFlowLabel;
 @property (weak, nonatomic) IBOutlet UIButton *retryButton;
 


### PR DESCRIPTION
Adds `authenticationActivityIndicatorContainerView` outlet for https://github.com/vector-im/element-ios/pull/4491.

It seemed more logical to have this in `MXKAuthenticationViewController.h`, as it keeps it along side the `authenticationActivityIndicator` outlet.