### PR TITLE
Add support for sending slow motion videos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * MXKRoomViewController, MXKRoomDataSource & MXKRoomInputToolbarView: `sendVideo` methods now take an `AVAsset` instead of an `NSURL`.
+ * MXKRoomViewController, MXKRoomDataSource & MXKRoomInputToolbarView: `sendVideo` methods now take an `AVAsset` instead of an `NSURL`  (vector-im/element-ios/issues/4483).
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,13 @@ Changes to be released in next version
 
 🙌 Improvements
  * MXKAttachment: Add support for all voice message types (vector-im/element-ios/issues/4094).
+ * MXKRoomViewController, MXKRoomDataSource & MXKRoomInputToolbarView: Add methods to send videos as `AVAsset` objects (vector-im/element-ios/issues/4483).
 
 🐛 Bugfix
  * 
 
 ⚠️ API Changes
- * MXKRoomViewController, MXKRoomDataSource & MXKRoomInputToolbarView: `sendVideo` methods now take an `AVAsset` instead of an `NSURL`  (vector-im/element-ios/issues/4483).
+ *
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- *
+ * 
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * 
+ * MXKRoomViewController, MXKRoomDataSource & MXKRoomInputToolbarView: `sendVideo` methods now take an `AVAsset` instead of an `NSURL`.
 
 🗣 Translations
  * 

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -3505,10 +3505,16 @@
     }];
 }
 
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(NSURL*)videoLocalURL withThumbnail:(UIImage*)videoThumbnail
+{
+    AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
+    [self roomInputToolbarView:toolbarView sendVideoAsset:videoAsset withThumbnail:videoThumbnail];
+}
+
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideoAsset:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail
 {
     // Let the datasource send it and manage the local echo
-    [roomDataSource sendVideo:videoAsset withThumbnail:videoThumbnail success:nil failure:^(NSError *error)
+    [roomDataSource sendVideoAsset:videoAsset withThumbnail:videoThumbnail success:nil failure:^(NSError *error)
     {
         // Nothing to do. The video is marked as unsent in the room history by the datasource
         MXLogDebug(@"[MXKRoomViewController] sendVideo failed.");

--- a/MatrixKit/Controllers/MXKRoomViewController.m
+++ b/MatrixKit/Controllers/MXKRoomViewController.m
@@ -3505,10 +3505,10 @@
     }];
 }
 
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(NSURL*)videoLocalURL withThumbnail:(UIImage*)videoThumbnail
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail
 {
     // Let the datasource send it and manage the local echo
-    [roomDataSource sendVideo:videoLocalURL withThumbnail:videoThumbnail success:nil failure:^(NSError *error)
+    [roomDataSource sendVideo:videoAsset withThumbnail:videoThumbnail success:nil failure:^(NSError *error)
     {
         // Nothing to do. The video is marked as unsent in the room history by the datasource
         MXLogDebug(@"[MXKRoomViewController] sendVideo failed.");

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -488,18 +488,18 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 - (void)sendImage:(NSData*)imageData mimeType:(NSString*)mimetype success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure;
 
 /**
- Send an video to the room.
+ Send a video to the room.
 
  While sending, a fake event will be echoed in the messages list.
  Once complete, this local echo will be replaced by the event saved by the homeserver.
 
- @param videoLocalURL the local filesystem path of the video to send.
+ @param videoAsset the AVAsset that represents the video to send.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver
  @param failure A block object called when the operation fails.
  */
-- (void)sendVideo:(NSURL*)videoLocalURL
+- (void)sendVideo:(AVAsset*)videoAsset
     withThumbnail:(UIImage*)videoThumbnail
           success:(void (^)(NSString *eventId))success
           failure:(void (^)(NSError *error))failure;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -493,16 +493,33 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  While sending, a fake event will be echoed in the messages list.
  Once complete, this local echo will be replaced by the event saved by the homeserver.
 
+ @param videoLocalURL the local filesystem path of the video to send.
+ @param videoThumbnail the UIImage hosting a video thumbnail.
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the homeserver
+ @param failure A block object called when the operation fails.
+ */
+- (void)sendVideo:(NSURL*)videoLocalURL
+    withThumbnail:(UIImage*)videoThumbnail
+          success:(void (^)(NSString *eventId))success
+          failure:(void (^)(NSError *error))failure;
+
+/**
+ Send a video to the room.
+
+ While sending, a fake event will be echoed in the messages list.
+ Once complete, this local echo will be replaced by the event saved by the homeserver.
+
  @param videoAsset the AVAsset that represents the video to send.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver
  @param failure A block object called when the operation fails.
  */
-- (void)sendVideo:(AVAsset*)videoAsset
-    withThumbnail:(UIImage*)videoThumbnail
-          success:(void (^)(NSString *eventId))success
-          failure:(void (^)(NSError *error))failure;
+- (void)sendVideoAsset:(AVAsset*)videoAsset
+         withThumbnail:(UIImage*)videoThumbnail
+               success:(void (^)(NSString *eventId))success
+               failure:(void (^)(NSError *error))failure;
 
 /**
  Send an audio file to the room.

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1851,7 +1851,13 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 }
 
-- (void)sendVideo:(AVAsset *)videoAsset withThumbnail:(UIImage *)videoThumbnail success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
+- (void)sendVideo:(NSURL *)videoLocalURL withThumbnail:(UIImage *)videoThumbnail success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
+{
+    AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
+    [self sendVideoAsset:videoAsset withThumbnail:videoThumbnail success:success failure:failure];
+}
+
+- (void)sendVideoAsset:(AVAsset *)videoAsset withThumbnail:(UIImage *)videoThumbnail success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
 {
     __block MXEvent *localEchoEvent = nil;
     

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1851,11 +1851,11 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
     }
 }
 
-- (void)sendVideo:(NSURL *)videoLocalURL withThumbnail:(UIImage *)videoThumbnail success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
+- (void)sendVideo:(AVAsset *)videoAsset withThumbnail:(UIImage *)videoThumbnail success:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
 {
     __block MXEvent *localEchoEvent = nil;
     
-    [_room sendVideo:videoLocalURL withThumbnail:videoThumbnail localEcho:&localEchoEvent success:success failure:failure];
+    [_room sendVideo:videoAsset withThumbnail:videoThumbnail localEcho:&localEchoEvent success:success failure:failure];
     
     if (localEchoEvent)
     {

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1855,7 +1855,7 @@ NSString *const kMXKRoomDataSourceTimelineErrorErrorKey = @"kMXKRoomDataSourceTi
 {
     __block MXEvent *localEchoEvent = nil;
     
-    [_room sendVideo:videoAsset withThumbnail:videoThumbnail localEcho:&localEchoEvent success:success failure:failure];
+    [_room sendVideoAsset:videoAsset withThumbnail:videoThumbnail localEcho:&localEchoEvent success:success failure:failure];
     
     if (localEchoEvent)
     {

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -113,10 +113,19 @@ typedef enum : NSUInteger
  Tells the delegate that the user wants to send a video.
  
  @param toolbarView the room input toolbar view.
+ @param videoLocalURL the local filesystem path of the video to send.
+ @param videoThumbnail the UIImage hosting a video thumbnail.
+ */
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(NSURL*)videoLocalURL withThumbnail:(UIImage*)videoThumbnail;
+
+/**
+ Tells the delegate that the user wants to send a video.
+ 
+ @param toolbarView the room input toolbar view.
  @param videoAsset the AVAsset that represents the video to send.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  */
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail;
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideoAsset:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail;
 
 /**
  Tells the delegate that the user wants to send a file.
@@ -275,10 +284,19 @@ typedef enum : NSUInteger
  Handle video attachment.
  Save the video in user's photos library when 'isPhotoLibraryAsset' flag is NO and auto saving is enabled.
  
+ @param selectedVideo the local url of the video to send.
+ @param isPhotoLibraryAsset tell whether the video has been selected from user's photos library.
+ */
+- (void)sendSelectedVideo:(NSURL*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
+
+/**
+ Handle video attachment.
+ Save the video in user's photos library when 'isPhotoLibraryAsset' flag is NO and auto saving is enabled.
+ 
  @param selectedVideo an AVAsset that represents the video to send.
  @param isPhotoLibraryAsset tell whether the video has been selected from user's photos library.
  */
-- (void)sendSelectedVideo:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
+- (void)sendSelectedVideoAsset:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
 
 /**
  Handle multiple media attachments according to the compression mode.

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -113,10 +113,10 @@ typedef enum : NSUInteger
  Tells the delegate that the user wants to send a video.
  
  @param toolbarView the room input toolbar view.
- @param videoLocalURL the local filesystem path of the video to send.
+ @param videoAsset the AVAsset that represents the video to send.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  */
-- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(NSURL*)videoLocalURL withThumbnail:(UIImage*)videoThumbnail;
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView sendVideo:(AVAsset*)videoAsset withThumbnail:(UIImage*)videoThumbnail;
 
 /**
  Tells the delegate that the user wants to send a file.
@@ -275,10 +275,10 @@ typedef enum : NSUInteger
  Handle video attachment.
  Save the video in user's photos library when 'isPhotoLibraryAsset' flag is NO and auto saving is enabled.
  
- @param selectedVideo the local url of the video to send.
+ @param selectedVideo an AVAsset that represents the video to send.
  @param isPhotoLibraryAsset tell whether the video has been selected from user's photos library.
  */
-- (void)sendSelectedVideo:(NSURL*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
+- (void)sendSelectedVideo:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset;
 
 /**
  Handle multiple media attachments according to the compression mode.

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -762,7 +762,13 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     }
 }
 
-- (void)sendSelectedVideo:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset
+- (void)sendSelectedVideo:(NSURL*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset
+{
+    AVURLAsset *videoAsset = [AVURLAsset assetWithURL:selectedVideo];
+    [self sendSelectedVideoAsset:videoAsset isPhotoLibraryAsset:isPhotoLibraryAsset];
+}
+
+- (void)sendSelectedVideoAsset:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset
 {
     // Check condition before saving this media in user's library
     if (_enableAutoSaving && !isPhotoLibraryAsset)
@@ -778,7 +784,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         }
     }
     
-    if ([self.delegate respondsToSelector:@selector(roomInputToolbarView:sendVideo:withThumbnail:)])
+    if ([self.delegate respondsToSelector:@selector(roomInputToolbarView:sendVideoAsset:withThumbnail:)])
     {
         // Retrieve the video frame at 1 sec to define the video thumbnail
         AVAssetImageGenerator *assetImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:selectedVideo];
@@ -790,7 +796,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         UIImage* videoThumbnail = [[UIImage alloc] initWithCGImage:imageRef];
         CFRelease(imageRef);
         
-        [self.delegate roomInputToolbarView:self sendVideo:selectedVideo withThumbnail:videoThumbnail];
+        [self.delegate roomInputToolbarView:self sendVideoAsset:selectedVideo withThumbnail:videoThumbnail];
     }
     else
     {

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -767,8 +767,15 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     // Check condition before saving this media in user's library
     if (_enableAutoSaving && !isPhotoLibraryAsset)
     {
-        // FIXME: Get the asset's URL if it came from the camera
-//        [MXMediaManager saveMediaToPhotosLibrary:selectedVideo isImage:NO success:nil failure:nil];
+        if ([selectedVideo isKindOfClass:[AVURLAsset class]])
+        {
+            AVURLAsset *urlAsset = (AVURLAsset*)selectedVideo;
+            [MXMediaManager saveMediaToPhotosLibrary:[urlAsset URL] isImage:NO success:nil failure:nil];
+        }
+        else
+        {
+            MXLogError(@"[RoomInputToolbarView] Unable to save video, incorrect asset type.")
+        }
     }
     
     if ([self.delegate respondsToSelector:@selector(roomInputToolbarView:sendVideo:withThumbnail:)])

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -762,19 +762,19 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     }
 }
 
-- (void)sendSelectedVideo:(NSURL*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset
+- (void)sendSelectedVideo:(AVAsset*)selectedVideo isPhotoLibraryAsset:(BOOL)isPhotoLibraryAsset
 {
     // Check condition before saving this media in user's library
     if (_enableAutoSaving && !isPhotoLibraryAsset)
     {
-        [MXMediaManager saveMediaToPhotosLibrary:selectedVideo isImage:NO success:nil failure:nil];
+        // FIXME: Get the asset's URL if it came from the camera
+//        [MXMediaManager saveMediaToPhotosLibrary:selectedVideo isImage:NO success:nil failure:nil];
     }
     
     if ([self.delegate respondsToSelector:@selector(roomInputToolbarView:sendVideo:withThumbnail:)])
     {
         // Retrieve the video frame at 1 sec to define the video thumbnail
-        AVURLAsset *urlAsset = [[AVURLAsset alloc] initWithURL:selectedVideo options:nil];
-        AVAssetImageGenerator *assetImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:urlAsset];
+        AVAssetImageGenerator *assetImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:selectedVideo];
         assetImageGenerator.appliesPreferredTrackTransform = YES;
         CMTime time = CMTimeMake(1, 1);
         CGImageRef imageRef = [assetImageGenerator copyCGImageAtTime:time actualTime:NULL error:nil];


### PR DESCRIPTION
Slow motion videos are returned from the photos picker as AVComposition objects.

- `sendVideo:` methods now take an `AVAsset` instead of an `NSURL`.

Part of https://github.com/vector-im/element-ios/pull/4541 along with https://github.com/matrix-org/matrix-ios-sdk/pull/1153