### PR TITLE
Fix crash during late-decryption of timeline events with attachments.

### DIFF
--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -2594,7 +2594,8 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
                 BOOL eventIsFirstInBubble = NO;
                 NSInteger bubbleDataIndex =  [bubbles indexOfObject:bubbleData];
                 
-                if (NSNotFound == bubbleDataIndex) {
+                if (NSNotFound == bubbleDataIndex)
+                {
                     // If bubbleData is not in bubbles there is nothing to update for this event, its not displayed.
                     return;
                 }

--- a/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -2593,6 +2593,11 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             {
                 BOOL eventIsFirstInBubble = NO;
                 NSInteger bubbleDataIndex =  [bubbles indexOfObject:bubbleData];
+                
+                if (NSNotFound == bubbleDataIndex) {
+                    // If bubbleData is not in bubbles there is nothing to update for this event, its not displayed.
+                    return;
+                }
 
                 // We need to create a dedicated cell for the event attachment.
                 // From the current bubble, remove the updated event and all events after.

--- a/changelog.d/5203.bugfix
+++ b/changelog.d/5203.bugfix
@@ -1,0 +1,1 @@
+Fix crash during late-decryption of timeline events with attachments.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5203