### PR TITLE
Add +videoConversionPromptForVideoAsset:withCompletion: to MXKTools.

### DIFF
--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -271,9 +271,9 @@
 "attachment_small" = "Small (~%@)";
 "attachment_medium" = "Medium (~%@)";
 "attachment_large" = "Large (~%@)";
-"attachment_small_with_resolution" = "Small %@ (%@)";
-"attachment_medium_with_resolution" = "Medium %@ (%@)";
-"attachment_large_with_resolution" = "Large %@ (%@)";
+"attachment_small_with_resolution" = "Small %@ (~%@)";
+"attachment_medium_with_resolution" = "Medium %@ (~%@)";
+"attachment_large_with_resolution" = "Large %@ (~%@)";
 "attachment_cancel_download" = "Cancel the download?";
 "attachment_cancel_upload" = "Cancel the upload?";
 "attachment_multiselection_size_prompt" = "Do you want to send images as:";

--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -265,10 +265,15 @@
 
 // Attachment
 "attachment_size_prompt" = "Do you want to send as:";
-"attachment_original" = "Actual Size: %@";
-"attachment_small" = "Small: %@";
-"attachment_medium" = "Medium: %@";
-"attachment_large" = "Large: %@";
+"attachment_size_prompt_title" = "Confirm size to send";
+"attachment_size_prompt_message" = "You can turn this off in settings.";
+"attachment_original" = "Actual Size (%@)";
+"attachment_small" = "Small (~%@)";
+"attachment_medium" = "Medium (~%@)";
+"attachment_large" = "Large (~%@)";
+"attachment_small_with_resolution" = "Small %@ (%@)";
+"attachment_medium_with_resolution" = "Medium %@ (%@)";
+"attachment_large_with_resolution" = "Large %@ (%@)";
 "attachment_cancel_download" = "Cancel the download?";
 "attachment_cancel_upload" = "Cancel the upload?";
 "attachment_multiselection_size_prompt" = "Do you want to send images as:";

--- a/MatrixKit/Utils/MXKTools.h
+++ b/MatrixKit/Utils/MXKTools.h
@@ -15,6 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 
 #define MXKTOOLS_LARGE_IMAGE_SIZE    1024
 #define MXKTOOLS_MEDIUM_IMAGE_SIZE   768
@@ -280,6 +281,15 @@ typedef struct
  @return the pattern color which can be used to define the background color of a view in order to display the provided image as its background.
  */
 + (UIColor*)convertImageToPatternColor:(NSString*)reourceName backgroundColor:(UIColor*)backgroundColor patternSize:(CGSize)patternSize resourceSize:(CGSize)resourceSize;
+
+#pragma mark - Video conversion
+/**
+Creates a `UIAlertController` with appropriate `AVAssetExportPreset` choices for the video passed in.
+ @param videoAsset The video to generate the choices for.
+ @param completion The block called when a preset has been chosen. `presetName` will contain the preset name or `nil` if cancelled.
+*/
++ (UIAlertController*)videoConversionPromptForVideoAsset:(AVAsset *)videoAsset
+                                           withCompletion:(void (^)(NSString * _Nullable presetName))completion;
 
 #pragma mark - App permissions
 

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -711,12 +711,17 @@ static NSMutableDictionary* backgroundByImageNameDict;
 + (UIAlertController*)videoConversionPromptForVideoAsset:(AVAsset *)videoAsset
                                            withCompletion:(void (^)(NSString * _Nullable presetName))completion
 {
-    UIAlertController *compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertController *compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_title"]
+                                                                               message:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_message"]
+                                                                        preferredStyle:UIAlertControllerStyleActionSheet];
     
     CGSize naturalSize = [videoAsset tracksWithMediaType:AVMediaTypeVideo].firstObject.naturalSize;
     
     // Provide 480p as the baseline preset.
-    [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], @"480p"]
+    #warning video file size not implemented.
+    NSString *fileSizeString = @"";
+    NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small_with_resolution"], @"480p", fileSizeString];
+    [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                           style:UIAlertActionStyleDefault
                                                         handler:^(UIAlertAction * action) {
         // Call the completion with 480p preset.
@@ -726,7 +731,9 @@ static NSMutableDictionary* backgroundByImageNameDict;
     // Allow 720p when the video exceeds 480p.
     if (naturalSize.height > 480)
     {
-        [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], @"720p"]
+        NSString *fileSizeString = @"";
+        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium_with_resolution"], @"720p", fileSizeString];
+        [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
                                                             handler:^(UIAlertAction * action) {
             // Call the completion with 720p preset.
@@ -737,7 +744,9 @@ static NSMutableDictionary* backgroundByImageNameDict;
     // Allow 1080p when the video exceeds 720p.
     if (naturalSize.height > 720)
     {
-        [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], @"1080p"]
+        NSString *fileSizeString = @"";
+        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large_with_resolution"], @"1080p", fileSizeString];
+        [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
                                                             handler:^(UIAlertAction * action) {
             // Call the completion with 1080p preset.
@@ -746,7 +755,7 @@ static NSMutableDictionary* backgroundByImageNameDict;
     }
     
     [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]
-                                                          style:UIAlertActionStyleDefault
+                                                          style:UIAlertActionStyleCancel
                                                         handler:^(UIAlertAction * action) {
         // Cancelled. Call the completion with nil.
         completion(nil);

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -706,6 +706,55 @@ static NSMutableDictionary* backgroundByImageNameDict;
     return bgColor;
 }
 
+#pragma mark - Video Conversion
+
++ (UIAlertController*)videoConversionPromptForVideoAsset:(AVAsset *)videoAsset
+                                           withCompletion:(void (^)(NSString * _Nullable presetName))completion
+{
+    UIAlertController *compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    
+    CGSize naturalSize = [videoAsset tracksWithMediaType:AVMediaTypeVideo].firstObject.naturalSize;
+    
+    // Provide 480p as the baseline preset.
+    [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], @"480p"]
+                                                          style:UIAlertActionStyleDefault
+                                                        handler:^(UIAlertAction * action) {
+        // Call the completion with 480p preset.
+        completion(AVAssetExportPreset640x480);
+    }]];
+    
+    // Allow 720p when the video exceeds 480p.
+    if (naturalSize.height > 480)
+    {
+        [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], @"720p"]
+                                                              style:UIAlertActionStyleDefault
+                                                            handler:^(UIAlertAction * action) {
+            // Call the completion with 720p preset.
+            completion(AVAssetExportPreset1280x720);
+        }]];
+    }
+    
+    // Allow 1080p when the video exceeds 720p.
+    if (naturalSize.height > 720)
+    {
+        [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], @"1080p"]
+                                                              style:UIAlertActionStyleDefault
+                                                            handler:^(UIAlertAction * action) {
+            // Call the completion with 1080p preset.
+            completion(AVAssetExportPreset1920x1080);
+        }]];
+    }
+    
+    [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]
+                                                          style:UIAlertActionStyleDefault
+                                                        handler:^(UIAlertAction * action) {
+        // Cancelled. Call the completion with nil.
+        completion(nil);
+    }]];
+    
+    return compressionPrompt;
+}
+
 #pragma mark - App permissions
 
 + (void)checkAccessForMediaType:(NSString *)mediaType

--- a/MatrixKit/Utils/MXKTools.m
+++ b/MatrixKit/Utils/MXKTools.m
@@ -23,6 +23,7 @@
 @import DTCoreText;
 
 #import "NSBundle+MatrixKit.h"
+#import <MatrixSDK/MXTools.h>
 
 #pragma mark - Constants definitions
 
@@ -718,8 +719,7 @@ static NSMutableDictionary* backgroundByImageNameDict;
     CGSize naturalSize = [videoAsset tracksWithMediaType:AVMediaTypeVideo].firstObject.naturalSize;
     
     // Provide 480p as the baseline preset.
-    #warning video file size not implemented.
-    NSString *fileSizeString = @"";
+    NSString *fileSizeString = [MXKTools estimatedFileSizeStringForVideoAsset:videoAsset withPresetName:AVAssetExportPreset640x480];
     NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small_with_resolution"], @"480p", fileSizeString];
     [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                           style:UIAlertActionStyleDefault
@@ -731,7 +731,7 @@ static NSMutableDictionary* backgroundByImageNameDict;
     // Allow 720p when the video exceeds 480p.
     if (naturalSize.height > 480)
     {
-        NSString *fileSizeString = @"";
+        NSString *fileSizeString = [MXKTools estimatedFileSizeStringForVideoAsset:videoAsset withPresetName:AVAssetExportPreset1280x720];
         NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium_with_resolution"], @"720p", fileSizeString];
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
@@ -744,7 +744,7 @@ static NSMutableDictionary* backgroundByImageNameDict;
     // Allow 1080p when the video exceeds 720p.
     if (naturalSize.height > 720)
     {
-        NSString *fileSizeString = @"";
+        NSString *fileSizeString = [MXKTools estimatedFileSizeStringForVideoAsset:videoAsset withPresetName:AVAssetExportPreset1920x1080];
         NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large_with_resolution"], @"1080p", fileSizeString];
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
@@ -762,6 +762,14 @@ static NSMutableDictionary* backgroundByImageNameDict;
     }]];
     
     return compressionPrompt;
+}
+
++ (NSString *)estimatedFileSizeStringForVideoAsset:(AVAsset *)videoAsset withPresetName:(NSString *)presetName
+{
+    AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:presetName];
+    exportSession.timeRange = CMTimeRangeMake(kCMTimeZero, videoAsset.duration);
+    
+    return [MXTools fileSizeToString:exportSession.estimatedOutputFileLength];
 }
 
 #pragma mark - App permissions

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -599,7 +599,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         return;
     }
 
-    // Get availabe sizes for this image
+    // Get available sizes for this image
     UIImage *image = [UIImage imageWithData:imageData];
     MXKImageCompressionSizes compressionSizes = [MXKTools availableCompressionSizesForImage:image originalFileSize:imageData.length];
 

--- a/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -609,13 +609,15 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     {
         __weak typeof(self) weakSelf = self;
         
-        compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_title"]
+                                                                message:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_message"]
+                                                         preferredStyle:UIAlertControllerStyleActionSheet];
         
         if (compressionSizes.small.fileSize)
         {
-            NSString *resolution = [NSString stringWithFormat:@"%@ (%d x %d)", [MXTools fileSizeToString:compressionSizes.small.fileSize round:NO], (int)compressionSizes.small.imageSize.width, (int)compressionSizes.small.imageSize.height];
+            NSString *fileSizeString = [MXTools fileSizeToString:compressionSizes.small.fileSize];
 
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], resolution];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], fileSizeString];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -637,9 +639,9 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         
         if (compressionSizes.medium.fileSize)
         {
-            NSString *resolution = [NSString stringWithFormat:@"%@ (%d x %d)", [MXTools fileSizeToString:compressionSizes.medium.fileSize round:NO], (int)compressionSizes.medium.imageSize.width, (int)compressionSizes.medium.imageSize.height];
+            NSString *fileSizeString = [MXTools fileSizeToString:compressionSizes.medium.fileSize];
 
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], resolution];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], fileSizeString];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -661,9 +663,9 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         
         if (compressionSizes.large.fileSize)
         {
-            NSString *resolution = [NSString stringWithFormat:@"%@ (%d x %d)", [MXTools fileSizeToString:compressionSizes.large.fileSize round:NO], (int)compressionSizes.large.imageSize.width, (int)compressionSizes.large.imageSize.height];
+            NSString *fileSizeString = [MXTools fileSizeToString:compressionSizes.large.fileSize];
 
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], resolution];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], fileSizeString];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -683,9 +685,9 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                                                                 }]];
         }
         
-        NSString *resolution = [NSString stringWithFormat:@"%@ (%d x %d)", [MXTools fileSizeToString:compressionSizes.original.fileSize round:NO], (int)compressionSizes.original.imageSize.width, (int)compressionSizes.original.imageSize.height];
+        NSString *fileSizeString = [MXTools fileSizeToString:compressionSizes.original.fileSize];
 
-        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_original"], resolution];
+        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_original"], fileSizeString];
         
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
@@ -704,7 +706,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                                                             }]];
         
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]
-                                                              style:UIAlertActionStyleDefault
+                                                              style:UIAlertActionStyleCancel
                                                             handler:^(UIAlertAction * action) {
                                                                 
                                                                 if (weakSelf)
@@ -836,13 +838,15 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         && (fileSizes.small || fileSizes.medium || fileSizes.large))
     {
         // Ask the user for the compression value
-        compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_multiselection_size_prompt"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        compressionPrompt = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_title"]
+                                                                message:[NSBundle mxk_localizedStringForKey:@"attachment_size_prompt_message"]
+                                                         preferredStyle:UIAlertControllerStyleActionSheet];
         
         __weak typeof(self) weakSelf = self;
 
         if (fileSizes.small)
         {
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], [MXTools fileSizeToString:fileSizes.small round:NO]];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_small"], [MXTools fileSizeToString:fileSizes.small]];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -862,7 +866,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
 
         if (fileSizes.medium)
         {
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], [MXTools fileSizeToString:fileSizes.medium round:NO]];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_medium"], [MXTools fileSizeToString:fileSizes.medium]];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -882,7 +886,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
 
         if (fileSizes.large)
         {
-            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], [MXTools fileSizeToString:fileSizes.large round:NO]];
+            NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_large"], [MXTools fileSizeToString:fileSizes.large]];
             
             [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                                   style:UIAlertActionStyleDefault
@@ -900,7 +904,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                                                                 }]];
         }
 
-        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_original"], [MXTools fileSizeToString:fileSizes.original round:NO]];
+        NSString *title = [NSString stringWithFormat:[NSBundle mxk_localizedStringForKey:@"attachment_original"], [MXTools fileSizeToString:fileSizes.original]];
         
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:title
                                                               style:UIAlertActionStyleDefault
@@ -918,7 +922,7 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                                                             }]];
         
         [compressionPrompt addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]
-                                                              style:UIAlertActionStyleDefault
+                                                              style:UIAlertActionStyleCancel
                                                             handler:^(UIAlertAction * action) {
                                                                 
                                                                 if (weakSelf)

--- a/changelog.d/4638.feature
+++ b/changelog.d/4638.feature
@@ -1,0 +1,1 @@
+MXKTools: Add +videoConversionPromptForVideoAsset:withCompletion: to create a UIAlertController with appropriate presets.


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/issues/4638 along with the PR https://github.com/vector-im/element-ios/pull/4721.

Additionally tweaks the strings used in the image compression mode prompt, and uses https://github.com/matrix-org/matrix-ios-sdk/pull/1218 for an updated file size string.