### PR TITLE
Remove room summary observer on MXKRoomTitleView.

### DIFF
--- a/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -96,6 +96,12 @@
 {
     self.delegate = nil;
     self.mxRoom = nil;
+    
+    if (mxRoomSummaryDidChangeObserver)
+    {
+        [NSNotificationCenter.defaultCenter removeObserver:mxRoomSummaryDidChangeObserver];
+        mxRoomSummaryDidChangeObserver = nil;
+    }
 }
 
 - (void)dismissKeyboard

--- a/changelog.d/pr-951.bugfix
+++ b/changelog.d/pr-951.bugfix
@@ -1,0 +1,1 @@
+MXKRoomTitleView: Remove room summary observer on destroy.


### PR DESCRIPTION
This was creating a *lot* of noise in the logs:
> ⚠️ [MXStrongifyAndReturnIfNil] Released reference at MXKRoomTitleView.m:128
