### PR TITLE
Revert removal of default ignored hosts value.

### DIFF
--- a/MatrixKit/Models/MXKAppSettings.h
+++ b/MatrixKit/Models/MXKAppSettings.h
@@ -116,7 +116,7 @@ typedef NS_ENUM(NSUInteger, MXKKeyPreSharingStrategy)
  Customising this value modifies the behaviour of link detection in `MXKRoomBubbleComponent`.
  
  This boolean value is defined in shared settings object with the key: `firstURLDetectionIgnoredHosts`.
- Return NO if no value is defined.
+ The default value of this property only contains the matrix.to host.
  */
 @property (nonatomic) NSArray<NSString *> *firstURLDetectionIgnoredHosts;
 

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -511,7 +511,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
     {
         if (ignoredHosts == nil)
         {
-            ignoredHosts = @[]
+            ignoredHosts = @[];
         }
         
         [NSUserDefaults.standardUserDefaults setObject:ignoredHosts forKey:@"firstURLDetectionIgnoredHosts"];

--- a/MatrixKit/Models/MXKAppSettings.m
+++ b/MatrixKit/Models/MXKAppSettings.m
@@ -497,7 +497,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
 {
     if (self == [MXKAppSettings standardAppSettings])
     {
-        return [NSUserDefaults.standardUserDefaults objectForKey:@"firstURLDetectionIgnoredHosts"];
+        return [NSUserDefaults.standardUserDefaults objectForKey:@"firstURLDetectionIgnoredHosts"] ?: @[[NSURL URLWithString:kMXMatrixDotToUrl].host];
     }
     else
     {
@@ -509,6 +509,11 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
 {
     if (self == [MXKAppSettings standardAppSettings])
     {
+        if (ignoredHosts == nil)
+        {
+            ignoredHosts = @[]
+        }
+        
         [NSUserDefaults.standardUserDefaults setObject:ignoredHosts forKey:@"firstURLDetectionIgnoredHosts"];
     }
     else

--- a/changelog.d/4826.bugfix
+++ b/changelog.d/4826.bugfix
@@ -1,0 +1,1 @@
+MXKAppSettings: Return matrix.to when firstURLDetectionIgnoredHosts is nil, and store an empty array when setting nil.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4826. The matrix.to host was only stored in the synthesized variable and not the user defaults.

This returns matrix.to when the user defaults return `nil` and always sets `@[]` instead of `nil`, to match the desirable behaviour discussed [here](https://github.com/matrix-org/matrix-ios-kit/pull/893#discussion_r704513073).