### PR TITLE
MXKAccount: Use `pauseable` property of MXSession

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1080,7 +1080,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     // Reset internal flag
     isPauseRequested = NO;
     
-    if (mxSession && mxSession.state == MXSessionStateRunning)
+    if (mxSession && mxSession.isPauseable)
     {
         id<MXBackgroundModeHandler> handler = [MXSDKOptions sharedInstance].backgroundModeHandler;
         if (handler)

--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -1143,6 +1143,8 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     
     if (mxSession)
     {
+        MXLogVerbose(@"[MXKAccount] resume with session state: %tu", mxSession.state);
+        
         [self cancelBackgroundSync];
         
         if (mxSession.state == MXSessionStatePaused || mxSession.state == MXSessionStatePauseRequested)

--- a/changelog.d/4834.change
+++ b/changelog.d/4834.change
@@ -1,0 +1,1 @@
+MXKAccount: Use new `pauseable` property of MXSession to check the session is suitable for pausing.


### PR DESCRIPTION
Fix vector-im/element-ios#4834