### PR TITLE
Standardise casing of identity server

### DIFF
--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -26,7 +26,7 @@
 "login_server_url_placeholder" = "URL (e.g. https://matrix.org)";
 "login_home_server_title" = "Homeserver URL:";
 "login_home_server_info" = "Your homeserver stores all your conversations and account data";
-"login_identity_server_title" = "Identity Server URL:";
+"login_identity_server_title" = "Identity server URL:";
 "login_identity_server_info" = "Matrix provides identity servers to track which emails etc. belong to which Matrix IDs. Only https://matrix.org currently exists.";
 "login_user_id_placeholder" = "Matrix ID (e.g. @bob:matrix.org or bob)";
 "login_password_placeholder" = "Password";
@@ -36,8 +36,8 @@
 "login_email_placeholder" = "Email address";
 "login_prompt_email_token" = "Please enter your email validation token:";
 "login_error_title" = "Login Failed";
-"login_error_no_login_flow" = "We failed to retrieve authentication information from this Home Server";
-"login_error_do_not_support_login_flows" = "Currently we do not support any or all login flows defined by this Home Server";
+"login_error_no_login_flow" = "We failed to retrieve authentication information from this homeserver";
+"login_error_do_not_support_login_flows" = "Currently we do not support any or all login flows defined by this homeserver";
 "login_error_registration_is_not_supported" = "Registration is not currently supported";
 "login_error_forbidden" = "Invalid username/password";
 "login_error_unknown_token" = "The access token specified was not recognised";

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -75,7 +75,7 @@
     NSTimer* registrationTimer;
 
     /**
-     Identity Server discovery.
+     Identity server discovery.
      */
     MXAutoDiscovery *autoDiscovery;
 

--- a/MatrixKit/Controllers/MXKAuthenticationViewController.xib
+++ b/MatrixKit/Controllers/MXKAuthenticationViewController.xib
@@ -157,7 +157,7 @@
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wgD-7Z-30S" userLabel="IdentityServerView">
                                     <rect key="frame" x="115" y="462" width="370" height="30"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity Server:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5CT-Ht-Z3v">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity server:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5CT-Ht-Z3v">
                                             <rect key="frame" x="0.0" y="6" width="114" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="114" id="zee-RK-6DE"/>

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -2123,7 +2123,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
 }
 
 
-#pragma mark - Identity Server updates
+#pragma mark - Identity server updates
 
 - (void)registerAccountDataDidChangeIdentityServerNotification
 {
@@ -2148,7 +2148,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
 }
 
 
-#pragma mark - Identity Server Access Token updates
+#pragma mark - Identity server Access Token updates
 
 - (void)identityService:(MXIdentityService *)identityService didUpdateAccessToken:(NSString *)accessToken
 {

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -1453,7 +1453,7 @@ NSString *const MXKContactManagerDataType = @"org.matrix.kit.MXKContactManagerDa
 }
 
 
-#pragma mark - Identity Server updates
+#pragma mark - Identity server updates
 
 - (void)registerAccountDataDidChangeIdentityServerNotification
 {

--- a/changelog.d/857.misc
+++ b/changelog.d/857.misc
@@ -1,0 +1,1 @@
+MXKAuthenticationViewController: Standardise spelling and casing of homeserver and identity server


### PR DESCRIPTION
This PR standardises the spelling and casing of the following terms, across the codebase, as per vector-im/element-ios#2655:

- homeserver
- identity server
- integration manager

While the issue mentions only user-visible text, this PR changes all instances of the terms, regardless of whether they're user-visible or not. I think there's value in standardising these terms even in non-user-visible text, so I went ahead and applied the changes to all text.

For reference, here's the script I used to find candidates for replacement: https://gist.github.com/psrpinto/b3787bae212d5d99649b517e2efd4dce

Related to vector-im/element-ios#4559