### PR TITLE
Release 0.15.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Changes in 0.15.8 (2021-08-11)
+
+No significant changes.
+
+
 ## Changes in 0.15.7 (2021-08-11)
 
 🙌 Improvements

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixKit"
-  s.version      = "0.15.7"
+  s.version      = "0.15.8"
   s.summary      = "The Matrix reusable UI library for iOS based on MatrixSDK."
 
   s.description  = <<-DESC

--- a/MatrixKit/MatrixKitVersion.m
+++ b/MatrixKit/MatrixKitVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixKitVersion = @"0.15.7";
+NSString *const MatrixKitVersion = @"0.15.8";

--- a/changelog.d/4393.build
+++ b/changelog.d/4393.build
@@ -1,1 +1,0 @@
-CHANGES.md: Use towncrier to manage the change log. More info in [CONTRIBUTING](CONTRIBUTING.md#changelog).

--- a/changelog.d/4393.doc
+++ b/changelog.d/4393.doc
@@ -1,1 +1,0 @@
-Convert CHANGES and CONTRIBUTING to MarkDown.

--- a/changelog.d/pr-873.build
+++ b/changelog.d/pr-873.build
@@ -1,1 +1,0 @@
-CHANGES.md: Use towncrier to manage the change log. More info in [CONTRIBUTING](CONTRIBUTING.md#changelog).


### PR DESCRIPTION
This PR prepares the release of MatrixKit v0.15.8.

Notes:
- This PR targets `release/0.15.8/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.15.8/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-kit/compare/develop...release/0.15.8/release)
