### PR TITLE
vector-im/element-ios/issues/4717 - Exposed new room name localizable…

### DIFF
--- a/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
+++ b/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
@@ -158,6 +158,7 @@
 "room_displayname_empty_room" = "Empty room";
 "room_displayname_two_members" = "%@ and %@";
 "room_displayname_more_than_two_members" = "%@ and %@ others";
+"room_displayname_all_other_participants_left" = "%@ (Left)";
 
 // Settings
 "settings" = "Settings";

--- a/MatrixKit/Utils/EventFormatter/MXKRoomNameStringLocalizations.h
+++ b/MatrixKit/Utils/EventFormatter/MXKRoomNameStringLocalizations.h
@@ -21,10 +21,6 @@
 /**
  The `MXKRoomNameStringLocalizations` implements localization strings for `MXRoomNameStringsLocalizable`.
  */
-@interface MXKRoomNameStringLocalizations : NSObject<MXRoomNameStringsLocalizable>
-
-@property (copy, readonly, nonnull) NSString *emptyRoom;
-@property (copy, readonly, nonnull) NSString *twoMembers;
-@property (copy, readonly, nonnull) NSString *moreThanTwoMembers;
+@interface MXKRoomNameStringLocalizations : NSObject <MXRoomNameStringsLocalizable>
 
 @end

--- a/MatrixKit/Utils/EventFormatter/MXKRoomNameStringLocalizations.m
+++ b/MatrixKit/Utils/EventFormatter/MXKRoomNameStringLocalizations.m
@@ -18,6 +18,15 @@
 
 #import "NSBundle+MatrixKit.h"
 
+@interface MXKRoomNameStringLocalizations ()
+
+@property (nonatomic, copy) NSString *emptyRoom;
+@property (nonatomic, copy) NSString *twoMembers;
+@property (nonatomic, copy) NSString *moreThanTwoMembers;
+@property (nonatomic, copy) NSString *allOtherParticipantsLeft;
+
+@end
+
 @implementation MXKRoomNameStringLocalizations
 
 - (instancetype)init
@@ -28,6 +37,7 @@
         _emptyRoom = [NSBundle mxk_localizedStringForKey:@"room_displayname_empty_room"];
         _twoMembers = [NSBundle mxk_localizedStringForKey:@"room_displayname_two_members"];
         _moreThanTwoMembers = [NSBundle mxk_localizedStringForKey:@"room_displayname_more_than_two_members"];
+        _allOtherParticipantsLeft = [NSBundle mxk_localizedStringForKey:@"room_displayname_all_other_participants_left"];
     }
     return self;
 }

--- a/changelog.d/4717.change
+++ b/changelog.d/4717.change
@@ -1,0 +1,1 @@
+Exposed new room name localizable string to use for empty direct messages.


### PR DESCRIPTION
… string to use for empty direct messages.