### PR TITLE
Fix unresponsive "Jump to unread"

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -234,7 +234,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     //  In order to successfully fetch the room, we should wait for store to be ready.
     if (mxSession.state >= MXSessionStateStoreDataReady)
     {
-        [self ensureInitialEventExistenceForDataSource:roomDataSource initialEventId:initialEventId andMatrixSession:mxSession onComplete:onComplete];
+        [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
     }
     else
     {
@@ -243,40 +243,8 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             if (mxSession.state >= MXSessionStateStoreDataReady)
             {
                 [[NSNotificationCenter defaultCenter] removeObserver:sessionStateObserver];
-                [self ensureInitialEventExistenceForDataSource:roomDataSource initialEventId:initialEventId andMatrixSession:mxSession onComplete:onComplete];
+                [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
             }
-        }];
-    }
-}
-
-/// Ensure initial event existence for the roomDataSource.
-+ (void)ensureInitialEventExistenceForDataSource:(MXKRoomDataSource*)roomDataSource initialEventId:(NSString*)initialEventId andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(id roomDataSource))onComplete
-{
-    if (roomDataSource.room)
-    {
-        //  already finalized
-        return;
-    }
-    
-    if (initialEventId == nil)
-    {
-        //  if an initialEventId not provided, finalize
-        [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
-        return;
-    }
-    
-    //  ensure event with id 'initialEventId' exists in the session store
-    if ([mxSession.store eventExistsWithEventId:initialEventId inRoom:roomDataSource.roomId])
-    {
-        [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
-    }
-    else
-    {
-        //  give a chance for the specific event to be existent, for only one sync
-        //  use kMXSessionDidSyncNotification here instead of MXSessionStateRunning, because session does not send this state update if it's already in this state
-        __block id syncObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDidSyncNotification object:mxSession queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-            [[NSNotificationCenter defaultCenter] removeObserver:syncObserver];
-            [self finalizeRoomDataSource:roomDataSource onComplete:onComplete];
         }];
     }
 }
@@ -290,7 +258,6 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
         // Asynchronously preload data here so that the data will be ready later
         // to synchronously respond to that request
         [roomDataSource.room liveTimeline:^(MXEventTimeline *liveTimeline) {
-
             onComplete(roomDataSource);
         }];
     }

--- a/changelog.d/4701.bugfix
+++ b/changelog.d/4701.bugfix
@@ -1,0 +1,1 @@
+Fix problem with "Jump to unread" button being unresponsive.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4071

I think we can remove this check altogether @ismailgulek. 

It was introduced in an [attempt to fix an issue](https://github.com/matrix-org/matrix-ios-kit/pull/674) with notifications not going to the message. But we no longer [highlight messages from notifications](https://github.com/vector-im/element-ios/pull/3341).

In the codes current state, I don't think this check is having any effect(maybe it did in the past) other than causing a delay in the join.

At the moment it's just called for the "jump to unread" button and when joining a room with an initialEventId, in both cases we are starting the timeline at a point in the past.

When we start the timeline at an event in the past [we load an in memory event store](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/MatrixSDK/Data/MXEventTimeline.m#L89) rather than the persisted session store.

So from my testing the [initial check](https://github.com/matrix-org/matrix-ios-kit/blob/develop/MatrixKit/Models/Room/MXKRoomDataSource.m#L269) for the event in this in memory store always fails. We then wait for the next sync, but don't make any requests that would trigger the server to return. This means it hangs for an arbitrary amount of time(0-15 seconds for me), until the server pushes something on sync. During this time the join/jump to unread appear unresponsive.

Then we finalise the room and load the event using `/context`.



