### PR TITLE
Decrypt attachments on a background thread.

### DIFF
--- a/MatrixKit/Models/Room/MXKAttachment.m
+++ b/MatrixKit/Models/Room/MXKAttachment.m
@@ -290,17 +290,18 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
             MXStrongifyAndReturnIfNil(self);
             NSInputStream *instream = [[NSInputStream alloc] initWithFileAtPath:self.thumbnailCachePath];
             NSOutputStream *outstream = [[NSOutputStream alloc] initToMemory];
-            NSError *err = [MXEncryptedAttachments decryptAttachment:self->thumbnailFile inputStream:instream outputStream:outstream];
-            if (err) {
-                MXLogDebug(@"Error decrypting attachment! %@", err.userInfo);
-                if (onFailure) onFailure(self, err);
-                return;
-            }
-            
-            UIImage *img = [UIImage imageWithData:[outstream propertyForKey:NSStreamDataWrittenToMemoryStreamKey]];
-            // Save this image to in-memory cache.
-            [MXMediaManager cacheImage:img withCachePath:self.thumbnailCachePath];
-            onSuccess(self, img);
+            [MXEncryptedAttachments decryptAttachment:self->thumbnailFile inputStream:instream outputStream:outstream success:^{
+                UIImage *img = [UIImage imageWithData:[outstream propertyForKey:NSStreamDataWrittenToMemoryStreamKey]];
+                // Save this image to in-memory cache.
+                [MXMediaManager cacheImage:img withCachePath:self.thumbnailCachePath];
+                onSuccess(self, img);
+            } failure:^(NSError *err) {
+                if (err) {
+                    MXLogDebug(@"Error decrypting attachment! %@", err.userInfo);
+                    if (onFailure) onFailure(self, err);
+                    return;
+                }
+            }];
         };
         
         if ([[NSFileManager defaultManager] fileExistsAtPath:_thumbnailCachePath])
@@ -398,13 +399,15 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
             // decrypt the encrypted file
             NSInputStream *instream = [[NSInputStream alloc] initWithFileAtPath:self.cacheFilePath];
             NSOutputStream *outstream = [[NSOutputStream alloc] initToMemory];
-            NSError *err = [MXEncryptedAttachments decryptAttachment:self->contentFile inputStream:instream outputStream:outstream];
-            if (err)
-            {
-                MXLogDebug(@"Error decrypting attachment! %@", err.userInfo);
-                return;
-            }
-            onSuccess([outstream propertyForKey:NSStreamDataWrittenToMemoryStreamKey]);
+            [MXEncryptedAttachments decryptAttachment:self->contentFile inputStream:instream outputStream:outstream success:^{
+                onSuccess([outstream propertyForKey:NSStreamDataWrittenToMemoryStreamKey]);
+            } failure:^(NSError *err) {
+                if (err)
+                {
+                    MXLogDebug(@"Error decrypting attachment! %@", err.userInfo);
+                    return;
+                }
+            }];
         }
         else
         {
@@ -428,12 +431,14 @@ NSString *const kMXKAttachmentErrorDomain = @"kMXKAttachmentErrorDomain";
         NSInputStream *inStream = [NSInputStream inputStreamWithFileAtPath:self.cacheFilePath];
         NSOutputStream *outStream = [NSOutputStream outputStreamToFileAtPath:tempPath append:NO];
         
-        NSError *err = [MXEncryptedAttachments decryptAttachment:self->contentFile inputStream:inStream outputStream:outStream];
-        if (err) {
-            if (onFailure) onFailure(err);
-            return;
-        }
-        onSuccess(tempPath);
+        [MXEncryptedAttachments decryptAttachment:self->contentFile inputStream:inStream outputStream:outStream success:^{
+            onSuccess(tempPath);
+        } failure:^(NSError *err) {
+            if (err) {
+                if (onFailure) onFailure(err);
+                return;
+            }
+        }];
     } failure:onFailure];
 }
 

--- a/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -554,7 +554,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  */
 - (void)sendVoiceMessage:(NSURL *)audioFileLocalURL
                 mimeType:mimeType
-                duration:(NSTimeInterval)duration
+                duration:(NSUInteger)duration
                  samples:(NSArray<NSNumber *> *)samples
                  success:(void (^)(NSString *))success
                  failure:(void (^)(NSError *))failure;

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1896,7 +1896,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
 
 - (void)sendVoiceMessage:(NSURL *)audioFileLocalURL
                 mimeType:mimeType
-                duration:(NSTimeInterval)duration
+                duration:(NSUInteger)duration
                  samples:(NSArray<NSNumber *> *)samples
                  success:(void (^)(NSString *))success
                  failure:(void (^)(NSError *))failure

--- a/MatrixKitTests/EncryptedAttachmentsTest.m
+++ b/MatrixKitTests/EncryptedAttachmentsTest.m
@@ -79,16 +79,16 @@
                    @"v": @"v1",
                    @"hashes": @{
                            @"sha256": @"LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
-                           },
+                   },
                    @"key": @{
                            @"kty": @"oct",
                            @"key_ops": @[@"encrypt",@"decrypt"],
                            @"k": @"__________________________________________8",
                            @"alg": @"A256CTR"
-                           },
+                   },
                    @"iv": @"/////////////////////w"
-                   }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
-     ];
+             }, @"YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
+        ];
     
     for (NSArray *vector in testVectors) {
         NSString *inputCiphertext = vector[0];
@@ -99,13 +99,15 @@
         NSInputStream *inputStream = [NSInputStream inputStreamWithData:ctData];
         NSOutputStream *outputStream = [NSOutputStream outputStreamToMemory];
         
-        NSError *err = [MXEncryptedAttachments decryptAttachment:inputInfo inputStream:inputStream outputStream:outputStream];
-        XCTAssertNil(err);
-        NSData *gotData = [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
-        
-        NSData *wantData = [[NSData alloc] initWithBase64EncodedString:[MXBase64Tools padBase64:want] options:0];
-        
-        XCTAssertEqualObjects(wantData, gotData, "Decrypted data did not match expectation.");
+        [MXEncryptedAttachments decryptAttachment:inputInfo inputStream:inputStream outputStream:outputStream success:^{
+            NSData *gotData = [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+            
+            NSData *wantData = [[NSData alloc] initWithBase64EncodedString:[MXBase64Tools padBase64:want] options:0];
+            
+            XCTAssertEqualObjects(wantData, gotData, "Decrypted data did not match expectation.");
+        } failure:^(NSError *error) {
+            XCTFail();
+        }];
     }
 }
 


### PR DESCRIPTION
Fixes vector-im/element-ios/issues/4577 - Decrypt attachments on a background thread.
