### PR TITLE
Doug/4484 contacts access

### DIFF
--- a/MatrixKit/Models/Contact/MXKContactManager.h
+++ b/MatrixKit/Models/Contact/MXKContactManager.h
@@ -17,6 +17,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Contacts/Contacts.h>
 
 #import <MatrixSDK/MatrixSDK.h>
 

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -509,182 +509,177 @@ NSString *const MXKContactManagerDataType = @"org.matrix.kit.MXKContactManagerDa
     
     NSDate *startDate = [NSDate date];
     
-    MXWeakify(self);
-    
-    [MXKTools checkAccessForContacts:nil showPopUpInViewController:nil completionHandler:^(BOOL granted) {
-
-        MXStrongifyAndReturnIfNil(self);
-        
-        if (!granted)
+    if ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts] != CNAuthorizationStatusAuthorized)
+    {
+        if ([MXKAppSettings standardAppSettings].syncLocalContacts)
         {
-            if ([MXKAppSettings standardAppSettings].syncLocalContacts)
-            {
-                // The user authorised syncLocalContacts and allowed access to his contacts
-                // but he then removed contacts access from app permissions.
-                // So, reset syncLocalContacts value
-                [MXKAppSettings standardAppSettings].syncLocalContacts = NO;
-            }
-            
-            // Local contacts list is empty if the access is denied.
-            self->localContactByContactID = nil;
-            self->localContactsWithMethods = nil;
-            self->splitLocalContacts = nil;
-            [self cacheLocalContacts];
-            
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKContactManagerDidUpdateLocalContactsNotification object:nil userInfo:nil];
-            
-            MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Complete");
-            MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Local contacts access denied");
+            // The user authorised syncLocalContacts and allowed access to his contacts
+            // but he then removed contacts access from app permissions.
+            // So, reset syncLocalContacts value
+            [MXKAppSettings standardAppSettings].syncLocalContacts = NO;
         }
-        else
+        
+        // Local contacts list is empty if the access is denied.
+        self->localContactByContactID = nil;
+        self->localContactsWithMethods = nil;
+        self->splitLocalContacts = nil;
+        [self cacheLocalContacts];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKContactManagerDidUpdateLocalContactsNotification object:nil userInfo:nil];
+        
+        MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Complete");
+        MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Local contacts access denied");
+    }
+    else
+    {
+        self->isLocalContactListRefreshing = YES;
+        
+        // Reset the internal contact lists (These arrays will be prepared only if need).
+        self->localContactsWithMethods = self->splitLocalContacts = nil;
+        
+        BOOL isColdStart = NO;
+        
+        // Check whether the local contacts sync has been disabled.
+        if (self->matrixIDBy3PID && ![MXKAppSettings standardAppSettings].syncLocalContacts)
         {
-            self->isLocalContactListRefreshing = YES;
+            // The user changed his mind and disabled the local contact sync, remove the cached data.
+            self->matrixIDBy3PID = nil;
+            [self cacheMatrixIDsDict];
             
-            // Reset the internal contact lists (These arrays will be prepared only if need).
-            self->localContactsWithMethods = self->splitLocalContacts = nil;
+            // Reload the local contacts from the system
+            self->localContactByContactID = nil;
+            [self cacheLocalContacts];
+        }
+        
+        // Check whether this is a cold start.
+        if (!self->matrixIDBy3PID)
+        {
+            isColdStart = YES;
             
-            BOOL isColdStart = NO;
+            // Load the dictionary from the file system. It is cached to improve UX.
+            [self loadCachedMatrixIDsDict];
+        }
+        
+        MXWeakify(self);
+        
+        dispatch_async(self->processingQueue, ^{
             
-            // Check whether the local contacts sync has been disabled.
-            if (self->matrixIDBy3PID && ![MXKAppSettings standardAppSettings].syncLocalContacts)
+            MXStrongifyAndReturnIfNil(self);
+
+            // In case of cold start, retrieve the data from the file system
+            if (isColdStart)
             {
-                // The user changed his mind and disabled the local contact sync, remove the cached data.
-                self->matrixIDBy3PID = nil;
-                [self cacheMatrixIDsDict];
-                
-                // Reload the local contacts from the system
-                self->localContactByContactID = nil;
+                [self loadCachedLocalContacts];
+                [self loadCachedContactBookInfo];
+
+                // no local contact -> assume that the last sync date is useless
+                if (self->localContactByContactID.count == 0)
+                {
+                    self->lastSyncDate = nil;
+                }
+            }
+
+            BOOL didContactBookChange = NO;
+
+            NSMutableArray* deletedContactIDs = [NSMutableArray arrayWithArray:[self->localContactByContactID allKeys]];
+
+            // can list local contacts?
+            if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusAuthorized)
+            {
+                NSString* countryCode = [[MXKAppSettings standardAppSettings] phonebookCountryCode];
+
+                ABAddressBookRef ab = ABAddressBookCreateWithOptions(nil, nil);
+                ABRecordRef      contactRecord;
+                CFIndex          index;
+                CFMutableArrayRef people = (CFMutableArrayRef)ABAddressBookCopyArrayOfAllPeople(ab);
+
+                if (nil != people)
+                {
+                    CFIndex peopleCount = CFArrayGetCount(people);
+
+                    for (index = 0; index < peopleCount; index++)
+                    {
+                        contactRecord = (ABRecordRef)CFArrayGetValueAtIndex(people, index);
+
+                        NSString* contactID = [MXKContact contactID:contactRecord];
+
+                        // the contact still exists
+                        [deletedContactIDs removeObject:contactID];
+
+                        if (self->lastSyncDate)
+                        {
+                            // ignore unchanged contacts since the previous sync
+                            CFDateRef lastModifDate = ABRecordCopyValue(contactRecord, kABPersonModificationDateProperty);
+                            if (lastModifDate)
+                            {
+                                if (kCFCompareGreaterThan != CFDateCompare(lastModifDate, (__bridge CFDateRef)self->lastSyncDate, nil))
+
+                                {
+                                    CFRelease(lastModifDate);
+                                    continue;
+                                }
+                                CFRelease(lastModifDate);
+                            }
+                        }
+
+                        didContactBookChange = YES;
+
+                        MXKContact* contact = [[MXKContact alloc] initLocalContactWithABRecord:contactRecord];
+
+                        if (countryCode)
+                        {
+                            contact.defaultCountryCode = countryCode;
+                        }
+
+                        // update the local contacts list
+                        [self->localContactByContactID setValue:contact forKey:contactID];
+                    }
+
+                    CFRelease(people);
+                }
+
+                if (ab)
+                {
+                    CFRelease(ab);
+                }
+            }
+
+            // some contacts have been deleted
+            for (NSString* contactID in deletedContactIDs)
+            {
+                didContactBookChange = YES;
+                [self->localContactByContactID removeObjectForKey:contactID];
+            }
+
+            // something has been modified in the local contact book
+            if (didContactBookChange)
+            {
                 [self cacheLocalContacts];
             }
             
-            // Check whether this is a cold start.
-            if (!self->matrixIDBy3PID)
-            {
-                isColdStart = YES;
-                
-                // Load the dictionary from the file system. It is cached to improve UX.
-                [self loadCachedMatrixIDsDict];
-            }
+            self->lastSyncDate = [NSDate date];
+            [self cacheContactBookInfo];
             
-            dispatch_async(self->processingQueue, ^{
+            // Update loaded contacts with the known dict 3PID -> matrix ID
+            [self updateAllLocalContactsMatrixIDs];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
                 
-                MXStrongifyAndReturnIfNil(self);
-
-                // In case of cold start, retrieve the data from the file system
-                if (isColdStart)
+                // Contacts are loaded, post a notification
+                self->isLocalContactListRefreshing = NO;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKContactManagerDidUpdateLocalContactsNotification object:nil userInfo:nil];
+                
+                // Check the conditions required before triggering a matrix users lookup.
+                if (isColdStart || didContactBookChange)
                 {
-                    [self loadCachedLocalContacts];
-                    [self loadCachedContactBookInfo];
-
-                    // no local contact -> assume that the last sync date is useless
-                    if (self->localContactByContactID.count == 0)
-                    {
-                        self->lastSyncDate = nil;
-                    }
-                }
-
-                BOOL didContactBookChange = NO;
-
-                NSMutableArray* deletedContactIDs = [NSMutableArray arrayWithArray:[self->localContactByContactID allKeys]];
-
-                // can list local contacts?
-                if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusAuthorized)
-                {
-                    NSString* countryCode = [[MXKAppSettings standardAppSettings] phonebookCountryCode];
-
-                    ABAddressBookRef ab = ABAddressBookCreateWithOptions(nil, nil);
-                    ABRecordRef      contactRecord;
-                    CFIndex          index;
-                    CFMutableArrayRef people = (CFMutableArrayRef)ABAddressBookCopyArrayOfAllPeople(ab);
-
-                    if (nil != people)
-                    {
-                        CFIndex peopleCount = CFArrayGetCount(people);
-
-                        for (index = 0; index < peopleCount; index++)
-                        {
-                            contactRecord = (ABRecordRef)CFArrayGetValueAtIndex(people, index);
-
-                            NSString* contactID = [MXKContact contactID:contactRecord];
-
-                            // the contact still exists
-                            [deletedContactIDs removeObject:contactID];
-
-                            if (self->lastSyncDate)
-                            {
-                                // ignore unchanged contacts since the previous sync
-                                CFDateRef lastModifDate = ABRecordCopyValue(contactRecord, kABPersonModificationDateProperty);
-                                if (lastModifDate)
-                                {
-                                    if (kCFCompareGreaterThan != CFDateCompare(lastModifDate, (__bridge CFDateRef)self->lastSyncDate, nil))
-
-                                    {
-                                        CFRelease(lastModifDate);
-                                        continue;
-                                    }
-                                    CFRelease(lastModifDate);
-                                }
-                            }
-
-                            didContactBookChange = YES;
-
-                            MXKContact* contact = [[MXKContact alloc] initLocalContactWithABRecord:contactRecord];
-
-                            if (countryCode)
-                            {
-                                contact.defaultCountryCode = countryCode;
-                            }
-
-                            // update the local contacts list
-                            [self->localContactByContactID setValue:contact forKey:contactID];
-                        }
-
-                        CFRelease(people);
-                    }
-
-                    if (ab)
-                    {
-                        CFRelease(ab);
-                    }
-                }
-
-                // some contacts have been deleted
-                for (NSString* contactID in deletedContactIDs)
-                {
-                    didContactBookChange = YES;
-                    [self->localContactByContactID removeObjectForKey:contactID];
-                }
-
-                // something has been modified in the local contact book
-                if (didContactBookChange)
-                {
-                    [self cacheLocalContacts];
+                    [self updateMatrixIDsForAllLocalContacts];
                 }
                 
-                self->lastSyncDate = [NSDate date];
-                [self cacheContactBookInfo];
-                
-                // Update loaded contacts with the known dict 3PID -> matrix ID
-                [self updateAllLocalContactsMatrixIDs];
-                
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    
-                    // Contacts are loaded, post a notification
-                    self->isLocalContactListRefreshing = NO;
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXKContactManagerDidUpdateLocalContactsNotification object:nil userInfo:nil];
-                    
-                    // Check the conditions required before triggering a matrix users lookup.
-                    if (isColdStart || didContactBookChange)
-                    {
-                        [self updateMatrixIDsForAllLocalContacts];
-                    }
-                    
-                    MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Complete");
-                    MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Refresh %tu local contacts in %.0fms", self->localContactByContactID.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
-                });
+                MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Complete");
+                MXLogDebug(@"[MXKContactManager] refreshLocalContacts : Refresh %tu local contacts in %.0fms", self->localContactByContactID.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
             });
-        }
-    }];
+        });
+    }
 }
 
 - (void)updateMatrixIDsForLocalContact:(MXKContact *)contact

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -162,10 +162,19 @@ typedef NS_ENUM(NSUInteger, MXKKeyPreSharingStrategy)
 /**
  Return YES if the user has been already asked for local contacts sync permission.
 
- This boolean value is defined in shared settings object with the key: `syncLocalContactsRequested`.
+ This boolean value is defined in shared settings object with the key: `syncLocalContactsPermissionRequested`.
  Return NO if no value is defined.
  */
 @property (nonatomic) BOOL syncLocalContactsPermissionRequested;
+
+/**
+ Return YES if after the user has been asked for local contacts sync permission and choose to open
+ the system's Settings app to enable contacts access.
+
+ This boolean value is defined in shared settings object with the key: `syncLocalContactsPermissionOpenedSystemSettings`.
+ Return NO if no value is defined.
+ */
+@property (nonatomic) BOOL syncLocalContactsPermissionOpenedSystemSettings;
 
 /**
  The current selected country code for the phonebook.

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -44,7 +44,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
 @synthesize syncWithLazyLoadOfRoomMembers;
 @synthesize showAllEventsInRoomHistory, showRedactionsInRoomHistory, showUnsupportedEventsInRoomHistory, httpLinkScheme, httpsLinkScheme;
 @synthesize showLeftMembersInRoomMemberList, sortRoomMembersUsingLastSeenTime;
-@synthesize syncLocalContacts, syncLocalContactsPermissionRequested, phonebookCountryCode;
+@synthesize syncLocalContacts, syncLocalContactsPermissionRequested, syncLocalContactsPermissionOpenedSystemSettings, phonebookCountryCode;
 @synthesize presenceColorForOnlineUser, presenceColorForUnavailableUser, presenceColorForOfflineUser;
 @synthesize enableCallKit;
 @synthesize sharedUserDefaults;
@@ -561,6 +561,30 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
     else
     {
         syncLocalContactsPermissionRequested = theSyncLocalContactsPermissionRequested;
+    }
+}
+
+- (BOOL)syncLocalContactsPermissionOpenedSystemSettings
+{
+    if (self == [MXKAppSettings standardAppSettings])
+    {
+        return [[NSUserDefaults standardUserDefaults] boolForKey:@"syncLocalContactsPermissionOpenedSystemSettings"];
+    }
+    else
+    {
+        return syncLocalContactsPermissionOpenedSystemSettings;
+    }
+}
+
+- (void)setSyncLocalContactsPermissionOpenedSystemSettings:(BOOL)theSyncLocalContactsPermissionOpenedSystemSettings
+{
+    if (self == [MXKAppSettings standardAppSettings])
+    {
+        [[NSUserDefaults standardUserDefaults] setBool:theSyncLocalContactsPermissionOpenedSystemSettings forKey:@"syncLocalContactsPermissionOpenedSystemSettings"];
+    }
+    else
+    {
+        syncLocalContactsPermissionOpenedSystemSettings = theSyncLocalContactsPermissionOpenedSystemSettings;
     }
 }
 

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -333,6 +333,25 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
      showPopUpInViewController:(UIViewController*)viewController
              completionHandler:(void (^)(BOOL granted))handler;
 
+/**
+ Check permission to access Contacts.
+
+ @discussion
+ If the access was not yet granted, a dialog will be shown to the user.
+ If it is the first attempt to access the media, the dialog is the classic iOS one.
+ Else, the dialog will ask the user to manually change the permission in the app settings.
+
+ @param manualChangeTitle the title to display if the end user must change the app settings manually.
+ @param manualChangeMessage the message to display if the end user must change the app settings manually.
+                            If nil, the dialog for displaying manualChangeMessage will not be shown.
+ @param viewController the view controller to attach the dialog displaying manualChangeMessage.
+ @param handler the block called with the result of requesting access
+ */
++ (void)checkAccessForContacts:(NSString *)manualChangeTitle
+       withManualChangeMessage:(NSString *)manualChangeMessage
+     showPopUpInViewController:(UIViewController *)viewController
+             completionHandler:(void (^)(BOOL granted))handler;
+
 #pragma mark - HTML processing
 
 /**

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -18,7 +18,7 @@
 #import "MXKTools.h"
 
 @import MatrixSDK;
-@import AddressBook;
+@import Contacts;
 @import libPhoneNumber_iOS;
 @import DTCoreText;
 
@@ -796,34 +796,23 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
              completionHandler:(void (^)(BOOL granted))handler
 {
     // Check if the application is allowed to list the contacts
-    ABAuthorizationStatus cbStatus = ABAddressBookGetAuthorizationStatus();
-    if (cbStatus == kABAuthorizationStatusAuthorized)
+    CNAuthorizationStatus authStatus = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+    if (authStatus == CNAuthorizationStatusAuthorized)
     {
         handler(YES);
     }
-    else if (cbStatus == kABAuthorizationStatusNotDetermined)
+    else if (authStatus == CNAuthorizationStatusNotDetermined)
     {
         // Request address book access
-        ABAddressBookRef ab = ABAddressBookCreateWithOptions(nil, nil);
-        if (ab)
-        {
-            ABAddressBookRequestAccessWithCompletion(ab, ^(bool granted, CFErrorRef error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-
-                    handler(granted);
-
-                });
+        [[CNContactStore new] requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError * _Nullable error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                
+                handler(granted);
+                
             });
-
-            CFRelease(ab);
-        }
-        else
-        {
-            // No phonebook
-            handler(YES);
-        }
+        }];
     }
-    else if (cbStatus == kABAuthorizationStatusDenied && viewController && manualChangeMessage)
+    else if (authStatus == CNAuthorizationStatusDenied && viewController && manualChangeMessage)
     {
         // Access not granted to the local contacts
         // Display manualChangeMessage


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/issues/4484.

Removes the automatic contacts access request when refreshing local contacts, instead behaving as if the user rejected access. This allows the app to decide the best time to make the request for access.

Additionally a new setting has been added to detect when the user has chosen "Settings" if they previously declined access. This can be used to check whether they enabled access the next time the app is launched.

* [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
