### PR TITLE
Tidy up following on from element-ios#4530

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.h
+++ b/MatrixKit/Models/Account/MXKAccount.h
@@ -223,12 +223,6 @@ typedef BOOL (^MXKAccountOnCertificateChange)(MXKAccount *mxAccount, NSData *cer
 @property (nonatomic,getter=isWarnedAboutEncryption) BOOL warnedAboutEncryption;
 
 /**
- Flag indicating whether to show decrypted content in notifications.
- NO by default
- */
-@property (nonatomic) BOOL showDecryptedContentInNotifications;
-
-/**
  Register the MXKAccountOnCertificateChange block that will be used to handle certificate change during account use.
  This block is nil by default, any new certificate is ignored/untrusted (this will abort the connection to the server).
  

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -227,8 +227,6 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
 
         _warnedAboutEncryption = [coder decodeBoolForKey:@"warnedAboutEncryption"];
         
-        _showDecryptedContentInNotifications = [coder decodeBoolForKey:@"showDecryptedContentInNotifications"];
-        
         _others = [coder decodeObjectForKey:@"others"];
         
         // Refresh device information
@@ -288,8 +286,6 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     [coder encodeBool:_isSoftLogout forKey:@"isSoftLogout"];
 
     [coder encodeBool:_warnedAboutEncryption forKey:@"warnedAboutEncryption"];
-    
-    [coder encodeBool:_showDecryptedContentInNotifications forKey:@"showDecryptedContentInNotifications"];
     
     [coder encodeObject:_others forKey:@"others"];
 }
@@ -610,14 +606,6 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
 {
     _warnedAboutEncryption = warnedAboutEncryption;
 
-    // Archive updated field
-    [[MXKAccountManager sharedManager] saveAccounts];
-}
-
-- (void)setShowDecryptedContentInNotifications:(BOOL)showDecryptedContentInNotifications
-{
-    _showDecryptedContentInNotifications = showDecryptedContentInNotifications;
-    
     // Archive updated field
     [[MXKAccountManager sharedManager] saveAccounts];
 }

--- a/changelog.d/4519.api
+++ b/changelog.d/4519.api
@@ -1,0 +1,1 @@
+MXKAccount: Remove unused showDecryptedContentInNotifications property.


### PR DESCRIPTION
Following on from https://github.com/vector-im/element-ios/pull/4530 this removes `showDecryptedContentInNotifications` from `MXKAccount` as it is no longer used.