### PR TITLE
MXKEventFormatter: Update MXRoomSummaryUpdating conformance for MXRoomSummary.localUnreadEventCount caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXKEventFormatter: Update MXRoomSummaryUpdating conformance for MXRoomSummary.localUnreadEventCount caching (vector-im/element-ios/issues/4585).
 
 🐛 Bugfix
  * 

--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -2004,6 +2004,10 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     return [defaultRoomSummaryUpdater session:session updateRoomSummary:summary withServerRoomSummary:serverRoomSummary roomState:roomState];
 }
 
+- (BOOL)session:(MXSession *)session updateRoomSummaryLocalUnreadEventCount:(MXRoomSummary *)summary withTypeIn:(NSArray *)types
+{
+    return [defaultRoomSummaryUpdater session:session updateRoomSummaryLocalUnreadEventCount:summary withTypeIn:types];
+}
 
 #pragma mark - Conversion private methods
 


### PR DESCRIPTION
vector-im/element-ios/issues/4585