### PR TITLE
Fix cell height when read receipts update.

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -2275,6 +2275,9 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
 - (void)updateCellData:(MXKRoomBubbleCellData*)cellData withReadReceipts:(NSArray<MXReceiptData*>*)readReceipts forEventId:(NSString*)eventId
 {
     cellData.readReceipts[eventId] = readReceipts;
+    
+    // Indicate that the text message layout should be recomputed.
+    [cellData invalidateTextLayout];
 }
 
 - (void)handleUnsentMessages

--- a/changelog.d/4950.bugfix
+++ b/changelog.d/4950.bugfix
@@ -1,0 +1,1 @@
+MXKRoomDataSource: Invalidate the cell data's text layout when updating read receipts.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4950 and likely issues like https://github.com/vector-im/element-ios/issues/4564 although I'm unsure how to reliably reproduce those kind of things.

Both `updateCellDataReactions:forEventId:` and `updateCellData:forEditionWithReplaceEvent:andEventId:` indicate that the text layout needs recomputing, but `updateCellData:withReadReceipts:forEventId:` did not.

![Frame 1](https://user-images.githubusercontent.com/6060466/135848702-a0b0f0a6-a2df-4a5b-9d7e-18507a80dc72.png)


