### PR TITLE
Release 0.16.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 0.16.4 (2021-09-30)
+
+🙌 Improvements
+
+- Upgrade MatrixSDK version ([v0.20.4](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.20.4)).
+
+
 ## Changes in 0.16.3 (2021-09-28)
 
 🙌 Improvements

--- a/MatrixKit.podspec
+++ b/MatrixKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixKit"
-  s.version      = "0.16.3"
+  s.version      = "0.16.4"
   s.summary      = "The Matrix reusable UI library for iOS based on MatrixSDK."
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.dependency 'MatrixSDK', "= 0.20.3"
+  s.dependency 'MatrixSDK', "= 0.20.4"
   s.dependency 'HPGrowingTextView', '~> 1.1'
   s.dependency 'libPhoneNumber-iOS', '~> 0.9.13'
   s.dependency 'DTCoreText', '~> 1.6.25'

--- a/MatrixKit/MatrixKitVersion.m
+++ b/MatrixKit/MatrixKitVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixKitVersion = @"0.16.3";
+NSString *const MatrixKitVersion = @"0.16.4";

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ abstract_target 'MatrixKitSamplePods' do
     
     # Different flavours of pods to Matrix SDK
     # The tagged version on which this version of MatrixKit has been built
-    pod 'MatrixSDK', '= 0.20.3'
+    pod 'MatrixSDK', '= 0.20.4'
     
     # The lastest release available on the CocoaPods repository
     #pod 'MatrixSDK'

--- a/changelog.d/x-nolink-0.change
+++ b/changelog.d/x-nolink-0.change
@@ -1,0 +1,1 @@
+Upgrade MatrixSDK version ([v0.20.4](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.20.4)).

--- a/changelog.d/x-nolink-0.change
+++ b/changelog.d/x-nolink-0.change
@@ -1,1 +1,0 @@
-Upgrade MatrixSDK version ([v0.20.4](https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.20.4)).


### PR DESCRIPTION
This PR prepares the release of MatrixKit v0.16.4.

Notes:
- This PR targets `release/0.16.4/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.16.4/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-kit/compare/develop...release/0.16.4/release)
