### PR TITLE
Fix timeline alignment bug

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -105,16 +105,19 @@
     
     if (!event.isEncrypted)
     {
-        if (event.isLocalEvent
-            || event.isState
-            || event.contentHasBeenEdited               // Local echo for an edit is clear but uses a true event id, the one of the edited event
-            || event.eventType == MXEventTypeReaction)  // Reaction events are unencrypted - without this, the cell data containing the sent reaction is misaligned
+        // Not all events are encrypted (e.g. reactions/redactions) and we only have encrypted cell subclasses for messages and attachments.
+        if (event.eventType == MXEventTypeRoomMessage || event.isMediaAttachment)
         {
-            shouldShowWarningBadge = NO;
-        }
-        else
-        {
-            shouldShowWarningBadge = YES;
+            if (event.isLocalEvent
+                || event.isState
+                || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event
+            {
+                shouldShowWarningBadge = NO;
+            }
+            else
+            {
+                shouldShowWarningBadge = YES;
+            }
         }
     }
     else if (event.decryptionError)

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -96,46 +96,51 @@
 
 - (BOOL)shouldShowWarningBadgeForEvent:(MXEvent*)event roomState:(MXRoomState*)roomState session:(MXSession*)session
 {
+    // Warning badges are unnecessary in unencrypted rooms
     if (!roomState.isEncrypted)
     {
         return NO;
     }
     
-    BOOL shouldShowWarningBadge = NO;
+    // Not all events are encrypted (e.g. state/reactions/redactions) and we only have encrypted cell subclasses for messages and attachments.
+    if (event.eventType != MXEventTypeRoomMessage && !event.isMediaAttachment)
+    {
+        return NO;
+    }
     
+    // Always show a warning badge if there was a decryption error.
+    if (event.decryptionError)
+    {
+        return YES;
+    }
+    
+    // Unencrypted message events should show a warning unless they're pending local echoes
     if (!event.isEncrypted)
     {
-        // Not all events are encrypted (e.g. reactions/redactions) and we only have encrypted cell subclasses for messages and attachments.
-        if (event.eventType == MXEventTypeRoomMessage || event.isMediaAttachment)
+        if (event.isLocalEvent
+            || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event
         {
-            if (event.isLocalEvent
-                || event.isState
-                || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event
-            {
-                shouldShowWarningBadge = NO;
-            }
-            else
-            {
-                shouldShowWarningBadge = YES;
-            }
+            return NO;
         }
+            
+        return YES;
     }
-    else if (event.decryptionError)
-    {
-        shouldShowWarningBadge = YES;
-    }
-    else if (event.sender)
+    
+    // The encryption is in a good state.
+    // Only show a warning badge if there are trust issues.
+    if (event.sender)
     {
         MXUserTrustLevel *userTrustLevel = [session.crypto trustLevelForUser:event.sender];
         MXDeviceInfo *deviceInfo = [session.crypto eventDeviceInfo:event];
         
         if (userTrustLevel.isVerified && !deviceInfo.trustLevel.isVerified)
         {
-            shouldShowWarningBadge = YES;
+            return YES;
         }
     }
     
-    return shouldShowWarningBadge;
+    // Everything was fine
+    return NO;
 }
 
 @end

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -107,7 +107,8 @@
     {
         if (event.isLocalEvent
             || event.isState
-            || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event
+            || event.contentHasBeenEdited               // Local echo for an edit is clear but uses a true event id, the one of the edited event
+            || event.eventType == MXEventTypeReaction)  // Reaction events are unencrypted - without this, the cell data containing the sent reaction is misaligned
         {
             shouldShowWarningBadge = NO;
         }

--- a/changelog.d/4510.bugfix
+++ b/changelog.d/4510.bugfix
@@ -1,1 +1,1 @@
-MXKRoomBubbleComponent: Ignore reaction events when computing whether to show a warning badge (fixes misaligned messages in the timeline).
+MXKRoomBubbleComponent: Only consider messages and attachments when computing whether to show a warning badge (fixes misaligned messages in the timeline).

--- a/changelog.d/4510.bugfix
+++ b/changelog.d/4510.bugfix
@@ -1,0 +1,1 @@
+MXKRoomBubbleComponent: Ignore reaction events when computing whether to show a warning badge (fixes misaligned messages in the timeline).


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4510 by ignoring reaction events when computing whether to show a warning badge.

From what I can tell, the cell data for the point in time when a reaction was sent would be wanting to show the encryption badge but without a component to show it, so would appear to be randomly indented.