### PR TITLE
vector-im/element-ios/issues/4899 - MXKEventFormatter: Fixed invalid …

### DIFF
--- a/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -997,11 +997,11 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
             {
                 if (isRoomDirect)
                 {
-                    displayText = [MatrixKitL10n noticeRoomAliasesForDm:aliases];
+                    displayText = [MatrixKitL10n noticeRoomAliasesForDm:[aliases componentsJoinedByString:@", "]];
                 }
                 else
                 {
-                    displayText = [MatrixKitL10n noticeRoomAliases:aliases];
+                    displayText = [MatrixKitL10n noticeRoomAliases:[aliases componentsJoinedByString:@", "]];
                 }
                 // Append redacted info if any
                 if (redactedInfo)
@@ -1017,7 +1017,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
             MXJSONModelSetArray(groups, event.content[@"groups"]);
             if (groups)
             {
-                displayText = [MatrixKitL10n noticeRoomRelatedGroups:groups];
+                displayText = [MatrixKitL10n noticeRoomRelatedGroups:[groups componentsJoinedByString:@", "]];
                 // Append redacted info if any
                 if (redactedInfo)
                 {

--- a/changelog.d/4899.bugfix
+++ b/changelog.d/4899.bugfix
@@ -1,0 +1,1 @@
+MXKEventFormatter: Fixed invalid parameters passed to generated localization functions.


### PR DESCRIPTION
…parameters passed to generated localization functions.