### PR TITLE
Avoid race condition calling validateSyncLocalContactsState.

### DIFF
--- a/MatrixKit/Models/Account/MXKAccount.m
+++ b/MatrixKit/Models/Account/MXKAccount.m
@@ -24,6 +24,7 @@
 #import "MXKEventFormatter.h"
 
 #import "MXKTools.h"
+#import "MXKContactManager.h"
 
 #import "MXKConstants.h"
 
@@ -844,6 +845,11 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
         
         // Complete session registration by launching live stream
         MXStrongifyAndReturnIfNil(self);
+        
+        // Validate the availability of local contact sync for any changes to the
+        // authorization of contacts access that may have occurred since the last launch.
+        // The session is passed in as the contacts manager may not have had a session added yet.
+        [MXKContactManager.sharedManager validateSyncLocalContactsStateForSession:self.mxSession];
         
         // Refresh pusher state
         [self refreshAPNSPusher];

--- a/MatrixKit/Models/Contact/MXKContactManager.h
+++ b/MatrixKit/Models/Contact/MXKContactManager.h
@@ -161,8 +161,9 @@ typedef void(^MXKContactManagerDiscoverUsersBoundTo3PIDs)(NSArray<NSArray<NSStri
  Takes into account the state of the identity service's terms, local contacts access authorization along with
  whether the user has left the app for the Settings app to update the contacts access, and enables/disables
  the `syncLocalContacts` property of `MXKAppSettings` when necessary.
+ @param mxSession The session who's identity service shall be used.
  */
-- (void)validateSyncLocalContactsState;
+- (void)validateSyncLocalContactsStateForSession:(MXSession *)mxSession;
 
 /**
  Load and/or refresh the local contacts. Observe kMXKContactManagerDidUpdateLocalContactsNotification to know when local contacts are available.

--- a/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/MatrixKit/Models/Contact/MXKContactManager.m
@@ -499,7 +499,7 @@ NSString *const MXKContactManagerDataType = @"org.matrix.kit.MXKContactManagerDa
 
 #pragma mark -
 
-- (void)validateSyncLocalContactsState
+- (void)validateSyncLocalContactsStateForSession:(MXSession *)mxSession
 {
     if (!self.allowLocalContactsAccess)
     {
@@ -507,7 +507,7 @@ NSString *const MXKContactManagerDataType = @"org.matrix.kit.MXKContactManagerDa
     }
     
     // Get the status of the identity service terms.
-    BOOL areAllTermsAgreed = self.identityService.areAllTermsAgreed;
+    BOOL areAllTermsAgreed = mxSession.identityService.areAllTermsAgreed;
     
     if (MXKAppSettings.standardAppSettings.syncLocalContacts)
     {

--- a/changelog.d/4989.bugfix
+++ b/changelog.d/4989.bugfix
@@ -1,0 +1,1 @@
+MXKContactManager: Add an MXSession parameter to validateSyncLocalContactsState and call from MXKAccount.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4989. The timing of when to call `validateSyncLocalContactsState` was fragile (although it appeared to be consistent on a per device basis). This fixes that by passing the session into the method to avoid any doubt of a missing session.