### PR TITLE
Add notificationBodyLocalizationKey to MXKAppSettings.

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1241,10 +1241,12 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     NSString *appId = [[NSUserDefaults standardUserDefaults] objectForKey:@"pusherAppIdProd"];
 #endif
     
+    NSString *locKey = MXKAppSettings.standardAppSettings.notificationBodyLocalizationKey;
+    
     NSDictionary *pushData = @{
         @"url": self.pushGatewayURL,
         @"format": @"event_id_only",
-        @"default_payload": @{@"aps": @{@"mutable-content": @(1), @"alert": @{@"loc-key": @"NOTIFICATION", @"loc-args": @[]}}}
+        @"default_payload": @{@"aps": @{@"mutable-content": @(1), @"alert": @{@"loc-key": locKey, @"loc-args": @[]}}}
     };
     
     [self enablePusher:enabled appId:appId token:[MXKAccountManager sharedManager].apnsDeviceToken pushData:pushData success:^{

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1244,7 +1244,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     NSDictionary *pushData = @{
         @"url": self.pushGatewayURL,
         @"format": @"event_id_only",
-        @"default_payload": @{@"aps": @{@"mutable-content": @(1), @"alert": @{@"loc-key": @"MESSAGE", @"loc-args": @[]}}}
+        @"default_payload": @{@"aps": @{@"mutable-content": @(1), @"alert": @{@"loc-key": @"NOTIFICATION", @"loc-args": @[]}}}
     };
     
     [self enablePusher:enabled appId:appId token:[MXKAccountManager sharedManager].apnsDeviceToken pushData:pushData success:^{

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -202,10 +202,20 @@ typedef NS_ENUM(NSUInteger, MXKKeyPreSharingStrategy)
  */
 @property (nonatomic) UIColor *presenceColorForOfflineUser;
 
-#pragma mark - Push
+#pragma mark - Notifications
 
 /// Flag to allow PushKit pushers or not. Default value is `NO`.
 @property (nonatomic, assign) BOOL allowPushKitPushers;
+
+/**
+ A localization key used when registering the default notification payload.
+ This key will be translated and displayed for APNS notifications as the body
+ content, unless it is modified locally by a Notification Service Extension.
+ 
+ The default value for this setting is "MESSAGE". Updating it after MXKAccount
+ has called `enableAPNSPusher:success:failure:` will have no effect.
+ */
+@property (nonatomic) NSString *notificationBodyLocalizationKey;
 
 #pragma mark - Calls
 

--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -212,8 +212,9 @@ typedef NS_ENUM(NSUInteger, MXKKeyPreSharingStrategy)
  This key will be translated and displayed for APNS notifications as the body
  content, unless it is modified locally by a Notification Service Extension.
  
- The default value for this setting is "MESSAGE". Updating it after MXKAccount
- has called `enableAPNSPusher:success:failure:` will have no effect.
+ The default value for this setting is "MESSAGE". Changes are *not* persisted.
+ Updating the value after MXKAccount has called `enableAPNSPusher:success:failure:`
+ will have no effect.
  */
 @property (nonatomic) NSString *notificationBodyLocalizationKey;
 

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -120,6 +120,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
         httpsLinkScheme = @"https";
         
         _allowPushKitPushers = NO;
+        _notificationBodyLocalizationKey = @"MESSAGE";
         enableCallKit = YES;
         
         eventsFilterForMessages = [NSMutableArray arrayWithArray:@[

--- a/changelog.d/4132.change
+++ b/changelog.d/4132.change
@@ -1,0 +1,1 @@
+Notifications: Use NOTIFICATION localisation key instead of MESSAGE for the default payload's content.

--- a/changelog.d/4132.change
+++ b/changelog.d/4132.change
@@ -1,1 +1,1 @@
-Notifications: Use NOTIFICATION localisation key instead of MESSAGE for the default payload's content.
+Notifications: Add notificationBodyLocalizationKey to MXKAppSettings to customise the default notification payload.


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/pull/4662.

- Adds `notificationBodyLocalizationKey` to `MXKAppSettings` to customise the default notification payload.