### PR TITLE
Use attributed string whitespace for URL previews.

### DIFF
--- a/MatrixKit.xcodeproj/project.pbxproj
+++ b/MatrixKit.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		8C751E43C4D87B309065E3C8 /* Pods-MatrixKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixKitTests/Pods-MatrixKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		9135FFD826DE8EFD000E6D84 /* NSString+MatrixKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+MatrixKit.swift"; sourceTree = "<group>"; };
 		918DAB9E26E622BF00CE20A9 /* NSAttributedString+MatrixKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+MatrixKit.swift"; sourceTree = "<group>"; };
+		91FE762A27047EB700E035D9 /* MXKURLPreviewDataProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKURLPreviewDataProtocol.h; sourceTree = "<group>"; };
 		92663A6A1EF6E5B3005FB712 /* MXKSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKSoundPlayer.h; sourceTree = "<group>"; };
 		92663A6B1EF6E5B3005FB712 /* MXKSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKSoundPlayer.m; sourceTree = "<group>"; };
 		A82C7BAE25F0BA900059F7F1 /* MXKRoomDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKRoomDataSourceTests.swift; sourceTree = "<group>"; };
@@ -1311,6 +1312,7 @@
 				B164380B210603CD00DBB3FD /* MXKSendReplyEventStringLocalizations.m */,
 				B1668ABE21072F93002B14F1 /* MXKSlashCommands.h */,
 				B1668ABF21072F93002B14F1 /* MXKSlashCommands.m */,
+				91FE762A27047EB700E035D9 /* MXKURLPreviewDataProtocol.h */,
 			);
 			path = Room;
 			sourceTree = "<group>";

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -116,10 +116,13 @@
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
 /**
- Indicate that the data's text message layout should be recomputed.
- Under the hood, this is done by clearing the current `attributedTextMessage`.
+ Indicate that the data's text message layout should be recomputed
+ before being presented in a bubble cell.
+ 
+ This will clear the current `attributedTextMessage` allowing it to be
+ rebuilt on demand when requested.
  */
-- (void)setNeedsUpdateContent;
+- (void)invalidateTextLayout;
 
 /**
  Check and refresh the position of each component.

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -116,6 +116,12 @@
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
 /**
+ Indicates that the cell should recompute its content for layout.
+ Under the hood, this is done by clearing the current `attributedTextMessage`.
+ */
+- (void)setNeedsUpdateContent;
+
+/**
  Check and refresh the position of each component.
  */
 - (void)prepareBubbleComponentsPosition;

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -116,7 +116,7 @@
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
 /**
- Indicates that the cell should recompute its content for layout.
+ Indicate that the data's text message layout should be recomputed.
  Under the hood, this is done by clearing the current `attributedTextMessage`.
  */
 - (void)setNeedsUpdateContent;

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -116,8 +116,9 @@
 @property (nonatomic, readonly) BOOL containsBubbleComponentWithEncryptionBadge;
 
 /**
- Indicate that the data's text message layout should be recomputed
- before being presented in a bubble cell.
+ Indicate that the current text message layout is no longer valid and should be recomputed
+ before presentation in a bubble cell. This could be due to the content changing, or the
+ available space for the cell has been updated.
  
  This will clear the current `attributedTextMessage` allowing it to be
  rebuilt on demand when requested.

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -420,6 +420,11 @@
 
 #pragma mark -
 
+- (void)invalidateTextLayout
+{
+    self.attributedTextMessage = nil;
+}
+
 - (void)prepareBubbleComponentsPosition
 {
     // Consider here only the first component if any
@@ -709,11 +714,6 @@
         // Reset content size
         _contentSize = CGSizeZero;
     }
-}
-
-- (void)invalidateTextLayout
-{
-    self.attributedTextMessage = nil;
 }
 
 - (CGSize)contentSize

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -711,6 +711,11 @@
     }
 }
 
+- (void)setNeedsUpdateContent
+{
+    self.attributedTextMessage = nil;
+}
+
 - (CGSize)contentSize
 {
     if (CGSizeEqualToSize(_contentSize, CGSizeZero))

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -120,8 +120,8 @@
                 {
                     [bubbleComponents removeObjectAtIndex:index];
                 }
-                // flush the current attributed string to force refresh
-                self.attributedTextMessage = nil;
+                // Indicate that the text message layout should be recomputed.
+                [self setNeedsUpdateContent];
                 
                 // Handle here attachment update.
                 // For example: the case of update of attachment event happens when an echo is replaced by its true event
@@ -223,8 +223,8 @@
             {
                 [bubbleComponents removeObject:roomBubbleComponent];
                 
-                // flush the current attributed string to force refresh
-                self.attributedTextMessage = nil;
+                // Indicate that the text message layout should be recomputed.
+                [self setNeedsUpdateContent];
                 
                 break;
             }
@@ -256,8 +256,8 @@
 
             bubbleComponents = [NSMutableArray arrayWithArray:newBubbleComponents];
 
-            // Flush the current attributed string to force refresh
-            self.attributedTextMessage = nil;
+            // Indicate that the text message layout should be recomputed.
+            [self setNeedsUpdateContent];
         }
     }
 
@@ -357,8 +357,8 @@
     highlightedPatternColor = patternColor;
     highlightedPatternFont = patternFont;
     
-    // flush the current attributed string to force refresh
-    self.attributedTextMessage = nil;
+    // Indicate that the text message layout should be recomputed.
+    [self setNeedsUpdateContent];
 }
 
 - (void)setShouldHideSenderInformation:(BOOL)inShouldHideSenderInformation

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -121,7 +121,7 @@
                     [bubbleComponents removeObjectAtIndex:index];
                 }
                 // Indicate that the text message layout should be recomputed.
-                [self setNeedsUpdateContent];
+                [self invalidateTextLayout];
                 
                 // Handle here attachment update.
                 // For example: the case of update of attachment event happens when an echo is replaced by its true event
@@ -224,7 +224,7 @@
                 [bubbleComponents removeObject:roomBubbleComponent];
                 
                 // Indicate that the text message layout should be recomputed.
-                [self setNeedsUpdateContent];
+                [self invalidateTextLayout];
                 
                 break;
             }
@@ -257,7 +257,7 @@
             bubbleComponents = [NSMutableArray arrayWithArray:newBubbleComponents];
 
             // Indicate that the text message layout should be recomputed.
-            [self setNeedsUpdateContent];
+            [self invalidateTextLayout];
         }
     }
 
@@ -358,7 +358,7 @@
     highlightedPatternFont = patternFont;
     
     // Indicate that the text message layout should be recomputed.
-    [self setNeedsUpdateContent];
+    [self invalidateTextLayout];
 }
 
 - (void)setShouldHideSenderInformation:(BOOL)inShouldHideSenderInformation
@@ -711,7 +711,7 @@
     }
 }
 
-- (void)setNeedsUpdateContent
+- (void)invalidateTextLayout
 {
     self.attributedTextMessage = nil;
 }

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -279,6 +279,11 @@ Update the event because its sent state changed or it is has been redacted.
  */
 - (void)refreshSenderFlair;
 
+/**
+ Indicate that the data's text message layout should be recomputed.
+ */
+- (void)setNeedsUpdateContent;
+
 #pragma mark - Bubble collapsing
 
 /**

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -280,9 +280,10 @@ Update the event because its sent state changed or it is has been redacted.
 - (void)refreshSenderFlair;
 
 /**
- Indicate that the data's text message layout should be recomputed.
+ Indicate that the data's text message layout should be recomputed
+ before being presented in a bubble cell.
  */
-- (void)setNeedsUpdateContent;
+- (void)invalidateTextLayout;
 
 #pragma mark - Bubble collapsing
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -280,8 +280,9 @@ Update the event because its sent state changed or it is has been redacted.
 - (void)refreshSenderFlair;
 
 /**
- Indicate that the data's text message layout should be recomputed
- before being presented in a bubble cell.
+ Indicate that the current text message layout is no longer valid and should be recomputed
+ before presentation in a bubble cell. This could be due to the content changing, or the
+ available space for the cell has been updated.
  */
 - (void)invalidateTextLayout;
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -345,7 +345,7 @@ static NSAttributedString *messageSeparator = nil;
         [bubbleComponents insertObject:addedComponent atIndex:index];
         
         // Indicate that the data's text message layout should be recomputed.
-        [self setNeedsUpdateContent];
+        [self invalidateTextLayout];
     }
 }
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -344,8 +344,8 @@ static NSAttributedString *messageSeparator = nil;
         // Insert new component
         [bubbleComponents insertObject:addedComponent atIndex:index];
         
-        // Reset the current attributed string (This will reset rendering attributes).
-        self.attributedTextMessage = nil;
+        // Indicate that the data's text message layout should be recomputed.
+        [self setNeedsUpdateContent];
     }
 }
 

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -18,6 +18,8 @@
 
 #import "MXKEventFormatter.h"
 
+@class URLPreviewData;
+
 /**
  Flags to indicate if a fix is required at the display time.
  */
@@ -79,6 +81,18 @@ typedef enum : NSUInteger {
  The first link detected in the event's content, otherwise nil.
  */
 @property (nonatomic) NSURL *link;
+
+/**
+ Any data necessary to show a URL preview.
+ Note: MatrixKit is unable to display this data by itself.
+ */
+@property (nonatomic) URLPreviewData *urlPreviewData;
+
+/**
+ Whether a URL preview should be displayed for this cell.
+ Note: MatrixKit is unable to display URL previews by itself.
+ */
+@property (nonatomic) BOOL showURLPreview;
 
 /**
  Event antivirus scan. Present only if antivirus is enabled and event contains media.

--- a/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -17,8 +17,7 @@
 #import <MatrixSDK/MatrixSDK.h>
 
 #import "MXKEventFormatter.h"
-
-@class URLPreviewData;
+#import "MXKURLPreviewDataProtocol.h"
 
 /**
  Flags to indicate if a fix is required at the display time.
@@ -86,7 +85,7 @@ typedef enum : NSUInteger {
  Any data necessary to show a URL preview.
  Note: MatrixKit is unable to display this data by itself.
  */
-@property (nonatomic) URLPreviewData *urlPreviewData;
+@property (nonatomic) id <MXKURLPreviewDataProtocol> urlPreviewData;
 
 /**
  Whether a URL preview should be displayed for this cell.

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1399,7 +1399,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     {
         for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles)
         {
-            bubble.attributedTextMessage = nil;
+            [bubble setNeedsUpdateContent];
         }
     }
 }
@@ -3899,8 +3899,8 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
         roomBubbleCellData.reactions[eventId] = nil;
     }
 
-    // Recompute the text message layout
-    roomBubbleCellData.attributedTextMessage = nil;
+    // Indicate that the text message layout should be recomputed.
+    [roomBubbleCellData setNeedsUpdateContent];
 }
 
 - (BOOL)canReactToEventWithId:(NSString*)eventId
@@ -4074,7 +4074,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             }
 
             [bubbleCellData updateEvent:eventId withEvent:editedEvent];
-            bubbleCellData.attributedTextMessage = nil;
+            [bubbleCellData setNeedsUpdateContent];
             hasChanged = YES;
         }
     }

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1399,7 +1399,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     {
         for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles)
         {
-            [bubble setNeedsUpdateContent];
+            [bubble invalidateTextLayout];
         }
     }
 }
@@ -3900,7 +3900,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     }
 
     // Indicate that the text message layout should be recomputed.
-    [roomBubbleCellData setNeedsUpdateContent];
+    [roomBubbleCellData invalidateTextLayout];
 }
 
 - (BOOL)canReactToEventWithId:(NSString*)eventId
@@ -4074,7 +4074,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             }
 
             [bubbleCellData updateEvent:eventId withEvent:editedEvent];
-            [bubbleCellData setNeedsUpdateContent];
+            [bubbleCellData invalidateTextLayout];
             hasChanged = YES;
         }
     }

--- a/MatrixKit/Models/Room/MXKURLPreviewDataProtocol.h
+++ b/MatrixKit/Models/Room/MXKURLPreviewDataProtocol.h
@@ -1,0 +1,40 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@protocol MXKURLPreviewDataProtocol <NSObject>
+
+/// The URL that's represented by the preview data.
+@property (readonly, nonnull) NSURL *url;
+
+/// The ID of the event that created this preview.
+@property (readonly, nonnull) NSString *eventID;
+
+/// The ID of the room that this preview is from.
+@property (readonly, nonnull) NSString *roomID;
+
+/// The OpenGraph site name for the URL.
+@property (readonly, nullable) NSString *siteName;
+
+/// The OpenGraph title for the URL.
+@property (readonly, nullable) NSString *title;
+
+/// The OpenGraph description for the URL.
+@property (readonly, nullable) NSString *text;
+
+/// The OpenGraph image for the URL.
+@property (readwrite, nullable) UIImage *image;
+
+@end

--- a/changelog.d/4896.change
+++ b/changelog.d/4896.change
@@ -1,1 +1,1 @@
-MXKRoomBubbleCellData: Add invalidateTextLayout method and use this instead of clearing the attributed string.
+Adds `invalidateTextLayout` method to MXKRoomBubbleCellData along with `urlPreviewData` and `showURLPreview` to MXKBubbleComponent

--- a/changelog.d/4896.change
+++ b/changelog.d/4896.change
@@ -1,0 +1,1 @@
+MXKRoomBubbleCellData: Add invalidateTextLayout method and use this instead of clearing the attributed string.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4896 along side the PR https://github.com/vector-im/element-ios/pull/4924. This PR makes 2 changes:

Adds `invalidateTextLayout` method to `MXKRoomBubbleCellData` and replaces all occurrences of setting the attributed string to nil with this method. This was done to make updating the cell's layout more obvious. Any tweaks to the docs/naming totally welcome 🙂

Adds `urlPreviewData` and `showURLPreview` properties to `MXKBubbleComponent` for use from Element (they do nothing by theirselves in Kit). There is one question/comment inline about how this was done.